### PR TITLE
DB schema: runs.mode column (batch|interactive default batch), pause co…

### DIFF
--- a/src/db/migrations/0017_add_run_mode_and_pause.sql
+++ b/src/db/migrations/0017_add_run_mode_and_pause.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `runs` ADD `mode` text DEFAULT 'batch' NOT NULL;--> statement-breakpoint
+ALTER TABLE `runs` ADD `paused_at` text;--> statement-breakpoint
+ALTER TABLE `runs` ADD `paused_question_event_id` text;--> statement-breakpoint
+CREATE INDEX `runs_mode_idx` ON `runs` (`mode`);

--- a/src/db/migrations/meta/0017_snapshot.json
+++ b/src/db/migrations/meta/0017_snapshot.json
@@ -1,0 +1,949 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "3ba11c5a-36b0-4d9a-86ec-8529b7dd31b0",
+	"prevId": "2e7b64e4-ed6a-404c-ab46-186c96d5ca69",
+	"tables": {
+		"agents": {
+			"name": "agents",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rendered_json": {
+					"name": "rendered_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"registered_at": {
+					"name": "registered_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_refreshed": {
+					"name": "last_refreshed",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"agents_project_name_idx": {
+					"name": "agents_project_name_idx",
+					"columns": ["project_id", "name"],
+					"isUnique": true
+				},
+				"agents_global_name_idx": {
+					"name": "agents_global_name_idx",
+					"columns": ["name"],
+					"isUnique": true,
+					"where": "\"agents\".\"project_id\" IS NULL"
+				}
+			},
+			"foreignKeys": {
+				"agents_project_id_projects_id_fk": {
+					"name": "agents_project_id_projects_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"burrows": {
+			"name": "burrows",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"burrows_worker_idx": {
+					"name": "burrows_worker_idx",
+					"columns": ["worker_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"events": {
+			"name": "events",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"burrow_event_seq": {
+					"name": "burrow_event_seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ts": {
+					"name": "ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"stream": {
+					"name": "stream",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"payload_json": {
+					"name": "payload_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"events_run_seq_idx": {
+					"name": "events_run_seq_idx",
+					"columns": ["run_id", "burrow_event_seq"],
+					"isUnique": false
+				},
+				"events_run_ts_idx": {
+					"name": "events_run_ts_idx",
+					"columns": ["run_id", "ts"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"events_run_id_runs_id_fk": {
+					"name": "events_run_id_runs_id_fk",
+					"tableFrom": "events",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"plan_run_children": {
+			"name": "plan_run_children",
+			"columns": {
+				"plan_run_id": {
+					"name": "plan_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_merged_at": {
+					"name": "pr_merged_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"plan_run_children_run_idx": {
+					"name": "plan_run_children_run_idx",
+					"columns": ["run_id"],
+					"isUnique": false
+				},
+				"plan_run_children_state_idx": {
+					"name": "plan_run_children_state_idx",
+					"columns": ["plan_run_id", "state"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"plan_run_children_plan_run_id_plan_runs_id_fk": {
+					"name": "plan_run_children_plan_run_id_plan_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "plan_runs",
+					"columnsFrom": ["plan_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"plan_run_children_run_id_runs_id_fk": {
+					"name": "plan_run_children_run_id_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"plan_run_children_plan_run_id_seq_pk": {
+					"columns": ["plan_run_id", "seq"],
+					"name": "plan_run_children_plan_run_id_seq_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"plan_runs": {
+			"name": "plan_runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"plan_id": {
+					"name": "plan_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"prompt_template": {
+					"name": "prompt_template",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'work on sd {seed_id}'"
+				},
+				"ref": {
+					"name": "ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_override": {
+					"name": "provider_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"model_override": {
+					"name": "model_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dispatcher_handle": {
+					"name": "dispatcher_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'operator'"
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'manual'"
+				},
+				"plot_id": {
+					"name": "plot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"plan_runs_project_state_idx": {
+					"name": "plan_runs_project_state_idx",
+					"columns": ["project_id", "state"],
+					"isUnique": false
+				},
+				"plan_runs_state_idx": {
+					"name": "plan_runs_state_idx",
+					"columns": ["state"],
+					"isUnique": false
+				},
+				"plan_runs_plot_id_idx": {
+					"name": "plan_runs_plot_id_idx",
+					"columns": ["plot_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"plan_runs_project_id_projects_id_fk": {
+					"name": "plan_runs_project_id_projects_id_fk",
+					"tableFrom": "plan_runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"projects": {
+			"name": "projects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"git_url": {
+					"name": "git_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"local_path": {
+					"name": "local_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"default_branch": {
+					"name": "default_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_fetched_at": {
+					"name": "last_fetched_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_head_sha": {
+					"name": "last_head_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"has_plot": {
+					"name": "has_plot",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"has_seeds": {
+					"name": "has_seeds",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"projects_git_url_idx": {
+					"name": "projects_git_url_idx",
+					"columns": ["git_url"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"runs": {
+			"name": "runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"burrow_id": {
+					"name": "burrow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"burrow_run_id": {
+					"name": "burrow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"plot_id": {
+					"name": "plot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"rendered_agent_json": {
+					"name": "rendered_agent_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"prompt": {
+					"name": "prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"pr_url": {
+					"name": "pr_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cost_usd": {
+					"name": "cost_usd",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_input": {
+					"name": "tokens_input",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_output": {
+					"name": "tokens_output",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_cache_read": {
+					"name": "tokens_cache_read",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_cache_write": {
+					"name": "tokens_cache_write",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_state": {
+					"name": "preview_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_port": {
+					"name": "preview_port",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_started_at": {
+					"name": "preview_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_last_hit_at": {
+					"name": "preview_last_hit_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_failure_message": {
+					"name": "preview_failure_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'batch'"
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"paused_question_event_id": {
+					"name": "paused_question_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"runs_state_idx": {
+					"name": "runs_state_idx",
+					"columns": ["state"],
+					"isUnique": false
+				},
+				"runs_project_started_idx": {
+					"name": "runs_project_started_idx",
+					"columns": ["project_id", "\"started_at\" DESC"],
+					"isUnique": false
+				},
+				"runs_agent_started_idx": {
+					"name": "runs_agent_started_idx",
+					"columns": ["agent_name", "\"started_at\" DESC"],
+					"isUnique": false
+				},
+				"runs_worker_state_idx": {
+					"name": "runs_worker_state_idx",
+					"columns": ["worker_id", "state"],
+					"isUnique": false
+				},
+				"runs_plot_id_idx": {
+					"name": "runs_plot_id_idx",
+					"columns": ["plot_id"],
+					"isUnique": false
+				},
+				"runs_mode_idx": {
+					"name": "runs_mode_idx",
+					"columns": ["mode"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"runs_project_id_projects_id_fk": {
+					"name": "runs_project_id_projects_id_fk",
+					"tableFrom": "runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"triggers": {
+			"name": "triggers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"trigger_id": {
+					"name": "trigger_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_fired_at": {
+					"name": "last_fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"next_fire_at": {
+					"name": "next_fire_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_run_id": {
+					"name": "last_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"triggers_project_idx": {
+					"name": "triggers_project_idx",
+					"columns": ["project_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"triggers_project_id_projects_id_fk": {
+					"name": "triggers_project_id_projects_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"triggers_last_run_id_runs_id_fk": {
+					"name": "triggers_last_run_id_runs_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "runs",
+					"columnsFrom": ["last_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workers": {
+			"name": "workers",
+			"columns": {
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'healthy'"
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {
+			"runs_project_started_idx": {
+				"columns": {
+					"\"started_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"runs_agent_started_idx": {
+				"columns": {
+					"\"started_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
 			"when": 1779076503750,
 			"tag": "0016_add_plan_run_plot_id",
 			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "6",
+			"when": 1779495708939,
+			"tag": "0017_add_run_mode_and_pause",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/migrations/postgres/0010_add_run_mode_and_pause.sql
+++ b/src/db/migrations/postgres/0010_add_run_mode_and_pause.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "runs" ADD COLUMN "mode" text DEFAULT 'batch' NOT NULL;--> statement-breakpoint
+ALTER TABLE "runs" ADD COLUMN "paused_at" text;--> statement-breakpoint
+ALTER TABLE "runs" ADD COLUMN "paused_question_event_id" text;--> statement-breakpoint
+CREATE INDEX "runs_mode_idx" ON "runs" USING btree ("mode");

--- a/src/db/migrations/postgres/meta/0010_snapshot.json
+++ b/src/db/migrations/postgres/meta/0010_snapshot.json
@@ -1,0 +1,1099 @@
+{
+	"id": "3322e7f6-d512-45d2-bb4e-7f748bb9430d",
+	"prevId": "d6eea60d-fce5-44fb-b8ff-d0eb3f448372",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.agents": {
+			"name": "agents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rendered_json": {
+					"name": "rendered_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"registered_at": {
+					"name": "registered_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_refreshed": {
+					"name": "last_refreshed",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"agents_project_name_idx": {
+					"name": "agents_project_name_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"agents_global_name_idx": {
+					"name": "agents_global_name_idx",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"agents\".\"project_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agents_project_id_projects_id_fk": {
+					"name": "agents_project_id_projects_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.burrows": {
+			"name": "burrows",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"burrows_worker_idx": {
+					"name": "burrows_worker_idx",
+					"columns": [
+						{
+							"expression": "worker_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"burrow_event_seq": {
+					"name": "burrow_event_seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ts": {
+					"name": "ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stream": {
+					"name": "stream",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"payload_json": {
+					"name": "payload_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"events_run_seq_idx": {
+					"name": "events_run_seq_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "burrow_event_seq",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"events_run_ts_idx": {
+					"name": "events_run_ts_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "ts",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"events_run_id_runs_id_fk": {
+					"name": "events_run_id_runs_id_fk",
+					"tableFrom": "events",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.plan_run_children": {
+			"name": "plan_run_children",
+			"schema": "",
+			"columns": {
+				"plan_run_id": {
+					"name": "plan_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pr_merged_at": {
+					"name": "pr_merged_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"plan_run_children_run_idx": {
+					"name": "plan_run_children_run_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"plan_run_children_state_idx": {
+					"name": "plan_run_children_state_idx",
+					"columns": [
+						{
+							"expression": "plan_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"plan_run_children_plan_run_id_plan_runs_id_fk": {
+					"name": "plan_run_children_plan_run_id_plan_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "plan_runs",
+					"columnsFrom": ["plan_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"plan_run_children_run_id_runs_id_fk": {
+					"name": "plan_run_children_run_id_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"plan_run_children_plan_run_id_seq_pk": {
+					"name": "plan_run_children_plan_run_id_seq_pk",
+					"columns": ["plan_run_id", "seq"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.plan_runs": {
+			"name": "plan_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"plan_id": {
+					"name": "plan_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"prompt_template": {
+					"name": "prompt_template",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'work on sd {seed_id}'"
+				},
+				"ref": {
+					"name": "ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_override": {
+					"name": "provider_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"model_override": {
+					"name": "model_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatcher_handle": {
+					"name": "dispatcher_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'operator'"
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'manual'"
+				},
+				"plot_id": {
+					"name": "plot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"plan_runs_project_state_idx": {
+					"name": "plan_runs_project_state_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"plan_runs_state_idx": {
+					"name": "plan_runs_state_idx",
+					"columns": [
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"plan_runs_plot_id_idx": {
+					"name": "plan_runs_plot_id_idx",
+					"columns": [
+						{
+							"expression": "plot_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"plan_runs_project_id_projects_id_fk": {
+					"name": "plan_runs_project_id_projects_id_fk",
+					"tableFrom": "plan_runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"git_url": {
+					"name": "git_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"local_path": {
+					"name": "local_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"default_branch": {
+					"name": "default_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_fetched_at": {
+					"name": "last_fetched_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_head_sha": {
+					"name": "last_head_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_plot": {
+					"name": "has_plot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"has_seeds": {
+					"name": "has_seeds",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {
+				"projects_git_url_idx": {
+					"name": "projects_git_url_idx",
+					"columns": [
+						{
+							"expression": "git_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.runs": {
+			"name": "runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"burrow_id": {
+					"name": "burrow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"burrow_run_id": {
+					"name": "burrow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"plot_id": {
+					"name": "plot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rendered_agent_json": {
+					"name": "rendered_agent_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prompt": {
+					"name": "prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pr_url": {
+					"name": "pr_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cost_usd": {
+					"name": "cost_usd",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_input": {
+					"name": "tokens_input",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_output": {
+					"name": "tokens_output",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_cache_read": {
+					"name": "tokens_cache_read",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_cache_write": {
+					"name": "tokens_cache_write",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_state": {
+					"name": "preview_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_port": {
+					"name": "preview_port",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_started_at": {
+					"name": "preview_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_last_hit_at": {
+					"name": "preview_last_hit_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_failure_message": {
+					"name": "preview_failure_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'batch'"
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"paused_question_event_id": {
+					"name": "paused_question_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"runs_state_idx": {
+					"name": "runs_state_idx",
+					"columns": [
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_project_started_idx": {
+					"name": "runs_project_started_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"started_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_agent_started_idx": {
+					"name": "runs_agent_started_idx",
+					"columns": [
+						{
+							"expression": "agent_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"started_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_worker_state_idx": {
+					"name": "runs_worker_state_idx",
+					"columns": [
+						{
+							"expression": "worker_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_plot_id_idx": {
+					"name": "runs_plot_id_idx",
+					"columns": [
+						{
+							"expression": "plot_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_mode_idx": {
+					"name": "runs_mode_idx",
+					"columns": [
+						{
+							"expression": "mode",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"runs_project_id_projects_id_fk": {
+					"name": "runs_project_id_projects_id_fk",
+					"tableFrom": "runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.triggers": {
+			"name": "triggers",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"trigger_id": {
+					"name": "trigger_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_fired_at": {
+					"name": "last_fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_fire_at": {
+					"name": "next_fire_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_run_id": {
+					"name": "last_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"triggers_project_idx": {
+					"name": "triggers_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"triggers_project_id_projects_id_fk": {
+					"name": "triggers_project_id_projects_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"triggers_last_run_id_runs_id_fk": {
+					"name": "triggers_last_run_id_runs_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "runs",
+					"columnsFrom": ["last_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workers": {
+			"name": "workers",
+			"schema": "",
+			"columns": {
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'healthy'"
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/src/db/migrations/postgres/meta/_journal.json
+++ b/src/db/migrations/postgres/meta/_journal.json
@@ -71,6 +71,13 @@
 			"when": 1779076504033,
 			"tag": "0009_add_plan_run_plot_id",
 			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1779495709745,
+			"tag": "0010_add_run_mode_and_pause",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/repos/runs.ts
+++ b/src/db/repos/runs.ts
@@ -17,6 +17,7 @@ import type { SqliteDrizzleDb } from "../client.ts";
 import type {
 	PreviewState,
 	RunFailureReason,
+	RunMode,
 	RunRow,
 	RunState,
 	RunTerminalState,
@@ -25,7 +26,13 @@ import type { DrizzleAdapter } from "./drizzle-adapter.ts";
 
 const ALLOWED_TRANSITIONS: Record<RunState, readonly RunState[]> = {
 	queued: ["running", "cancelled"],
-	running: ["succeeded", "failed", "cancelled"],
+	// `paused` is pl-0344 step 1 / warren-67b6: the supervisor (step 5 /
+	// warren-2976) flips a running batch run to `paused` on detection of a
+	// blocking Plot `question_posed` event; the answer (or pause-timeout)
+	// flips it back to `running` via a respawned turn. Operators can still
+	// cancel a paused run.
+	running: ["paused", "succeeded", "failed", "cancelled"],
+	paused: ["running", "cancelled"],
 	succeeded: [],
 	failed: [],
 	cancelled: [],
@@ -70,6 +77,12 @@ export interface CreateRunInput {
 	 * project actually has a `.plot/` directory happens at handler level
 	 * via `project.hasPlot` — the repo writes whatever it's handed.
 	 */
+	/**
+	 * Run mode (pl-0344 step 1 / warren-67b6). `batch` (default) is the
+	 * historical single-shot run; `interactive` is the respawn-per-turn
+	 * primitive (pl-0344 step 3 / warren-1117). Fixed at run-create time.
+	 */
+	mode?: RunMode;
 	plotId?: string | null;
 	now?: Date;
 }
@@ -135,6 +148,9 @@ export class RunsRepo {
 			previewStartedAt: null,
 			previewLastHitAt: null,
 			previewFailureMessage: null,
+			mode: input.mode ?? "batch",
+			pausedAt: null,
+			pausedQuestionEventId: null,
 		};
 		await this.adapter.runWrite(this.db.insert(this.runs).values(row));
 		return row;

--- a/src/db/schema/columns.ts
+++ b/src/db/schema/columns.ts
@@ -15,7 +15,14 @@
  * Postgres tables exist but are unused at runtime.
  */
 
-export const RUN_STATES = ["queued", "running", "succeeded", "failed", "cancelled"] as const;
+export const RUN_STATES = [
+	"queued",
+	"running",
+	"paused",
+	"succeeded",
+	"failed",
+	"cancelled",
+] as const;
 export type RunState = (typeof RUN_STATES)[number];
 
 export const RUN_TERMINAL_STATES = [
@@ -24,6 +31,19 @@ export const RUN_TERMINAL_STATES = [
 	"cancelled",
 ] as const satisfies readonly RunState[];
 export type RunTerminalState = (typeof RUN_TERMINAL_STATES)[number];
+
+/**
+ * Run mode discriminator (pl-0344 step 1 / warren-67b6). `batch` is the
+ * historical single-shot run: warren spawns burrow, agent runs to completion,
+ * reap pushes the branch. `interactive` is the respawn-per-turn primitive
+ * powering brainstorm + planner agents (pl-0344 step 3 / warren-1117) — each
+ * user message dispatches a fresh burrow turn that reads Plot context, replies,
+ * and exits. Mode is fixed at run-create time. TS-only narrowing (mx-2ab984);
+ * defaults to `batch` so legacy rows written before this column existed match
+ * the historical shape.
+ */
+export const RUN_MODES = ["batch", "interactive"] as const;
+export type RunMode = (typeof RUN_MODES)[number];
 
 /**
  * Failure-cause discriminator for a `failed` run (warren-3c40, warren-5165).
@@ -190,6 +210,7 @@ export const INDEX_NAMES = {
 	runsAgentStarted: "runs_agent_started_idx",
 	runsWorkerState: "runs_worker_state_idx",
 	runsPlotId: "runs_plot_id_idx",
+	runsMode: "runs_mode_idx",
 	eventsRunSeq: "events_run_seq_idx",
 	eventsRunTs: "events_run_ts_idx",
 	triggersProject: "triggers_project_idx",

--- a/src/db/schema/postgres.ts
+++ b/src/db/schema/postgres.ts
@@ -41,6 +41,7 @@ import {
 	PLAN_RUN_STATES,
 	PREVIEW_STATES,
 	RUN_FAILURE_REASONS,
+	RUN_MODES,
 	RUN_STATES,
 	TABLE_NAMES,
 	WORKER_STATES,
@@ -117,6 +118,11 @@ export const runs = pgTable(
 		previewStartedAt: text("preview_started_at"),
 		previewLastHitAt: text("preview_last_hit_at"),
 		previewFailureMessage: text("preview_failure_message"),
+		// Mirror of sqlite mode (pl-0344 step 1 / warren-67b6). See sqlite.ts
+		// for shape + state-machine intent.
+		mode: text("mode", { enum: RUN_MODES }).notNull().default("batch"),
+		pausedAt: text("paused_at"),
+		pausedQuestionEventId: text("paused_question_event_id"),
 	},
 	(t) => [
 		index(INDEX_NAMES.runsState).on(t.state),
@@ -124,6 +130,7 @@ export const runs = pgTable(
 		index(INDEX_NAMES.runsAgentStarted).on(t.agentName, sql`${t.startedAt} DESC`),
 		index(INDEX_NAMES.runsWorkerState).on(t.workerId, t.state),
 		index(INDEX_NAMES.runsPlotId).on(t.plotId),
+		index(INDEX_NAMES.runsMode).on(t.mode),
 	],
 );
 

--- a/src/db/schema/sqlite.ts
+++ b/src/db/schema/sqlite.ts
@@ -34,6 +34,7 @@ import {
 	PLAN_RUN_STATES,
 	PREVIEW_STATES,
 	RUN_FAILURE_REASONS,
+	RUN_MODES,
 	RUN_STATES,
 	TABLE_NAMES,
 	WORKER_STATES,
@@ -189,6 +190,21 @@ export const runs = sqliteTable(
 		previewStartedAt: text("preview_started_at"),
 		previewLastHitAt: text("preview_last_hit_at"),
 		previewFailureMessage: text("preview_failure_message"),
+		// Run mode discriminator (pl-0344 step 1 / warren-67b6). `batch` is the
+		// historical single-shot run; `interactive` is the respawn-per-turn
+		// primitive (pl-0344 step 3 / warren-1117). Fixed at run-create time.
+		// Defaults to `batch` so legacy rows match the historical shape.
+		mode: text("mode", { enum: RUN_MODES }).notNull().default("batch"),
+		// Pause bookkeeping (pl-0344 step 1 / warren-67b6). Populated when the
+		// supervisor (pl-0344 step 5 / warren-2976) detects a blocking
+		// `question_posed` event on the linked Plot and transitions the run
+		// `running → paused`. `paused_at` is the ISO8601 transition timestamp;
+		// `paused_question_event_id` is the Plot event id awaiting an answer.
+		// Both nullable: only set while the run is in the `paused` state. On
+		// resume (`paused → running`), the row may keep or clear these — the
+		// supervisor clears them once the answering turn is dispatched.
+		pausedAt: text("paused_at"),
+		pausedQuestionEventId: text("paused_question_event_id"),
 	},
 	(t) => [
 		index(INDEX_NAMES.runsState).on(t.state),
@@ -196,6 +212,7 @@ export const runs = sqliteTable(
 		index(INDEX_NAMES.runsAgentStarted).on(t.agentName, sql`${t.startedAt} DESC`),
 		index(INDEX_NAMES.runsWorkerState).on(t.workerId, t.state),
 		index(INDEX_NAMES.runsPlotId).on(t.plotId),
+		index(INDEX_NAMES.runsMode).on(t.mode),
 	],
 );
 


### PR DESCRIPTION
## Summary

DB schema: runs.mode + paused state + pause columns (warren-67b6)

## Run

- **Warren run:** `run_gxqg9rqxka2k`
- **Agent:** pi
- **Cost:** $1.58 (50 in / 11.7k out / 1.9M cache-r)

## Seeds

- warren-67b6 — DB schema: runs.mode column (batch|interactive default batch), pause columns (paused_at, paused_question_event_id), add 'paused' to RUN_STATES, extend ALLOWED_TRANSITIONS (running→paused, paused→running, paused→cancelled). Mirror sqlite + postgres in src/db/schema/, update drift.test.ts, add migration.

## Commits (1)

- 6f1ccbe DB schema: runs.mode + paused state + pause columns (warren-67b6)

## Files changed

```
src/db/migrations/0017_add_run_mode_and_pause.sql  |    4 +
 src/db/migrations/meta/0017_snapshot.json          |  949 +++++++++++++++++
 src/db/migrations/meta/_journal.json               |    7 +
 .../postgres/0010_add_run_mode_and_pause.sql       |    4 +
 src/db/migrations/postgres/meta/0010_snapshot.json | 1099 ++++++++++++++++++++
 src/db/migrations/postgres/meta/_journal.json      |    7 +
 src/db/repos/runs.ts                               |   18 +-
 src/db/schema/columns.ts                           |   23 +-
 src/db/schema/postgres.ts                          |    7 +
 src/db/schema/sqlite.ts                            |   17 +
 10 files changed, 2133 insertions(+), 2 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-67b6. use ml. commit when done.
```

</details>

---

🤖 Opened by warren run `run_gxqg9rqxka2k`