### PR TITLE
Rewrite the operating-contract block in claude-code / sapling / pi buil…

### DIFF
--- a/src/registry/builtins/builtins.test.ts
+++ b/src/registry/builtins/builtins.test.ts
@@ -57,6 +57,21 @@ describe("BUILTIN_AGENTS", () => {
 			expect(builtin.frontmatter.source).toBe("builtin");
 		}
 	});
+
+	// warren-6a34: the operating-contract block for the three interactive
+	// coding built-ins must frame the quality gate as terminal, not advisory.
+	// This regression test prevents the bullet from drifting back to softer
+	// "run gates before committing" wording that lets agents declare success
+	// on a red tree.
+	test("claude-code / sapling / pi declare the quality gate as terminal (warren-6a34)", () => {
+		for (const builtin of [CLAUDE_CODE_BUILTIN, SAPLING_BUILTIN, PI_BUILTIN]) {
+			const system = builtin.sections.system ?? "";
+			expect(system).toContain("$WARREN_QUALITY_GATE");
+			expect(system).toContain("NOT done until the gate exits zero");
+			expect(system).toContain("Do not declare the task complete");
+			expect(system).toContain("red gate");
+		}
+	});
 });
 
 describe("readAgentSource", () => {

--- a/src/registry/builtins/claude-code.ts
+++ b/src/registry/builtins/claude-code.ts
@@ -22,7 +22,7 @@ Workspace map:
 
 Operating contract:
 - Edit files in place. Run tests when relevant.
-- Before committing, run the project's quality gates to catch lint, type, and test failures. Use \`$WARREN_QUALITY_GATE\` if set, otherwise look for the command in CLAUDE.md, or fall back to common commands (\`bun run check:all\`, \`npm run lint && npm run typecheck\`). Fix any failures before committing.
+- Quality gates are terminal, not advisory. You are NOT done until the gate exits zero. Resolve the command in this order: \`$WARREN_QUALITY_GATE\` if set, otherwise the command documented in CLAUDE.md / AGENTS.md, otherwise fall back to \`bun run check:all\` or \`npm run lint && npm run typecheck && npm test\`. Run it before committing and again before reporting completion. Do not declare the task complete, hand off, or end the session with a red gate — fix failures (including lint warnings, which CI treats as errors) until it is green. If the gate is genuinely unfixable in this run, say so explicitly and leave the work open rather than claiming success.
 - Use git as you normally would. Commit your changes; warren reaps the branch and pushes upstream.
 - Do not run \`git push\` yourself — warren handles the push host-side after the run terminates.
 `;

--- a/src/registry/builtins/pi.ts
+++ b/src/registry/builtins/pi.ts
@@ -27,7 +27,7 @@ Workspace map:
 
 Operating contract:
 - Edit files in place. Run tests when relevant.
-- Before committing, run the project's quality gates to catch lint, type, and test failures. Use \`$WARREN_QUALITY_GATE\` if set, otherwise look for the command in CLAUDE.md, or fall back to common commands (\`bun run check:all\`, \`npm run lint && npm run typecheck\`). Fix any failures before committing.
+- Quality gates are terminal, not advisory. You are NOT done until the gate exits zero. Resolve the command in this order: \`$WARREN_QUALITY_GATE\` if set, otherwise the command documented in CLAUDE.md / AGENTS.md, otherwise fall back to \`bun run check:all\` or \`npm run lint && npm run typecheck && npm test\`. Run it before committing and again before reporting completion. Do not declare the task complete, hand off, or end the session with a red gate — fix failures (including lint warnings, which CI treats as errors) until it is green. If the gate is genuinely unfixable in this run, say so explicitly and leave the work open rather than claiming success.
 - Use git as you normally would. Commit your changes; warren reaps the branch and pushes upstream.
 - Do not run \`git push\` yourself — warren handles the push host-side after the run terminates.
 `;

--- a/src/registry/builtins/sapling.ts
+++ b/src/registry/builtins/sapling.ts
@@ -19,7 +19,7 @@ Workspace map:
 
 Operating contract:
 - Edit files in place. Run tests when relevant.
-- Before committing, run the project's quality gates to catch lint, type, and test failures. Use \`$WARREN_QUALITY_GATE\` if set, otherwise look for the command in CLAUDE.md, or fall back to common commands (\`bun run check:all\`, \`npm run lint && npm run typecheck\`). Fix any failures before committing.
+- Quality gates are terminal, not advisory. You are NOT done until the gate exits zero. Resolve the command in this order: \`$WARREN_QUALITY_GATE\` if set, otherwise the command documented in CLAUDE.md / AGENTS.md, otherwise fall back to \`bun run check:all\` or \`npm run lint && npm run typecheck && npm test\`. Run it before committing and again before reporting completion. Do not declare the task complete, hand off, or end the session with a red gate — fix failures (including lint warnings, which CI treats as errors) until it is green. If the gate is genuinely unfixable in this run, say so explicitly and leave the work open rather than claiming success.
 - Use git as you normally would. Commit your changes; warren reaps the branch and pushes upstream.
 - Do not run \`git push\` yourself — warren handles the push host-side after the run terminates.
 `;


### PR DESCRIPTION
## Summary

agents: make quality gate terminal in claude-code/sapling/pi prompts

## Run

- **Warren run:** `run_10j6awfdngs2`
- **Agent:** pi
- **Cost:** $0.499 (28 in / 7.1k out / 422.3k cache-r)

## Seeds

- warren-6a34 — Rewrite the operating-contract block in claude-code / sapling / pi built-ins: green gate is terminal, not advisory — explicit "you are not done until $WARREN_QUALITY_GATE exits zero; do not declare task complete with a red gate" language

## Commits (1)

- aeadbdb agents: make quality gate terminal in claude-code/sapling/pi prompts

## Files changed

```
src/registry/builtins/builtins.test.ts | 15 +++++++++++++++
 src/registry/builtins/claude-code.ts   |  2 +-
 src/registry/builtins/pi.ts            |  2 +-
 src/registry/builtins/sapling.ts       |  2 +-
 4 files changed, 18 insertions(+), 3 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-6a34. use ml. commit when done.
```

</details>

---

🤖 Opened by warren run `run_10j6awfdngs2`