### PR TITLE
harden against empty pushes: detect, surface, and reduce silent no-comm…

### DIFF
--- a/src/db/schema/columns.ts
+++ b/src/db/schema/columns.ts
@@ -67,6 +67,15 @@ export type RunMode = (typeof RUN_MODES)[number];
  *     wiped burrow's in-memory run state. The reconciler (bootBridges)
  *     and the bridge's mid-stream 404 catch both mark the warren row
  *     `failed` with this reason instead of looping forever.
+ *   - `dropped_commit` (warren-72b9) means reap's `git push` landed zero
+ *     commits ahead of the base branch (`reap.empty_push`) AND the
+ *     workspace tree was still dirty at reap — the agent edited/staged
+ *     work but never ran `git commit` (the common weak-model failure,
+ *     e.g. Gemini Flash narrating "before committing" then exiting).
+ *     Distinguished from a deliberate no-op (clean tree, zero commits)
+ *     which stays `succeeded`. Marking the run `failed` keeps a dropped
+ *     commit from masquerading as success and, on plan-runs, fails the
+ *     plan instead of silently auto-merging/advancing past the child.
  *
  * Null on succeeded/cancelled rows.
  */
@@ -76,6 +85,7 @@ export const RUN_FAILURE_REASONS = [
 	"crashed",
 	"timed_out",
 	"burrow_run_lost",
+	"dropped_commit",
 ] as const;
 export type RunFailureReason = (typeof RUN_FAILURE_REASONS)[number];
 

--- a/src/plan-runs/coordinator.completion.test.ts
+++ b/src/plan-runs/coordinator.completion.test.ts
@@ -160,6 +160,35 @@ describe("advancePlanRun — completion phase", () => {
 		expect(reloaded.state).toBe("failed");
 	});
 
