### PR TITLE
Phase 6: Layout promotions — PageHeader, Field (label+control+error), F…

### DIFF
--- a/scripts/coverage-budgets.json
+++ b/scripts/coverage-budgets.json
@@ -1,5 +1,5 @@
 {
 	"_comment": "Coverage floors enforced by scripts/check-coverage.ts (warren-e4b1, pl-7b06 step 17). Set just below the current baseline (functions 86.25%, lines 91.62% as of 2026-05-27) to absorb measurement noise. The ratchet only goes UP — raise these numbers as coverage improves; never lower them. To grow past a budget: add tests first, then raise the floor.",
-	"functions": 85.0,
-	"lines": 90.0
+	"functions": 86.87,
+	"lines": 90.23
 }

--- a/src/ui/src/components/ui/card.tsx
+++ b/src/ui/src/components/ui/card.tsx
@@ -8,18 +8,27 @@ import { cn } from "@/lib/utils.ts";
  * Card grows elevation variants without changing the default look.
  * `default` keeps `shadow-xs` so existing call sites render
  * identically; `elevated` raises to `shadow-md` for content meant to
- * read above the page. Phase 6 (warren-e6b3) will add the
- * `interactive` and `flat` variants when callers actually need them
- * — adding them earlier just pays bundle-size for utilities no
- * consumer references yet.
+ * read above the page.
+ *
+ * Phase 6 (warren-e6b3 / pl-55a3 step 7) added:
+ *   - `flat` — no shadow, smaller `rounded-md` corner, used by the
+ *     ad-hoc `rounded-md border bg-(--color-card)` panels the sweep
+ *     promoted onto Card. Pairs with a translucent muted fill via
+ *     a className override on call sites that need it.
+ *
+ * Phase 7 (warren-2221) will add an `interactive` variant (hover
+ * border + shadow lift) once the PlotDetail decomposition surfaces
+ * actual clickable-row sites — adding it now would just pay the
+ * bundle-size cost for utilities no consumer references yet.
  */
 const cardVariants = cva(
-	"rounded-lg border bg-(--color-card) text-(--color-fg)",
+	"border bg-(--color-card) text-(--color-fg)",
 	{
 		variants: {
 			variant: {
-				default: "shadow-xs",
-				elevated: "shadow-md",
+				default: "rounded-lg shadow-xs",
+				elevated: "rounded-lg shadow-md",
+				flat: "rounded-md",
 			},
 		},
 		defaultVariants: {

--- a/src/ui/src/components/ui/field.tsx
+++ b/src/ui/src/components/ui/field.tsx
@@ -1,0 +1,107 @@
+import * as React from "react";
+import { cn } from "@/lib/utils.ts";
+import { Label } from "./label.tsx";
+
+/*
+ * Phase 6 layout primitive (warren-e6b3 / pl-55a3 step 7):
+ *
+ * Field — wraps `<Label>` + control + optional description/error/hint
+ * into the `space-y-1.5` stack that NewRun, NewPlanRun, ProjectDetail,
+ * and the per-Plot form blocks all repeat by hand. Consolidating the
+ * pattern means every form field gets:
+ *   - the same vertical rhythm,
+ *   - the same `text-xs text-(--color-muted-foreground)` hint copy,
+ *   - the same `text-(--color-destructive)` error voice,
+ *   - automatic `htmlFor`/`id` wiring + `aria-describedby` /
+ *     `aria-invalid` on the rendered control via render-prop.
+ *
+ * Two usage shapes:
+ *
+ *   <Field label="Branch" htmlFor="ref" description="…">
+ *     <Input id="ref" ... />
+ *   </Field>
+ *
+ * or, for full aria wiring of a single control:
+ *
+ *   <Field label="Branch" id="ref" description="…" error={err}>
+ *     {(ctl) => <Input {...ctl} value={ref} onChange={...} />}
+ *   </Field>
+ *
+ * In the render-prop form, the child receives `id`, `aria-invalid`,
+ * and `aria-describedby` props that point at the auto-generated
+ * description / error nodes.
+ */
+export interface FieldControlProps {
+	id: string;
+	"aria-invalid"?: boolean;
+	"aria-describedby"?: string;
+}
+
+export interface FieldProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
+	label: React.ReactNode;
+	/** id of the control. Used for htmlFor + aria wiring. */
+	id?: string;
+	/** legacy alias for `id`; pass either. */
+	htmlFor?: string;
+	description?: React.ReactNode;
+	error?: React.ReactNode;
+	required?: boolean;
+	children: React.ReactNode | ((ctl: FieldControlProps) => React.ReactNode);
+}
+
+export const Field = React.forwardRef<HTMLDivElement, FieldProps>(
+	(
+		{
+			className,
+			label,
+			id,
+			htmlFor,
+			description,
+			error,
+			required,
+			children,
+			...props
+		},
+		ref,
+	) => {
+		const controlId = id ?? htmlFor;
+		const descId = description !== undefined && controlId ? `${controlId}-desc` : undefined;
+		const errId = error !== undefined && error !== null && controlId
+			? `${controlId}-err`
+			: undefined;
+		const describedBy = [descId, errId].filter(Boolean).join(" ") || undefined;
+		const ctl: FieldControlProps = {
+			id: controlId ?? "",
+			"aria-invalid": error !== undefined && error !== null ? true : undefined,
+			"aria-describedby": describedBy,
+		};
+		return (
+			<div ref={ref} className={cn("space-y-1.5", className)} {...props}>
+				{controlId ? (
+					<Label htmlFor={controlId}>
+						{label}
+						{required ? (
+							<span aria-hidden="true" className="ml-0.5 text-(--color-destructive)">
+								*
+							</span>
+						) : null}
+					</Label>
+				) : (
+					<span className="text-sm font-medium leading-none">{label}</span>
+				)}
+				{typeof children === "function" ? children(ctl) : children}
+				{description !== undefined ? (
+					<p id={descId} className="text-xs text-(--color-muted-foreground)">
+						{description}
+					</p>
+				) : null}
+				{error !== undefined && error !== null ? (
+					<p id={errId} className="text-xs text-(--color-destructive)">
+						{error}
+					</p>
+				) : null}
+			</div>
+		);
+	},
+);
+Field.displayName = "Field";

--- a/src/ui/src/components/ui/filter-pill.tsx
+++ b/src/ui/src/components/ui/filter-pill.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import { cn } from "@/lib/utils.ts";
+
+/*
+ * Phase 6 layout primitive (warren-e6b3 / pl-55a3 step 7):
+ *
+ * FilterPill — the canonical "rounded chip toggle" surface. Extracted
+ * from Runs.tsx's inline FilterPill (the original implementation) so
+ * Plots.tsx's `aria-pressed` toggles and any future filter strip can
+ * share the active / hover / focus treatment.
+ *
+ * Active pills paint with the primary token; inactive pills sit on
+ * card with a subtle hover. `pressed` is mirrored to `aria-pressed`
+ * for screen readers — the component is a proper toggle button, not
+ * a styled link.
+ *
+ * `FilterPillGroup` is a thin layout wrapper that gives the strip
+ * `flex flex-wrap gap-2` so pages don't keep retyping the same
+ * container.
+ */
+export interface FilterPillProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+	/** Whether the pill is in its toggled-on state. Mirrored to `aria-pressed`. */
+	active: boolean;
+	/** Convenience: render the label as the button's only child. */
+	label?: React.ReactNode;
+}
+
+export const FilterPill = React.forwardRef<HTMLButtonElement, FilterPillProps>(
+	({ className, active, label, children, type = "button", ...props }, ref) => (
+		<button
+			ref={ref}
+			type={type}
+			aria-pressed={active}
+			className={cn(
+				"rounded-full border px-3 py-1 text-xs transition-colors",
+				"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-ring)",
+				active
+					? "bg-(--color-primary) text-(--color-primary-foreground)"
+					: "bg-(--color-card) hover:bg-(--color-accent)",
+				className,
+			)}
+			{...props}
+		>
+			{label ?? children}
+		</button>
+	),
+);
+FilterPill.displayName = "FilterPill";
+
+export const FilterPillGroup = React.forwardRef<
+	HTMLDivElement,
+	React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+	<div
+		ref={ref}
+		role="group"
+		className={cn("flex flex-wrap gap-2", className)}
+		{...props}
+	/>
+));
+FilterPillGroup.displayName = "FilterPillGroup";

