### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-05-23
+
+Patch release. Fixes interactive agents (brainstorm/planner) failing
+with "agent not registered" (#68).
+
+### Fixed
+
+- Interactive agents (brainstorm/planner) no longer fail with
+  "agent not registered" (#68).
+
 ## [0.5.0] — 2026-05-23
 
 Minor release shipping the Plot-workbench loop (plan pl-0344, parent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@os-eco/warren-cli",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "Self-hostable control plane for ephemeral cloud agents — spawn sandboxed agents at your GitHub repos, watch them work live, steer them, get a branch back",
 	"type": "module",
 	"bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@
  * `Client` class is deferred to V2 (SPEC §8.3).
  */
 
-export const VERSION = "0.5.0";
+export const VERSION = "0.5.1";


### PR DESCRIPTION
## Summary

release: v0.5.1

## Run

- **Warren run:** `run_2r9gqw9629jx`
- **Agent:** pi
- **Cost:** $0.149 (18 in / 2.0k out / 126.9k cache-r)

## Commits (1)

- 1925223 release: v0.5.1

## Files changed

```
CHANGELOG.md | 10 ++++++++++
 package.json |  2 +-
 src/index.ts |  2 +-
 3 files changed, 12 insertions(+), 2 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
follow .claude/commands/release.md and bump proj to v0.5.1. Commit when you are done! Ignored instructions in prompt file to wait for user confirmation, this is the user giving confirmation. Commit when you're done. 
```

</details>

---

🤖 Opened by warren run `run_2r9gqw9629jx`