+	test("dropped-commit child (failed/dropped_commit) fails the plan, not a trivial merge (warren-72b9)", async () => {
+		await h.repos.planRuns.transitionTo(h.planRun.id, "running", { startedAt: NOW.toISOString() });
+		const runId = await h.makeRun("warren-a");
+		await h.repos.runs.markRunning(runId, NOW);
+		// reap flips a zero-commit + dirty-tree run to failed/dropped_commit.
+		await h.repos.runs.finalize(runId, "failed", NOW, "dropped_commit");
+		await h.repos.planRuns.updateChild({
+			planRunId: h.planRun.id,
+			seq: 1,
+			patch: { runId, state: "running", startedAt: NOW.toISOString() },
+		});
+		const planRun = await h.repos.planRuns.require(h.planRun.id);
+		const result = await advancePlanRun({
+			planRun,
+			repos: h.repos,
+			showSeed: h.showSeedStub("open"),
+			checkPrMerged: neverPoll,
+			spawn: h.spawnStub(() => "unused"),
+			emit: h.emit,
+			now: () => NOW,
+		});
+		expect(result.kind).toBe("plan_failed");
+		if (result.kind === "plan_failed") {
+			expect(result.reason).toBe("child_dropped_commit");
+		}
+		const reloaded = await h.repos.planRuns.require(h.planRun.id);
+		expect(reloaded.state).toBe("failed");
+	});
+
 	test("trivial merge: succeeded run with no prUrl + reap.empty_push event", async () => {
 		await h.repos.planRuns.transitionTo(h.planRun.id, "running", { startedAt: NOW.toISOString() });
 		const runId = await h.makeRun("warren-a");

--- a/src/plan-runs/coordinator.ts
+++ b/src/plan-runs/coordinator.ts
@@ -20,7 +20,7 @@
  * Trivial-merge (mx-fd8619): when the child run terminal-succeeds with
  * `run.prUrl === null` AND reap emitted a `reap.empty_push` system event
  * (commitsAhead === 0), the coordinator advances directly to `merged`
- * without GitHub polling — there's nothing to merge.
+ * without GitHub polling. Dropped commits (warren-72b9) reap `failed` first.
  *
  * Events fire via `emit(runId, kind, payload)` on the most recently
  * dispatched child run; callers wire it to `repos.events.append`

--- a/src/registry/builtins/pi.ts
+++ b/src/registry/builtins/pi.ts
@@ -29,6 +29,7 @@ Operating contract:
 - Edit files in place. Run tests when relevant.
 - Quality gates are terminal, not advisory. You are NOT done until the gate exits zero. Resolve the command in this order: \`$WARREN_QUALITY_GATE\` if set, otherwise the command documented in CLAUDE.md / AGENTS.md, otherwise fall back to \`bun run check:all\` or \`npm run lint && npm run typecheck && npm test\`. Run it before committing and again before reporting completion. Do not declare the task complete, hand off, or end the session with a red gate — fix failures (including lint warnings, which CI treats as errors) until it is green. If the gate is genuinely unfixable in this run, say so explicitly and leave the work open rather than claiming success.
 - Use git as you normally would. Commit your changes; warren reaps the branch and pushes upstream.
+- Committing is mandatory, not the same as staging. \`git add\` ALONE IS NOT ENOUGH — you must run \`git commit\` so the work lands as a real commit. A run that ends with staged-but-uncommitted changes is treated as a FAILURE (\`dropped_commit\`), not a success. Before you report completion, run \`git status\`/\`git log\` and confirm your changes are in a commit, not just staged. The only exception is when you have genuinely made no file changes at all.
 - Do not run \`git push\` yourself — warren handles the push host-side after the run terminates.
 `;
 

--- a/src/runs/reap/run.test.ts
+++ b/src/runs/reap/run.test.ts
@@ -82,15 +82,62 @@ describe("reapRun", () => {
 
 		expect(result.branchPushed).toBe(true);
 		expect(result.commitsAhead).toBe(0);
+		// Clean tree (default fakeExec gitStatus="") => deliberate no-op, the
+		// run still succeeds (warren-72b9).
+		expect(result.state).toBe("succeeded");
+		expect(result.failureReason).toBeNull();
 		const events = await ctx.repos.events.listByRun(ctx.runId);
 		const empty = events.find((ev) => ev.kind === "reap.empty_push");
 		expect(empty).toBeDefined();
 		expect(empty?.payloadJson).toMatchObject({
 			branch: "agent/refactor-bot/run-1",
 			baseBranch: "main",
+			dirty: false,
+			droppedCommit: false,
 		});
 		const completed = events.find((ev) => ev.kind === "reap.completed");
 		expect(completed?.payloadJson).toMatchObject({ branchPushed: true, commitsAhead: 0 });
+	});
+
+	test("flags a dropped commit (zero commits + dirty tree) and fails the run (warren-72b9)", async () => {
+		const e = fakeExec({ revListCount: "0", gitStatus: " M src/foo.ts\n?? new.ts\n" });
+
+		const result = await reapRun({
+			runId: ctx.runId,
+			outcome: "succeeded",
+			repos: ctx.repos,
+			burrowClientPool: await makePool(fakeBurrowClient(makeBurrow()), ctx.repos),
+			broker: ctx.broker,
+			fs: fakeFs().fs,
+			exec: e.exec,
+		});
+
+		expect(result.commitsAhead).toBe(0);
+		expect(result.state).toBe("failed");
+		expect(result.failureReason).toBe("dropped_commit");
+		const events = await ctx.repos.events.listByRun(ctx.runId);
+		const empty = events.find((ev) => ev.kind === "reap.empty_push");
+		expect(empty?.payloadJson).toMatchObject({ dirty: true, droppedCommit: true });
+		const run = await ctx.repos.runs.require(ctx.runId);
+		expect(run.state).toBe("failed");
+		expect(run.failureReason).toBe("dropped_commit");
+	});
+
+	test("git status probe failure degrades a zero-commit push to a no-op success (warren-72b9)", async () => {
+		const e = fakeExec({ revListCount: "0", failGitStatus: "fatal: not a git repo" });
+
+		const result = await reapRun({
+			runId: ctx.runId,
+			outcome: "succeeded",
+			repos: ctx.repos,
+			burrowClientPool: await makePool(fakeBurrowClient(makeBurrow()), ctx.repos),
+			fs: fakeFs().fs,
+			exec: e.exec,
+		});
+
+		expect(result.commitsAhead).toBe(0);
+		expect(result.state).toBe("succeeded");
+		expect(result.failureReason).toBeNull();
 	});
 
 	test("does not emit reap.empty_push when push lands real commits", async () => {

--- a/src/runs/reap/run.ts
+++ b/src/runs/reap/run.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import type { BurrowClient } from "../../burrow-client/client.ts";
 import { withTransportMapping } from "../../burrow-client/client.ts";
-import type { EventRow, RunFailureReason } from "../../db/schema.ts";
+import type { EventRow, RunFailureReason, RunTerminalState } from "../../db/schema.ts";
 import { openPullRequest } from "../pr.ts";
 import { dispatchAutoPlanRuns, hasAutoPlanRunFrontmatter, parsePlanIds } from "./auto-plan-run.ts";
 import { runWorkspaceDestroy } from "./destroy.ts";
@@ -13,7 +13,13 @@ import { mirrorPlans, mirrorSeeds } from "./seeds.ts";
 import { stagePlotForCommit, stageSeedsForCommit } from "./stage.ts";
 import { inferFailureReason, isTerminal, transitionToTerminal } from "./state.ts";
 import type { ReapRunInput, ReapRunResult, ReapStep, ReapStepError } from "./types.ts";
-import { buildAlreadyTerminalResult, createSeqAllocator, defaultExec, defaultFs } from "./util.ts";
+import {
+	buildAlreadyTerminalResult,
+	createSeqAllocator,
+	defaultExec,
+	defaultFs,
+	isWorkspaceDirty,
+} from "./util.ts";
 
 export async function reapRun(input: ReapRunInput): Promise<ReapRunResult> {
 	const fs = input.fs ?? defaultFs;
@@ -77,6 +83,7 @@ export async function reapRun(input: ReapRunInput): Promise<ReapRunResult> {
 	let seedsCommitted = false;
 	let branchPushed = false;
 	let commitsAhead: number | null = null;
+	let droppedCommit = false;
 	let prUrl: string | null = null;
 	let previewLaunchState: "live" | "failed" | null = null;
 	let previewLaunchPort: number | null = null;
@@ -260,12 +267,10 @@ export async function reapRun(input: ReapRunInput): Promise<ReapRunResult> {
 		}
 
 		// Empty-push observability (warren-f3bb): branchPushed alone can't
-		// tell apart a real-work push from a no-op against an unchanged
-		// HEAD (the agent never `git commit`-ed). Count commits ahead of
-		// the project's defaultBranch; surface zero as `reap.empty_push`
-		// and pin the count on `commitsAhead`. rev-list failures are
-		// non-fatal — a missing base ref or transient git error degrades
-		// to `commitsAhead: null` rather than failing the reap step.
+		// tell a real-work push from a no-op against an unchanged HEAD.
+		// Count commits ahead of the project's defaultBranch; surface zero
+		// as `reap.empty_push` and pin the count on `commitsAhead`. rev-list
+		// failures are non-fatal — they degrade to `commitsAhead: null`.
 		if (branchPushed && baseBranch !== null) {
 			try {
 				const out = await exec.run("git", ["rev-list", "--count", `${baseBranch}..HEAD`], {
@@ -281,11 +286,17 @@ export async function reapRun(input: ReapRunInput): Promise<ReapRunResult> {
 				);
 			}
 			if (commitsAhead === 0) {
+				// warren-72b9: dirty tree + zero commits = staged-but-uncommitted.
+				const dirty = await isWorkspaceDirty(exec, workspacePath);
+				droppedCommit = dirty && input.outcome === "succeeded";
 				await emit("reap.empty_push", {
 					branch,
 					baseBranch,
-					message:
-						"git push exited zero but the branch landed no new commits — agent did not commit",
+					dirty,
+					droppedCommit,
+					message: dirty
+						? "git push exited zero and the workspace still has uncommitted changes — agent staged work but never committed"
+						: "git push exited zero but the branch landed no new commits — agent did not commit",
 				});
 			}
 		}
@@ -318,9 +329,11 @@ export async function reapRun(input: ReapRunInput): Promise<ReapRunResult> {
 		}
 
 		// Preview launch (warren-f156 / SPEC §11.L). See runPreviewLaunch +
-		// runPreviewAnnotate for the gate semantics.
+		// runPreviewAnnotate for the gate semantics. Skipped on a dropped
+		// commit (warren-72b9).
 		if (
 			input.outcome === "succeeded" &&
+			!droppedCommit &&
 			input.previewConfig !== undefined &&
 			input.portAllocator !== undefined &&
 			workerClient !== null &&
@@ -371,16 +384,23 @@ export async function reapRun(input: ReapRunInput): Promise<ReapRunResult> {
 		});
 	}
 
-	const failureReason: RunFailureReason | null =
-		input.outcome === "failed"
-			? (input.failureReason ?? (await inferFailureReason(input.repos, run.id, stateOnEntry)))
-			: null;
+	// warren-72b9: `droppedCommit` flips an otherwise-succeeded run to
+	// `failed`/`dropped_commit` so it can't masquerade as success.
+	const effectiveOutcome: RunTerminalState = droppedCommit ? "failed" : input.outcome;
+
+	let failureReason: RunFailureReason | null = null;
+	if (droppedCommit) {
+		failureReason = "dropped_commit";
+	} else if (effectiveOutcome === "failed") {
+		failureReason =
+			input.failureReason ?? (await inferFailureReason(input.repos, run.id, stateOnEntry));
+	}
 
 	const finalState = await transitionToTerminal(
 		input.repos,
 		run.id,
 		stateOnEntry,
-		input.outcome,
+		effectiveOutcome,
 		now(),
 		failureReason,
 	);

--- a/src/runs/reap/test-helpers.ts
+++ b/src/runs/reap/test-helpers.ts
@@ -115,6 +115,37 @@ export interface FakeExecOpts {
 	 * has-staged-delta branch under stagePlotForCommit.
 	 */
 	stagedDelta?: boolean;
+	/**
+	 * Stdout for `git status --porcelain` (warren-72b9 dropped-commit
+	 * probe). Default `""` (clean tree = deliberate no-op). Set to a
+	 * non-empty string (e.g. `" M src/foo.ts"`) to simulate uncommitted
+	 * changes left behind by an agent that never ran `git commit`.
+	 */
+	gitStatus?: string;
+	/** Throw on `git status --porcelain` calls (default: succeed). */
+	failGitStatus?: string;
+}
+
+/** Match a `git <sub> …` invocation for the fakeExec command router. */
+function isGitSub(cmd: string, args: readonly string[], sub: string): boolean {
+	return cmd === "git" && args[0] === sub;
+}
+
+type ExecResult = { stdout: string; stderr: string };
+
+function handleRevList(failRevList: string | null, revListCount: string): ExecResult {
+	if (failRevList !== null) throw new Error(failRevList);
+	return { stdout: `${revListCount}\n`, stderr: "" };
+}
+
+function handleStatus(failGitStatus: string | null, gitStatus: string): ExecResult {
+	if (failGitStatus !== null) throw new Error(failGitStatus);
+	return { stdout: gitStatus, stderr: "" };
+}
+
+function handleDiffCached(stagedDelta: boolean): ExecResult {
+	if (stagedDelta) throw new Error("staged changes present");
+	return { stdout: "", stderr: "" };
 }
 
 export function fakeExec(opts: FakeExecOpts = {}): FakeExec {
@@ -123,22 +154,17 @@ export function fakeExec(opts: FakeExecOpts = {}): FakeExec {
 	const failRevList = opts.failRevList ?? null;
 	const revListCount = opts.revListCount ?? "1";
 	const stagedDelta = opts.stagedDelta === true;
+	const gitStatus = opts.gitStatus ?? "";
+	const failGitStatus = opts.failGitStatus ?? null;
 	const exec: ReapExec = {
 		run: async (cmd, args, opt) => {
 			calls.push({ cmd, args, cwd: opt.cwd });
-			const isRevList = cmd === "git" && args[0] === "rev-list";
-			if (isRevList) {
-				if (failRevList !== null) throw new Error(failRevList);
-				return { stdout: `${revListCount}\n`, stderr: "" };
+			if (isGitSub(cmd, args, "rev-list")) return handleRevList(failRevList, revListCount);
+			if (isGitSub(cmd, args, "status") && args.includes("--porcelain")) {
+				return handleStatus(failGitStatus, gitStatus);
 			}
-			const isDiffCached =
-				cmd === "git" &&
-				args[0] === "diff" &&
-				args.includes("--cached") &&
-				args.includes("--quiet");
-			if (isDiffCached) {
-				if (stagedDelta) throw new Error("staged changes present");
-				return { stdout: "", stderr: "" };
+			if (isGitSub(cmd, args, "diff") && args.includes("--cached") && args.includes("--quiet")) {
+				return handleDiffCached(stagedDelta);
 			}
 			if (fail !== null) throw new Error(fail.reason);
 			return { stdout: "", stderr: "" };

--- a/src/runs/reap/util.ts
+++ b/src/runs/reap/util.ts
@@ -92,6 +92,26 @@ export const defaultFs: ReapFs = {
 	},
 };
 
+/**
+ * Probe whether the workspace tree has uncommitted changes (warren-72b9).
+ * Used by the empty-push path to tell a dropped commit (dirty tree + zero
+ * commits ahead = agent staged work but never `git commit`-ed) apart from
+ * a deliberate no-op (clean tree). `git status --porcelain` failures
+ * resolve to `false` so a probe error degrades to the no-op shape rather
+ * than crying wolf.
+ */
+export async function isWorkspaceDirty(exec: ReapExec, workspacePath: string): Promise<boolean> {
+	try {
+		const status = await exec.run("git", ["status", "--porcelain"], {
+			cwd: workspacePath,
+			timeoutMs: 10_000,
+		});
+		return status.stdout.trim() !== "";
+	} catch {
+		return false;
+	}
+}
+
 export const defaultExec: ReapExec = {
 	run: async (cmd, args, opts) => {
 		const execOpts: { cwd: string; timeout?: number } = { cwd: opts.cwd };

--- a/src/ui/src/api/types.ts
+++ b/src/ui/src/api/types.ts
@@ -14,7 +14,8 @@ export type RunFailureReason =
 	| "no_model_response"
 	| "crashed"
 	| "timed_out"
-	| "burrow_run_lost";
+	| "burrow_run_lost"
+	| "dropped_commit";
 
 /**
  * Preview environment lifecycle (R-19 / SPEC §11.L). Null on rows whose


### PR DESCRIPTION
## Summary

harden against empty pushes: fail dropped commits (warren-72b9)

## Run

- **Warren run:** `run_7x8ezh6sbwsk`
- **Agent:** pi
- **Cost:** $4.59 (200 in / 38.6k out / 5.9M cache-r)

## Seeds

- warren-72b9 — harden against empty pushes: detect, surface, and reduce silent no-commit runs

## Commits (1)

- 038fb17 harden against empty pushes: fail dropped commits (warren-72b9)

## Files changed

```
src/db/schema/columns.ts                     | 10 ++++++
 src/plan-runs/coordinator.completion.test.ts | 29 ++++++++++++++++
 src/plan-runs/coordinator.ts                 |  2 +-
 src/registry/builtins/pi.ts                  |  1 +
 src/runs/reap/run.test.ts                    | 47 +++++++++++++++++++++++++
 src/runs/reap/run.ts                         | 52 +++++++++++++++++++---------
 src/runs/reap/test-helpers.ts                | 50 +++++++++++++++++++-------
 src/runs/reap/util.ts                        | 20 +++++++++++
 src/ui/src/api/types.ts                      |  3 +-
 9 files changed, 184 insertions(+), 30 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-72b9. use ml. commit when done.
```

</details>

---

🤖 Opened by warren run `run_7x8ezh6sbwsk`