### PR TITLE
chore(warren): plot state

### DIFF
--- a/.plot/plot-1ce5ca91.events.jsonl
+++ b/.plot/plot-1ce5ca91.events.jsonl
@@ -5,3 +5,12 @@
 {"type":"status_changed","actor":"user:jayminwest","at":"2026-05-24T21:15:09.068Z","data":{"from":"drafting","to":"ready"}}
 {"type":"intent_edited","actor":"user:operator","at":"2026-05-25T19:27:05.069Z","data":{"field":"goal","value":"Enable external projects to autonomously dispatch coding runs against its own codebase, stream events, steer agents mid-run, and manage projects/plots via warren's HTTP API without MCP"}}
 {"type":"intent_edited","actor":"user:operator","at":"2026-05-25T19:27:05.069Z","data":{"field":"success_criteria","value":["External projects can import WarrenClient from @os-eco/warren-cli/client, dispatch a run to Fly.io warren, stream events, and steer — all with bearer token auth"]}}
+{"type":"run_dispatched","actor":"user:operator","at":"2026-05-25T19:46:39.951Z","data":{"run_id":"run_0wz54sybfdr4","agent":"planner","model":"gemini-3.5-flash","project":"prj_z07y6ssfjfpk"}}
+{"type":"attachment_added","actor":"agent:planner:run_0wz54sybfdr4","at":"2026-05-25T19:50:20.150Z","data":{"id":"att-001","type":"seeds_issue","ref":"warren-7c75","role":"implementation"}}
+{"type":"attachment_added","actor":"agent:planner:run_0wz54sybfdr4","at":"2026-05-25T19:50:23.571Z","data":{"id":"att-002","type":"seeds_issue","ref":"warren-552c","role":"step"}}
+{"type":"attachment_added","actor":"agent:planner:run_0wz54sybfdr4","at":"2026-05-25T19:50:23.633Z","data":{"id":"att-003","type":"seeds_issue","ref":"warren-285f","role":"step"}}
+{"type":"attachment_added","actor":"agent:planner:run_0wz54sybfdr4","at":"2026-05-25T19:50:23.696Z","data":{"id":"att-004","type":"seeds_issue","ref":"warren-387a","role":"step"}}
+{"type":"attachment_added","actor":"agent:planner:run_0wz54sybfdr4","at":"2026-05-25T19:50:23.762Z","data":{"id":"att-005","type":"seeds_issue","ref":"warren-e0ed","role":"step"}}
+{"type":"attachment_added","actor":"agent:planner:run_0wz54sybfdr4","at":"2026-05-25T19:50:23.825Z","data":{"id":"att-006","type":"seeds_issue","ref":"warren-a4b9","role":"step"}}
+{"type":"attachment_added","actor":"agent:planner:run_0wz54sybfdr4","at":"2026-05-25T19:50:23.889Z","data":{"id":"att-007","type":"seeds_issue","ref":"warren-8ffc","role":"step"}}
+{"type":"attachment_added","actor":"agent:planner:run_0wz54sybfdr4","at":"2026-05-25T19:50:27.599Z","data":{"id":"att-008","type":"seeds_issue","ref":"pl-e4d7","role":"plan"}}

--- a/.plot/plot-1ce5ca91.json
+++ b/.plot/plot-1ce5ca91.json
@@ -1,5 +1,70 @@
 {
-  "attachments": [],
+  "attachments": [
+    {
+      "added_at": "2026-05-25T19:50:20.150Z",
+      "added_by": "agent:planner:run_0wz54sybfdr4",
+      "id": "att-001",
+      "ref": "warren-7c75",
+      "role": "implementation",
+      "type": "seeds_issue"
+    },
+    {
+      "added_at": "2026-05-25T19:50:23.571Z",
+      "added_by": "agent:planner:run_0wz54sybfdr4",
+      "id": "att-002",
+      "ref": "warren-552c",
+      "role": "step",
+      "type": "seeds_issue"
+    },
+    {
+      "added_at": "2026-05-25T19:50:23.633Z",
+      "added_by": "agent:planner:run_0wz54sybfdr4",
+      "id": "att-003",
+      "ref": "warren-285f",
+      "role": "step",
+      "type": "seeds_issue"
+    },
+    {
+      "added_at": "2026-05-25T19:50:23.696Z",
+      "added_by": "agent:planner:run_0wz54sybfdr4",
+      "id": "att-004",
+      "ref": "warren-387a",
+      "role": "step",
+      "type": "seeds_issue"
+    },
+    {
+      "added_at": "2026-05-25T19:50:23.762Z",
+      "added_by": "agent:planner:run_0wz54sybfdr4",
+      "id": "att-005",
+      "ref": "warren-e0ed",
+      "role": "step",
+      "type": "seeds_issue"
+    },
+    {
+      "added_at": "2026-05-25T19:50:23.825Z",
+      "added_by": "agent:planner:run_0wz54sybfdr4",
+      "id": "att-006",
+      "ref": "warren-a4b9",
+      "role": "step",
+      "type": "seeds_issue"
+    },
+    {
+      "added_at": "2026-05-25T19:50:23.889Z",
+      "added_by": "agent:planner:run_0wz54sybfdr4",
+      "id": "att-007",
+      "ref": "warren-8ffc",
+      "role": "step",
+      "type": "seeds_issue"
+    },
+    {
+      "added_at": "2026-05-25T19:50:27.599Z",
+      "added_by": "agent:planner:run_0wz54sybfdr4",
+      "id": "att-008",
+      "ref": "pl-e4d7",
+      "role": "plan",
+      "type": "seeds_issue"
+    }
+  ],
   "created_at": "2026-05-24T21:14:33.764Z",
   "id": "plot-1ce5ca91",
   "intent": {
@@ -15,5 +80,5 @@
   "name": "Warren Client SDK — typed remote client for external agents",
   "schema_version": 1,
   "status": "ready",
-  "updated_at": "2026-05-25T19:27:05.069Z"
+  "updated_at": "2026-05-25T19:50:27.599Z"
 }


### PR DESCRIPTION
## Summary

chore(warren): plot state

## Run

- **Warren run:** `run_0wz54sybfdr4`
- **Agent:** planner
- **Cost:** $1.07 (358.4k in / 24.0k out / 2.1M cache-r)

## Commits (1)

- 8d3aaf1 chore(warren): plot state

## Files changed

```
.plot/plot-1ce5ca91.events.jsonl |  9 ++++++
 .plot/plot-1ce5ca91.json         | 69 ++++++++++++++++++++++++++++++++++++++--
 2 files changed, 76 insertions(+), 2 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
<plot_context>
<plot id="plot-1ce5ca91" status="ready">
<name>Warren Client SDK — typed remote client for external agents</name>
<intent>
  <goal>Enable external projects to autonomously dispatch coding runs against its own codebase, stream events, steer agents mid-run, and manage projects/plots via warren's HTTP API without MCP</goal>
  <constraints>
    - Zero server-side deps in src/client/ (no drizzle, bun:sqlite, burrow). Wire types declared fresh. Follows src/burrow-client/ pattern. Single version — SDK and CLI cannot drift.
  </constraints>
  <success_criteria>
    - External projects can import WarrenClient from @os-eco/warren-cli/client, dispatch a run to Fly.io warren, stream events, and steer — all with bearer token auth
  </success_criteria>
</intent>
</plot>
</plot_context>

<user_message>
Read the Plot intent, scout the repo, and submit a structured plan (sd plan submit). Warren will commit and push your .seeds/ + .plot/ deltas at reap; you don't need to run git.
</user_message>
```

</details>

---

🤖 Opened by warren run `run_0wz54sybfdr4`