--- a/src/ui/src/components/ui/page-header.tsx
+++ b/src/ui/src/components/ui/page-header.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { cn } from "@/lib/utils.ts";
+
+/*
+ * Phase 6 layout primitive (warren-e6b3 / pl-55a3 step 7):
+ *
+ * PageHeader — the canonical top-of-page banner. Audit found ~10
+ * pages (Runs, Plots, Projects, PlanRuns, Agents, NewRun,
+ * NewPlanRun, CostAnalytics, PlotDetail, PlotSummary) each rolling
+ * their own `<header>` with `<h1 className="text-2xl font-semibold
+ * tracking-tight">` + muted-foreground description + actions cluster.
+ * This primitive consolidates that shape so all pages share spacing,
+ * heading scale, and wrap behaviour.
+ *
+ * Slots:
+ *   - `title`       — required heading. Renders inside `<h1>` unless
+ *                     `as` overrides the tag.
+ *   - `description` — optional muted secondary line.
+ *   - `actions`     — optional right-aligned cluster (Buttons, Links).
+ *   - `monoTitle`   — render the title in JetBrains Mono at xl scale
+ *                     instead of the default 2xl semibold tracking.
+ *                     Used by ID-keyed detail pages (PlanRunDetail,
+ *                     ProjectDetail, RunDetail).
+ *   - `as`          — override the heading tag (defaults to `h1`).
+ */
+export interface PageHeaderProps extends Omit<React.HTMLAttributes<HTMLElement>, "title"> {
+	title: React.ReactNode;
+	description?: React.ReactNode;
+	actions?: React.ReactNode;
+	monoTitle?: boolean;
+	as?: "h1" | "h2";
+}
+
+export const PageHeader = React.forwardRef<HTMLElement, PageHeaderProps>(
+	(
+		{ className, title, description, actions, monoTitle, as = "h1", children, ...props },
+		ref,
+	) => {
+		const Heading = as;
+		const headingClass = monoTitle
+			? "font-mono text-xl font-semibold"
+			: "text-2xl font-semibold tracking-tight";
+		return (
+			<header
+				ref={ref}
+				className={cn(
+					"flex flex-wrap items-center justify-between gap-4",
+					className,
+				)}
+				{...props}
+			>
+				<div className="min-w-0">
+					<Heading className={headingClass}>{title}</Heading>
+					{description ? (
+						<p className="text-sm text-(--color-muted-foreground)">{description}</p>
+					) : null}
+					{children}
+				</div>
+				{actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+			</header>
+		);
+	},
+);
+PageHeader.displayName = "PageHeader";

--- a/src/ui/src/pages/Agents.tsx
+++ b/src/ui/src/pages/Agents.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { EmptyState } from "@/components/ui/empty-state.tsx";
 import { Label } from "@/components/ui/label.tsx";
+import { PageHeader } from "@/components/ui/page-header.tsx";
 import { Spinner } from "@/components/ui/spinner.tsx";
 import {
 	Table,
@@ -53,17 +54,19 @@ export function AgentsPage() {
 
 	return (
 		<div className="space-y-6">
-			<header className="flex flex-wrap items-start justify-between gap-3">
-				<div>
-					<h1 className="text-2xl font-semibold tracking-tight">Agents</h1>
-					<p className="text-sm text-(--color-muted-foreground)">
+			<PageHeader
+				className="items-start"
+				title="Agents"
+				description={
+					<>
 						Agents available for dispatch. <code>claude-code</code>,{" "}
 						<code>sapling</code>, and <code>pi</code> ship inline; refresh
 						re-clones the optional canopy library for custom agents. Pick a
 						project to surface its <code>.canopy/</code> tier.
-					</p>
-				</div>
-				<div className="flex flex-wrap items-end gap-2">
+					</>
+				}
+				actions={
+					<div className="flex flex-wrap items-end gap-2">
 					<div className="space-y-1.5">
 						<Label htmlFor="agent-project-filter" className="text-xs">
 							Project
@@ -107,7 +110,8 @@ export function AgentsPage() {
 						Refresh registry
 					</Button>
 				</div>
-			</header>
+				}
+			/>
 
 			{refresh.isSuccess ? (
 				<Card>

--- a/src/ui/src/pages/CostAnalytics.tsx
+++ b/src/ui/src/pages/CostAnalytics.tsx
@@ -28,6 +28,7 @@ import {
 	projectsApi,
 } from "@/api/client.ts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
+import { PageHeader } from "@/components/ui/page-header.tsx";
 import {
 	Table,
 	TableBody,
@@ -103,12 +104,10 @@ export function CostAnalyticsPage() {
 
 	return (
 		<div className="space-y-6">
-			<header>
-				<h1 className="text-2xl font-semibold tracking-tight">Cost analytics</h1>
-				<p className="text-sm text-(--color-muted-foreground)">
-					Spend breakdown across runs.cost_usd. Defaults to the last 30 days.
-				</p>
-			</header>
+			<PageHeader
+				title="Cost analytics"
+				description="Spend breakdown across runs.cost_usd. Defaults to the last 30 days."
+			/>
 
 			<Card>
 				<CardHeader>

--- a/src/ui/src/pages/NewPlanRun.tsx
+++ b/src/ui/src/pages/NewPlanRun.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Label } from "@/components/ui/label.tsx";
+import { PageHeader } from "@/components/ui/page-header.tsx";
 import { Textarea } from "@/components/ui/textarea.tsx";
 
 const DEFAULT_PROMPT_TEMPLATE = "work on sd {seed_id}";
@@ -143,13 +144,10 @@ export function NewPlanRunPage() {
 
 	return (
 		<div className="mx-auto max-w-3xl space-y-6">
-			<header>
-				<h1 className="text-2xl font-semibold tracking-tight">Dispatch plan run</h1>
-				<p className="text-sm text-(--color-muted-foreground)">
-					Walk a seeds plan in order — one warren run per open child seed,
-					sequentially.
-				</p>
-			</header>
+			<PageHeader
+				title="Dispatch plan run"
+				description="Walk a seeds plan in order — one warren run per open child seed, sequentially."
+			/>
 
 			{noProjects ? (
 				<Card>

--- a/src/ui/src/pages/NewRun.tsx
+++ b/src/ui/src/pages/NewRun.tsx
@@ -7,7 +7,9 @@ import { Badge } from "@/components/ui/badge.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { Input } from "@/components/ui/input.tsx";
+import { Field } from "@/components/ui/field.tsx";
 import { Label } from "@/components/ui/label.tsx";
+import { PageHeader } from "@/components/ui/page-header.tsx";
 import { Textarea } from "@/components/ui/textarea.tsx";
 import { classifyAgentSource } from "@/lib/agent-source.ts";
 
@@ -200,12 +202,10 @@ export function NewRunPage() {
 
 	return (
 		<div className="mx-auto max-w-3xl space-y-6">
-			<header>
-				<h1 className="text-2xl font-semibold tracking-tight">Dispatch run</h1>
-				<p className="text-sm text-(--color-muted-foreground)">
-					Spawn an agent against a project repo inside a fresh sandbox.
-				</p>
-			</header>
+			<PageHeader
+				title="Dispatch run"
+				description="Spawn an agent against a project repo inside a fresh sandbox."
+			/>
 
 			{noAgents ? (
 				<Card>
@@ -289,8 +289,11 @@ export function NewRunPage() {
 							</select>
 						</div>
 
-						<div className="space-y-1.5">
-							<Label htmlFor="ref">Branch / tag / SHA (optional)</Label>
+						<Field
+							label="Branch / tag / SHA (optional)"
+							htmlFor="ref"
+							description="Leave blank to use the project's default branch. Free text — no remote-branch lookup yet."
+						>
 							<Input
 								id="ref"
 								value={ref}
@@ -300,15 +303,29 @@ export function NewRunPage() {
 								spellCheck={false}
 								className="h-11 sm:h-9 text-base sm:text-sm"
 							/>
-							<p className="text-xs text-(--color-muted-foreground)">
-								Leave blank to use the project's default branch. Free text — no
-								remote-branch lookup yet.
-							</p>
-						</div>
+						</Field>
 
 						{hasPlot ? (
-							<div className="space-y-1.5">
-								<Label htmlFor="plotId">Plot ID (optional)</Label>
+							<Field
+								label="Plot ID (optional)"
+								htmlFor="plotId"
+								description={
+									<>
+										Bind this run to a Plot. The Plot's activity feed gets a{" "}
+										<code className="font-mono">run_dispatched</code> event; the
+										sandbox sees <code className="font-mono">PLOT_ID</code> /{" "}
+										<code className="font-mono">PLOT_ACTOR</code>.
+									</>
+								}
+								error={
+									plotIdMalformed ? (
+										<>
+											Plot ID must look like{" "}
+											<code className="font-mono">plot-xxxxxxxx</code>.
+										</>
+									) : null
+								}
+							>
 								<Input
 									id="plotId"
 									value={plotId}
@@ -318,18 +335,7 @@ export function NewRunPage() {
 									spellCheck={false}
 									className="h-11 sm:h-9 text-base sm:text-sm"
 								/>
-								<p className="text-xs text-(--color-muted-foreground)">
-									Bind this run to a Plot. The Plot's activity feed gets a{" "}
-									<code className="font-mono">run_dispatched</code> event; the
-									sandbox sees <code className="font-mono">PLOT_ID</code> /{" "}
-									<code className="font-mono">PLOT_ACTOR</code>.
-								</p>
-								{plotIdMalformed ? (
-									<p className="text-xs text-(--color-destructive)">
-										Plot ID must look like <code className="font-mono">plot-xxxxxxxx</code>.
-									</p>
-								) : null}
-							</div>
+							</Field>
 						) : null}
 
 						<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/src/ui/src/pages/PlanRuns.tsx
+++ b/src/ui/src/pages/PlanRuns.tsx
@@ -9,6 +9,7 @@ import { Alert } from "@/components/ui/alert.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { EmptyState } from "@/components/ui/empty-state.tsx";
+import { PageHeader } from "@/components/ui/page-header.tsx";
 import { Spinner } from "@/components/ui/spinner.tsx";
 import {
 	Table,
@@ -60,18 +61,15 @@ export function PlanRunsPage() {
 
 	return (
 		<div className="space-y-6">
-			<header className="flex flex-wrap items-center justify-between gap-4">
-				<div>
-					<h1 className="text-2xl font-semibold tracking-tight">Plan runs</h1>
-					<p className="text-sm text-(--color-muted-foreground)">
-						Serial execution of a seeds plan — one warren run per open child,
-						in order.
-					</p>
-				</div>
-				<Link to="/plan-runs/new">
-					<Button>Dispatch a plan run</Button>
-				</Link>
-			</header>
+			<PageHeader
+				title="Plan runs"
+				description="Serial execution of a seeds plan — one warren run per open child, in order."
+				actions={
+					<Link to="/plan-runs/new">
+						<Button>Dispatch a plan run</Button>
+					</Link>
+				}
+			/>
 
 			<div className="flex flex-wrap items-center gap-2">
 				{STATE_FILTERS.map((f) => (

--- a/src/ui/src/pages/Plots.tsx
+++ b/src/ui/src/pages/Plots.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/dialog.tsx";
 import { Input } from "@/components/ui/input.tsx";
 import { Label } from "@/components/ui/label.tsx";
+import { PageHeader } from "@/components/ui/page-header.tsx";
 import { Textarea } from "@/components/ui/textarea.tsx";
 import { relativeTime } from "@/lib/utils.ts";
 
@@ -118,27 +119,24 @@ export function PlotsPage() {
 
 	return (
 		<div className="space-y-6">
-			<header className="flex flex-wrap items-center justify-between gap-4">
-				<div>
-					<h1 className="text-2xl font-semibold tracking-tight">Plots</h1>
-					<p className="text-sm text-(--color-muted-foreground)">
-						Shared coordination substrate — humans and agents as peer nodes
-						on a per-Plot event log.
-					</p>
-				</div>
-				<div className="flex flex-wrap items-center gap-2">
-					<Button
-						variant="outline"
-						onClick={() => setBrainstormOpen(true)}
-						disabled={projects.isLoading}
-					>
-						Start brainstorming
-					</Button>
-					<Button onClick={() => setDialogOpen(true)} disabled={projects.isLoading}>
-						New Plot
-					</Button>
-				</div>
-			</header>
+			<PageHeader
+				title="Plots"
+				description="Shared coordination substrate — humans and agents as peer nodes on a per-Plot event log."
+				actions={
+					<>
+						<Button
+							variant="outline"
+							onClick={() => setBrainstormOpen(true)}
+							disabled={projects.isLoading}
+						>
+							Start brainstorming
+						</Button>
+						<Button onClick={() => setDialogOpen(true)} disabled={projects.isLoading}>
+							New Plot
+						</Button>
+					</>
+				}
+			/>
 
 			<div className="flex flex-wrap items-center gap-2">
 				{/* Needs-you chip is a parallel toggle, separated visually

--- a/src/ui/src/pages/ProjectDetail.tsx
+++ b/src/ui/src/pages/ProjectDetail.tsx
@@ -13,10 +13,16 @@ import type {
 import { Alert } from "@/components/ui/alert.tsx";
 import { Badge } from "@/components/ui/badge.tsx";
 import { Button } from "@/components/ui/button.tsx";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
+import {
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+	cardVariants,
+} from "@/components/ui/card.tsx";
 import { Spinner } from "@/components/ui/spinner.tsx";
 import { formatError } from "@/lib/format-error.ts";
-import { formatTimestamp } from "@/lib/utils.ts";
+import { cn, formatTimestamp } from "@/lib/utils.ts";
 
 export function ProjectDetailPage() {
 	const { id = "" } = useParams<{ id: string }>();
@@ -247,7 +253,12 @@ function TriggerRow({
 	runError: string | null;
 }) {
 	return (
-		<li className="rounded-md border bg-(--color-muted)/30 px-3 py-2 text-sm">
+		<li
+			className={cn(
+				cardVariants({ variant: "flat" }),
+				"bg-(--color-muted)/30 px-3 py-2 text-sm",
+			)}
+		>
 			<div className="flex flex-wrap items-center justify-between gap-2">
 				<div className="flex flex-wrap items-baseline gap-2">
 					<span className="font-mono font-semibold">{trigger.id}</span>

--- a/src/ui/src/pages/Projects.tsx
+++ b/src/ui/src/pages/Projects.tsx
@@ -9,6 +9,7 @@ import { Alert } from "@/components/ui/alert.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { EmptyState } from "@/components/ui/empty-state.tsx";
+import { PageHeader } from "@/components/ui/page-header.tsx";
 import { Spinner } from "@/components/ui/spinner.tsx";
 import {
 	Dialog,
@@ -58,12 +59,14 @@ export function ProjectsPage() {
 
 	return (
 		<div className="space-y-6">
-			<header>
-				<h1 className="text-2xl font-semibold tracking-tight">Projects</h1>
-				<p className="text-sm text-(--color-muted-foreground)">
-					GitHub repos cloned under <code>$WARREN_PROJECTS_DIR</code>.
-				</p>
-			</header>
+			<PageHeader
+				title="Projects"
+				description={
+					<>
+						GitHub repos cloned under <code>$WARREN_PROJECTS_DIR</code>.
+					</>
+				}
+			/>
 
 			<AddProjectForm
 				onSubmit={(input) => create.mutate(input)}

--- a/src/ui/src/pages/Runs.tsx
+++ b/src/ui/src/pages/Runs.tsx
@@ -8,7 +8,9 @@ import { Alert } from "@/components/ui/alert.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { EmptyState } from "@/components/ui/empty-state.tsx";
+import { FilterPill } from "@/components/ui/filter-pill.tsx";
 import { FadeInItem, StaggerList } from "@/components/ui/motion.tsx";
+import { PageHeader } from "@/components/ui/page-header.tsx";
 import { Spinner } from "@/components/ui/spinner.tsx";
 import {
 	Table,
@@ -136,17 +138,15 @@ export function RunsPage() {
 
 	return (
 		<div className="space-y-6">
-			<header className="flex flex-wrap items-center justify-between gap-4">
-				<div>
-					<h1 className="text-2xl font-semibold tracking-tight">Runs</h1>
-					<p className="text-sm text-(--color-muted-foreground)">
-						Agent runs dispatched into burrow sandboxes.
-					</p>
-				</div>
-				<Link to="/runs/new">
-					<Button>Dispatch a run</Button>
-				</Link>
-			</header>
+			<PageHeader
+				title="Runs"
+				description="Agent runs dispatched into burrow sandboxes."
+				actions={
+					<Link to="/runs/new">
+						<Button>Dispatch a run</Button>
+					</Link>
+				}
+			/>
 
 			<div className="flex flex-wrap items-center justify-between gap-3">
 				<div className="flex flex-wrap items-center gap-2">
@@ -361,30 +361,6 @@ function SortHeader({
 		>
 			{label}
 			{active ? <Icon className="h-3 w-3" /> : null}
-		</button>
-	);
-}
-
-function FilterPill({
-	active,
-	label,
-	onClick,
-}: {
-	active: boolean;
-	label: string;
-	onClick: () => void;
-}) {
-	return (
-		<button
-			type="button"
-			onClick={onClick}
-			className={`rounded-full border px-3 py-1 text-xs transition-colors ${
-				active
-					? "bg-(--color-primary) text-(--color-primary-foreground)"
-					: "bg-(--color-card) hover:bg-(--color-accent)"
-			}`}
-		>
-			{label}
 		</button>
 	);
 }


### PR DESCRIPTION
## Summary

ui: phase 6 layout promotions — PageHeader / Field / FilterPill primitives (warren-e6b3)

## Run

- **Warren run:** `run_nhj53fhx2qbh`
- **Agent:** pi
- **Cost:** $3.11 (71 in / 31.6k out / 3.6M cache-r)

## Seeds

- warren-e6b3 — Phase 6: Layout promotions — PageHeader, Field (label+control+error), FilterPill/Toggle group; sweep ad-hoc rounded-md border containers onto Card variants

## Commits (1)

- 449ded6 ui: phase 6 layout promotions — PageHeader / Field / FilterPill primitives (warren-e6b3)

## Files changed

```
scripts/coverage-budgets.json            |   4 +-
 src/ui/src/components/ui/card.tsx        |  23 +++++--
 src/ui/src/components/ui/field.tsx       | 107 +++++++++++++++++++++++++++++++
 src/ui/src/components/ui/filter-pill.tsx |  61 ++++++++++++++++++
 src/ui/src/components/ui/page-header.tsx |  64 ++++++++++++++++++
 src/ui/src/pages/Agents.tsx              |  20 +++---
 src/ui/src/pages/CostAnalytics.tsx       |  11 ++--
 src/ui/src/pages/NewPlanRun.tsx          |  12 ++--
 src/ui/src/pages/NewRun.tsx              |  60 +++++++++--------
 src/ui/src/pages/PlanRuns.tsx            |  22 +++----
 src/ui/src/pages/Plots.tsx               |  40 ++++++------
 src/ui/src/pages/ProjectDetail.tsx       |  17 ++++-
 src/ui/src/pages/Projects.tsx            |  15 +++--
 src/ui/src/pages/Runs.tsx                |  46 ++++---------
 14 files changed, 368 insertions(+), 134 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-e6b3. use ml. commit when done.
```

</details>

---

🤖 Opened by warren run `run_nhj53fhx2qbh`