### PR TITLE
Default-landing flip + sidebar reorder: in src/ui/src/App.tsx the index…

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HashRouter, Navigate, Route, Routes } from "react-router-dom";
 import { AuthGate } from "@/components/AuthGate.tsx";
+import { DefaultLanding } from "@/components/DefaultLanding.tsx";
 import { Layout } from "@/components/Layout.tsx";
 import { AgentsPage } from "@/pages/Agents.tsx";
 import { LoginPage } from "@/pages/Login.tsx";
@@ -44,7 +45,7 @@ export function App() {
 							</AuthGate>
 						}
 					>
-						<Route index element={<Navigate to="/runs" replace />} />
+						<Route index element={<DefaultLanding />} />
 						<Route path="/runs" element={<RunsPage />} />
 						<Route path="/runs/new" element={<NewRunPage />} />
 						<Route path="/runs/:id" element={<RunDetailPage />} />

--- a/src/ui/src/components/DefaultLanding.tsx
+++ b/src/ui/src/components/DefaultLanding.tsx
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+import { Navigate } from "react-router-dom";
+import { plotsApi, projectsApi } from "@/api/client.ts";
+
+/**
+ * Default landing route (warren-e59a / pl-9d6a step 19).
+ *
+ * Renders at the index Route inside the AuthGate slot. Decides where to
+ * send the user on a fresh load:
+ *
+ *  - If at least one project has `hasPlot=true` AND `GET /plots` returns
+ *    at least one Plot, redirect to `/plots`.
+ *  - Otherwise redirect to `/runs` — preserves the CLAUDE.md standalone
+ *    path where Plots are an opt-in built-in feature.
+ *
+ * Both queries reuse the cached `["projects"]` and `["plots", "all"]`
+ * keys used by `Layout` and `PlotsPage` so tanstack-query dedupes the
+ * fetch. `/plots` is only fired when at least one project is
+ * Plot-enabled; on a vanilla install the second request never happens.
+ */
+export function DefaultLanding() {
+	const projects = useQuery({
+		queryKey: ["projects"],
+		queryFn: ({ signal }) => projectsApi.list(signal),
+		staleTime: 5000,
+	});
+
+	const anyHasPlot = (projects.data?.projects ?? []).some((p) => p.hasPlot);
+
+	const plots = useQuery({
+		queryKey: ["plots", "all"],
+		queryFn: ({ signal }) => plotsApi.list({}, signal),
+		enabled: anyHasPlot,
+		staleTime: 5000,
+	});
+
+	// While `/projects` is in flight, render nothing — the redirect has
+	// to wait on the gate. AuthGate already guarantees a token exists by
+	// the time we get here, so this is purely the "decide where to send
+	// them" window (typically <100ms against a warm cache).
+	if (projects.isPending) return null;
+
+	// No Plot-enabled projects → byte-identical to the pre-change path.
+	if (!anyHasPlot) return <Navigate to="/runs" replace />;
+
+	// Plot-enabled project exists but the Plots list is still loading —
+	// don't flicker /runs in the meantime; wait one frame.
+	if (plots.isPending) return null;
+
+	const hasAnyPlot = (plots.data?.plots ?? []).length > 0;
+	return <Navigate to={hasAnyPlot ? "/plots" : "/runs"} replace />;
+}

--- a/src/ui/src/components/Layout.tsx
+++ b/src/ui/src/components/Layout.tsx
@@ -45,14 +45,14 @@ export function Layout() {
 		[projects.data],
 	);
 	const navItems = useMemo<NavItem[]>(() => {
+		// Byte-identical to pre-Plots order when no project opted in —
+		// preserves the CLAUDE.md standalone path (warren-e59a / pl-9d6a
+		// step 19).
 		if (!anyHasPlot) return BASE_NAV_ITEMS;
-		// Order: Runs → Plans → Plots → Projects → Agents (insert
-		// Plots between Plans and Projects).
-		return [
-			...BASE_NAV_ITEMS.slice(0, 2),
-			PLOTS_NAV_ITEM,
-			...BASE_NAV_ITEMS.slice(2),
-		];
+		// Plot-enabled deployments lead with Plots, then the existing
+		// Runs → Plans → Projects → Agents order: Plots → Runs → Plans
+		// → Projects → Agents.
+		return [PLOTS_NAV_ITEM, ...BASE_NAV_ITEMS];
 	}, [anyHasPlot]);
 
 	const handleLogout = (): void => {


### PR DESCRIPTION
## Summary

ui: default-landing flip + sidebar reorder for Plot-enabled deployments

## Run

- **Warren run:** `run_zadst50vd2t8`
- **Agent:** pi
- **Cost:** $0.552 (27 in / 6.0k out / 506.0k cache-r)

## Seeds

- warren-e59a — Default-landing flip + sidebar reorder: in src/ui/src/App.tsx the index Route's Navigate target becomes a small component DefaultLanding.tsx that reads /projects (cached) — if someProject.hasPlot=true AND GET /plots returns at least one Plot, redirect to /plots; otherwise to /runs (preserves CLAUDE.md standalone path). In src/ui/src/components/Layout.tsx the sidebar reorders to Plots → Runs → Plan Runs → Projects → Agents (Plots above Runs only when the gate is true; otherwise the existing order is byte-identical). PlanRun detail-page back-link continues to point to /plots/:id when plotId is set (already covered in step 17).

## Commits (1)

- 537ee01 ui: default-landing flip + sidebar reorder for Plot-enabled deployments

## Files changed

```
src/ui/src/App.tsx                       |  3 +-
 src/ui/src/components/DefaultLanding.tsx | 52 ++++++++++++++++++++++++++++++++
 src/ui/src/components/Layout.tsx         | 14 ++++-----
 3 files changed, 61 insertions(+), 8 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-e59a. use ml. commit when done, no push.
```

</details>

---

🤖 Opened by warren run `run_zadst50vd2t8`