### PR TITLE
Re-prompt / re-trigger a terminated run — continue the same conversatio…

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -191,10 +191,7 @@ export class WarrenClient {
 		});
 	}
 
-	/**
-	 * POST /runs with the ergonomic `warren run` field names
-	 * (`branch`, `model`, `provider`). Thin wrapper over {@link createRun}.
-	 */
+	/** POST /runs with ergonomic `warren run` field names. Wraps {@link createRun}. */
 	async dispatch(input: DispatchRunInput): Promise<SpawnRunResponse> {
 		const body: CreateRunInput = {
 			agent: input.agent,
@@ -209,6 +206,7 @@ export class WarrenClient {
 		if (input.mode !== undefined) body.mode = input.mode;
 		if (input.interactiveAgent !== undefined) body.interactiveAgent = input.interactiveAgent;
 		if (input.dispatcherHandle !== undefined) body.dispatcherHandle = input.dispatcherHandle;
+		if (input.continueFromRunId !== undefined) body.continueFromRunId = input.continueFromRunId;
 		return this.createRun(body);
 	}
 

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -94,6 +94,8 @@ export interface RunRow {
 	burrowRunId: string | null;
 	seedId: string | null;
 	plotId: string | null;
+	/** Continuation back-link (warren-4b11); null for root runs. */
+	parentRunId: string | null;
 	mode: "batch" | "interactive";
 	renderedAgentJson: unknown;
 	state: RunState;
@@ -155,6 +157,8 @@ export interface CreateRunInput {
 	mode?: "batch" | "interactive";
 	interactiveAgent?: string;
 	dispatcherHandle?: string;
+	/** Continuation parent (warren-4b11): seed the workspace from this run's branch. */
+	continueFromRunId?: string;
 }
 
 /**
@@ -178,6 +182,8 @@ export interface DispatchRunInput {
 	mode?: "batch" | "interactive";
 	interactiveAgent?: string;
 	dispatcherHandle?: string;
+	/** Maps to CreateRunInput.continueFromRunId (warren-4b11). */
+	continueFromRunId?: string;
 }
 
 export interface SpawnRunResponse {

--- a/src/db/migrations/0019_whole_gunslinger.sql
+++ b/src/db/migrations/0019_whole_gunslinger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `parent_run_id` text;

--- a/src/db/migrations/meta/0019_snapshot.json
+++ b/src/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,963 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "f3fe1381-06fe-4604-8829-3407d4e8ffbd",
+	"prevId": "12ee5bd2-e302-4dad-8be2-7a96fefd6eda",
+	"tables": {
+		"agents": {
+			"name": "agents",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rendered_json": {
+					"name": "rendered_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"registered_at": {
+					"name": "registered_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_refreshed": {
+					"name": "last_refreshed",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"agents_project_name_idx": {
+					"name": "agents_project_name_idx",
+					"columns": ["project_id", "name"],
+					"isUnique": true
+				},
+				"agents_global_name_idx": {
+					"name": "agents_global_name_idx",
+					"columns": ["name"],
+					"isUnique": true,
+					"where": "\"agents\".\"project_id\" IS NULL"
+				}
+			},
+			"foreignKeys": {
+				"agents_project_id_projects_id_fk": {
+					"name": "agents_project_id_projects_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"burrows": {
+			"name": "burrows",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"burrows_worker_idx": {
+					"name": "burrows_worker_idx",
+					"columns": ["worker_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"events": {
+			"name": "events",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"burrow_event_seq": {
+					"name": "burrow_event_seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ts": {
+					"name": "ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"stream": {
+					"name": "stream",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"payload_json": {
+					"name": "payload_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"events_run_seq_idx": {
+					"name": "events_run_seq_idx",
+					"columns": ["run_id", "burrow_event_seq"],
+					"isUnique": false
+				},
+				"events_run_ts_idx": {
+					"name": "events_run_ts_idx",
+					"columns": ["run_id", "ts"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"events_run_id_runs_id_fk": {
+					"name": "events_run_id_runs_id_fk",
+					"tableFrom": "events",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"plan_run_children": {
+			"name": "plan_run_children",
+			"columns": {
+				"plan_run_id": {
+					"name": "plan_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_merged_at": {
+					"name": "pr_merged_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"plan_run_children_run_idx": {
+					"name": "plan_run_children_run_idx",
+					"columns": ["run_id"],
+					"isUnique": false
+				},
+				"plan_run_children_state_idx": {
+					"name": "plan_run_children_state_idx",
+					"columns": ["plan_run_id", "state"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"plan_run_children_plan_run_id_plan_runs_id_fk": {
+					"name": "plan_run_children_plan_run_id_plan_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "plan_runs",
+					"columnsFrom": ["plan_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"plan_run_children_run_id_runs_id_fk": {
+					"name": "plan_run_children_run_id_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"plan_run_children_plan_run_id_seq_pk": {
+					"columns": ["plan_run_id", "seq"],
+					"name": "plan_run_children_plan_run_id_seq_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"plan_runs": {
+			"name": "plan_runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"plan_id": {
+					"name": "plan_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"prompt_template": {
+					"name": "prompt_template",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'work on sd {seed_id}'"
+				},
+				"ref": {
+					"name": "ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_override": {
+					"name": "provider_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"model_override": {
+					"name": "model_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dispatcher_handle": {
+					"name": "dispatcher_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'operator'"
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'manual'"
+				},
+				"plot_id": {
+					"name": "plot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"plan_runs_project_state_idx": {
+					"name": "plan_runs_project_state_idx",
+					"columns": ["project_id", "state"],
+					"isUnique": false
+				},
+				"plan_runs_state_idx": {
+					"name": "plan_runs_state_idx",
+					"columns": ["state"],
+					"isUnique": false
+				},
+				"plan_runs_plot_id_idx": {
+					"name": "plan_runs_plot_id_idx",
+					"columns": ["plot_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"plan_runs_project_id_projects_id_fk": {
+					"name": "plan_runs_project_id_projects_id_fk",
+					"tableFrom": "plan_runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"projects": {
+			"name": "projects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"git_url": {
+					"name": "git_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"local_path": {
+					"name": "local_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"default_branch": {
+					"name": "default_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_fetched_at": {
+					"name": "last_fetched_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_head_sha": {
+					"name": "last_head_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"has_plot": {
+					"name": "has_plot",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"has_seeds": {
+					"name": "has_seeds",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"projects_git_url_idx": {
+					"name": "projects_git_url_idx",
+					"columns": ["git_url"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"runs": {
+			"name": "runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"burrow_id": {
+					"name": "burrow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"burrow_run_id": {
+					"name": "burrow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"plot_id": {
+					"name": "plot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"rendered_agent_json": {
+					"name": "rendered_agent_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"prompt": {
+					"name": "prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"pr_url": {
+					"name": "pr_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cost_usd": {
+					"name": "cost_usd",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_input": {
+					"name": "tokens_input",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_output": {
+					"name": "tokens_output",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_cache_read": {
+					"name": "tokens_cache_read",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_cache_write": {
+					"name": "tokens_cache_write",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_state": {
+					"name": "preview_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_port": {
+					"name": "preview_port",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_started_at": {
+					"name": "preview_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_last_hit_at": {
+					"name": "preview_last_hit_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_failure_message": {
+					"name": "preview_failure_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'batch'"
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"paused_question_event_id": {
+					"name": "paused_question_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"runs_state_idx": {
+					"name": "runs_state_idx",
+					"columns": ["state"],
+					"isUnique": false
+				},
+				"runs_project_started_idx": {
+					"name": "runs_project_started_idx",
+					"columns": ["project_id", "\"started_at\" DESC"],
+					"isUnique": false
+				},
+				"runs_agent_started_idx": {
+					"name": "runs_agent_started_idx",
+					"columns": ["agent_name", "\"started_at\" DESC"],
+					"isUnique": false
+				},
+				"runs_worker_state_idx": {
+					"name": "runs_worker_state_idx",
+					"columns": ["worker_id", "state"],
+					"isUnique": false
+				},
+				"runs_plot_id_idx": {
+					"name": "runs_plot_id_idx",
+					"columns": ["plot_id"],
+					"isUnique": false
+				},
+				"runs_mode_idx": {
+					"name": "runs_mode_idx",
+					"columns": ["mode"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"runs_project_id_projects_id_fk": {
+					"name": "runs_project_id_projects_id_fk",
+					"tableFrom": "runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"triggers": {
+			"name": "triggers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"trigger_id": {
+					"name": "trigger_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_fired_at": {
+					"name": "last_fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"next_fire_at": {
+					"name": "next_fire_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_run_id": {
+					"name": "last_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"triggers_project_idx": {
+					"name": "triggers_project_idx",
+					"columns": ["project_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"triggers_project_id_projects_id_fk": {
+					"name": "triggers_project_id_projects_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"triggers_last_run_id_runs_id_fk": {
+					"name": "triggers_last_run_id_runs_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "runs",
+					"columnsFrom": ["last_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"workers": {
+			"name": "workers",
+			"columns": {
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'healthy'"
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {
+			"runs_project_started_idx": {
+				"columns": {
+					"\"started_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"runs_agent_started_idx": {
+				"columns": {
+					"\"started_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
 			"when": 1779773494825,
 			"tag": "0018_add_plan_run_parent_run_id",
 			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "6",
+			"when": 1780018236829,
+			"tag": "0019_whole_gunslinger",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/migrations/postgres/0012_silent_silverclaw.sql
+++ b/src/db/migrations/postgres/0012_silent_silverclaw.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runs" ADD COLUMN "parent_run_id" text;

--- a/src/db/migrations/postgres/meta/0012_snapshot.json
+++ b/src/db/migrations/postgres/meta/0012_snapshot.json
@@ -1,0 +1,1111 @@
+{
+	"id": "430b9638-7e09-492d-96a4-0fa1cd116ef0",
+	"prevId": "adcb73b2-1b99-49a9-b955-d774f2c979ce",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.agents": {
+			"name": "agents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rendered_json": {
+					"name": "rendered_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"registered_at": {
+					"name": "registered_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_refreshed": {
+					"name": "last_refreshed",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"agents_project_name_idx": {
+					"name": "agents_project_name_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"agents_global_name_idx": {
+					"name": "agents_global_name_idx",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"agents\".\"project_id\" IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"agents_project_id_projects_id_fk": {
+					"name": "agents_project_id_projects_id_fk",
+					"tableFrom": "agents",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.burrows": {
+			"name": "burrows",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"burrows_worker_idx": {
+					"name": "burrows_worker_idx",
+					"columns": [
+						{
+							"expression": "worker_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"burrow_event_seq": {
+					"name": "burrow_event_seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ts": {
+					"name": "ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stream": {
+					"name": "stream",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"payload_json": {
+					"name": "payload_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"events_run_seq_idx": {
+					"name": "events_run_seq_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "burrow_event_seq",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"events_run_ts_idx": {
+					"name": "events_run_ts_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "ts",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"events_run_id_runs_id_fk": {
+					"name": "events_run_id_runs_id_fk",
+					"tableFrom": "events",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.plan_run_children": {
+			"name": "plan_run_children",
+			"schema": "",
+			"columns": {
+				"plan_run_id": {
+					"name": "plan_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pr_merged_at": {
+					"name": "pr_merged_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"plan_run_children_run_idx": {
+					"name": "plan_run_children_run_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"plan_run_children_state_idx": {
+					"name": "plan_run_children_state_idx",
+					"columns": [
+						{
+							"expression": "plan_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"plan_run_children_plan_run_id_plan_runs_id_fk": {
+					"name": "plan_run_children_plan_run_id_plan_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "plan_runs",
+					"columnsFrom": ["plan_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"plan_run_children_run_id_runs_id_fk": {
+					"name": "plan_run_children_run_id_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"plan_run_children_plan_run_id_seq_pk": {
+					"name": "plan_run_children_plan_run_id_seq_pk",
+					"columns": ["plan_run_id", "seq"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.plan_runs": {
+			"name": "plan_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"plan_id": {
+					"name": "plan_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"prompt_template": {
+					"name": "prompt_template",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'work on sd {seed_id}'"
+				},
+				"ref": {
+					"name": "ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_override": {
+					"name": "provider_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"model_override": {
+					"name": "model_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatcher_handle": {
+					"name": "dispatcher_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'operator'"
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'manual'"
+				},
+				"plot_id": {
+					"name": "plot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"plan_runs_project_state_idx": {
+					"name": "plan_runs_project_state_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"plan_runs_state_idx": {
+					"name": "plan_runs_state_idx",
+					"columns": [
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"plan_runs_plot_id_idx": {
+					"name": "plan_runs_plot_id_idx",
+					"columns": [
+						{
+							"expression": "plot_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"plan_runs_project_id_projects_id_fk": {
+					"name": "plan_runs_project_id_projects_id_fk",
+					"tableFrom": "plan_runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"git_url": {
+					"name": "git_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"local_path": {
+					"name": "local_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"default_branch": {
+					"name": "default_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_fetched_at": {
+					"name": "last_fetched_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_head_sha": {
+					"name": "last_head_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_plot": {
+					"name": "has_plot",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"has_seeds": {
+					"name": "has_seeds",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {
+				"projects_git_url_idx": {
+					"name": "projects_git_url_idx",
+					"columns": [
+						{
+							"expression": "git_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.runs": {
+			"name": "runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"burrow_id": {
+					"name": "burrow_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"burrow_run_id": {
+					"name": "burrow_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"plot_id": {
+					"name": "plot_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rendered_agent_json": {
+					"name": "rendered_agent_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prompt": {
+					"name": "prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pr_url": {
+					"name": "pr_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cost_usd": {
+					"name": "cost_usd",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_input": {
+					"name": "tokens_input",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_output": {
+					"name": "tokens_output",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_cache_read": {
+					"name": "tokens_cache_read",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_cache_write": {
+					"name": "tokens_cache_write",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_state": {
+					"name": "preview_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_port": {
+					"name": "preview_port",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_started_at": {
+					"name": "preview_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_last_hit_at": {
+					"name": "preview_last_hit_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_failure_message": {
+					"name": "preview_failure_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'batch'"
+				},
+				"paused_at": {
+					"name": "paused_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"paused_question_event_id": {
+					"name": "paused_question_event_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"runs_state_idx": {
+					"name": "runs_state_idx",
+					"columns": [
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_project_started_idx": {
+					"name": "runs_project_started_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"started_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_agent_started_idx": {
+					"name": "runs_agent_started_idx",
+					"columns": [
+						{
+							"expression": "agent_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"started_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_worker_state_idx": {
+					"name": "runs_worker_state_idx",
+					"columns": [
+						{
+							"expression": "worker_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_plot_id_idx": {
+					"name": "runs_plot_id_idx",
+					"columns": [
+						{
+							"expression": "plot_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_mode_idx": {
+					"name": "runs_mode_idx",
+					"columns": [
+						{
+							"expression": "mode",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"runs_project_id_projects_id_fk": {
+					"name": "runs_project_id_projects_id_fk",
+					"tableFrom": "runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.triggers": {
+			"name": "triggers",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"trigger_id": {
+					"name": "trigger_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_fired_at": {
+					"name": "last_fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_fire_at": {
+					"name": "next_fire_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_run_id": {
+					"name": "last_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"triggers_project_idx": {
+					"name": "triggers_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"triggers_project_id_projects_id_fk": {
+					"name": "triggers_project_id_projects_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"triggers_last_run_id_runs_id_fk": {
+					"name": "triggers_last_run_id_runs_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "runs",
+					"columnsFrom": ["last_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.workers": {
+			"name": "workers",
+			"schema": "",
+			"columns": {
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"url": {
+					"name": "url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'healthy'"
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/src/db/migrations/postgres/meta/_journal.json
+++ b/src/db/migrations/postgres/meta/_journal.json
@@ -85,6 +85,13 @@
 			"when": 1779773497017,
 			"tag": "0011_add_plan_run_parent_run_id",
 			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1780018237599,
+			"tag": "0012_silent_silverclaw",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/repos/runs.ts
+++ b/src/db/repos/runs.ts
@@ -54,36 +54,35 @@ export interface CreateRunInput {
 	burrowId?: string | null;
 	burrowRunId?: string | null;
 	/**
-	 * Worker that will host the burrow for this run (warren-135b). The
-	 * spawn flow (pl-9ba1 step 4) resolves this via `placeFor` before
-	 * provisioning and writes the denormalized id here so streaming /
-	 * cancel / steer paths can route without joining `burrows`. Null on
-	 * rows written before pl-9ba1 step 4 wired this in.
+	 * Worker that will host the burrow for this run (warren-135b). Resolved
+	 * by the spawn flow's `placeFor` (pl-9ba1 step 4) and denormalized here
+	 * so streaming / cancel / steer route without joining `burrows`.
 	 */
 	workerId?: string | null;
 	/**
-	 * Back-link to the seeds issue this run was dispatched against
-	 * (pl-bb70 step 3). Optional; null encodes "no seed" (manual prompt,
-	 * legacy row). Persisted so the post-dispatch `updateExtensions`
-	 * write (pl-bb70 step 4) has the seed to merge {role, trigger,
-	 * lastRunId, lastRunAt} into and so the Run API can surface a
-	 * back-link on RunDetail (pl-bb70 step 6).
+	 * Back-link to the seeds issue this run was dispatched against (pl-bb70
+	 * step 3). Null encodes "no seed". Persisted so the post-dispatch
+	 * `updateExtensions` write (step 4) has a seed to merge into and the Run
+	 * API can surface a back-link on RunDetail (step 6).
 	 */
 	seedId?: string | null;
 	/**
-	 * Back-link to the Plot this run was dispatched against (warren-a8c3,
-	 * parent warren-000b). Null/undefined when the project hasn't opted
-	 * into Plots or the dispatch omitted plot_id. Validation that the
-	 * project actually has a `.plot/` directory happens at handler level
-	 * via `project.hasPlot` — the repo writes whatever it's handed.
-	 */
-	/**
 	 * Run mode (pl-0344 step 1 / warren-67b6). `batch` (default) is the
 	 * historical single-shot run; `interactive` is the respawn-per-turn
-	 * primitive (pl-0344 step 3 / warren-1117). Fixed at run-create time.
+	 * primitive (warren-1117). Fixed at run-create time.
 	 */
 	mode?: RunMode;
+	/**
+	 * Back-link to the Plot this run was dispatched against (warren-a8c3).
+	 * Null when the project hasn't opted into Plots or plot_id was omitted;
+	 * `project.hasPlot` is validated at the handler.
+	 */
 	plotId?: string | null;
+	/**
+	 * Continuation back-link (warren-4b11): the prior run whose pushed branch
+	 * seeded this run's workspace. Null for root runs; plain text id, no FK.
+	 */
+	parentRunId?: string | null;
 	now?: Date;
 }
 
@@ -130,6 +129,7 @@ export class RunsRepo {
 			workerId: input.workerId ?? null,
 			seedId: input.seedId ?? null,
 			plotId: input.plotId ?? null,
+			parentRunId: input.parentRunId ?? null,
 			renderedAgentJson: input.renderedAgentJson,
 			state: "queued",
 			failureReason: null,

--- a/src/db/schema/postgres.ts
+++ b/src/db/schema/postgres.ts
@@ -123,6 +123,9 @@ export const runs = pgTable(
 		mode: text("mode", { enum: RUN_MODES }).notNull().default("batch"),
 		pausedAt: text("paused_at"),
 		pausedQuestionEventId: text("paused_question_event_id"),
+		// Mirror of sqlite parent_run_id (warren-4b11). Continuation back-link
+		// for re-run-with-follow-up; see sqlite.ts for the full shape + intent.
+		parentRunId: text("parent_run_id"),
 	},
 	(t) => [
 		index(INDEX_NAMES.runsState).on(t.state),

--- a/src/db/schema/sqlite.ts
+++ b/src/db/schema/sqlite.ts
@@ -205,6 +205,17 @@ export const runs = sqliteTable(
 		// supervisor clears them once the answering turn is dispatched.
 		pausedAt: text("paused_at"),
 		pausedQuestionEventId: text("paused_question_event_id"),
+		// Continuation back-link (warren-4b11): when an operator re-runs a
+		// terminated run "with a follow-up", the new run is spawned with the
+		// prior run's pushed branch as the workspace base (instead of the
+		// project default branch). This column records which run this one
+		// continues from, so the UI can render a chain indicator and chain
+		// cost/token totals are derivable by walking the link. Cost/tokens on
+		// each run stay independent — they are NOT accumulated with the
+		// parent. Nullable: the overwhelming majority of runs are roots.
+		// Plain text (no FK) for symmetry with the other run back-links and to
+		// keep the column tolerant of a since-deleted parent row.
+		parentRunId: text("parent_run_id"),
 	},
 	(t) => [
 		index(INDEX_NAMES.runsState).on(t.state),

--- a/src/runs/spawn/continuation.test.ts
+++ b/src/runs/spawn/continuation.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ValidationError } from "../../core/errors.ts";
+import type { WarrenDb } from "../../db/client.ts";
+import type { Repos } from "../../db/repos/index.ts";
+import { spawnRun } from "./index.ts";
+import { makeAgentJson, makeBurrowClient, makePool, setupRepos } from "./test-helpers.ts";
+
+/**
+ * warren-4b11: a continuation run ("re-run with follow-up") seeds its
+ * workspace from the prior run's pushed branch instead of the project
+ * default branch, and records the parent link on `runs.parent_run_id`.
+ */
+describe("spawnRun: continuation (warren-4b11)", () => {
+	let db: WarrenDb;
+	let repos: Repos;
+
+	beforeEach(async () => {
+		({ db, repos } = await setupRepos());
+	});
+	afterEach(async () => {
+		await db.close();
+	});
+
+	async function makeParent(): Promise<string> {
+		const parent = await repos.runs.create({
+			agentName: "refactor-bot",
+			projectId: "prj_xxxxxxxxxxxx",
+			prompt: "first pass",
+			renderedAgentJson: makeAgentJson(),
+			trigger: "manual",
+		});
+		return parent.id;
+	}
+
+	test("refreshes to the parent's pushed branch and records parent_run_id", async () => {
+		const parentId = await makeParent();
+		const { client } = makeBurrowClient();
+		let refreshRef: string | undefined;
+		const { run } = await spawnRun({
+			repos,
+			burrowClientPool: await makePool(repos, client),
+			agentName: "refactor-bot",
+			projectId: "prj_xxxxxxxxxxxx",
+			prompt: "follow up",
+			parentRunId: parentId,
+			projectsConfig: { root: "/data/projects", gitBinary: "git" },
+			projectSpawn: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+			refreshProjectFn: async (input) => {
+				refreshRef = input.ref;
+				const updated = await repos.projects.recordRefresh({
+					id: input.id,
+					headSha: "feedface".repeat(5),
+				});
+				return { project: updated, headSha: "feedface".repeat(5), ref: input.ref ?? "main" };
+			},
+		});
+
+		// Default prefix is "burrow"; parent branch is burrow/<parentId>.
+		expect(refreshRef).toBe(`burrow/${parentId}`);
+		expect(run.parentRunId).toBe(parentId);
+	});
+
+	test("honors a project runBranchPrefix when recomposing the parent branch", async () => {
+		const parentId = await makeParent();
+		const { client } = makeBurrowClient();
+		let refreshRef: string | undefined;
+		await spawnRun({
+			repos,
+			burrowClientPool: await makePool(repos, client),
+			agentName: "refactor-bot",
+			projectId: "prj_xxxxxxxxxxxx",
+			prompt: "follow up",
+			parentRunId: parentId,
+			runBranchPrefixDefault: "warren",
+			projectsConfig: { root: "/data/projects", gitBinary: "git" },
+			projectSpawn: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+			refreshProjectFn: async (input) => {
+				refreshRef = input.ref;
+				const updated = await repos.projects.recordRefresh({
+					id: input.id,
+					headSha: "feedface".repeat(5),
+				});
+				return { project: updated, headSha: "feedface".repeat(5), ref: input.ref ?? "main" };
+			},
+		});
+
+		expect(refreshRef).toBe(`warren/${parentId}`);
+	});
+
+	test("parent branch wins over an explicit ref", async () => {
+		const parentId = await makeParent();
+		const { client } = makeBurrowClient();
+		let refreshRef: string | undefined;
+		await spawnRun({
+			repos,
+			burrowClientPool: await makePool(repos, client),
+			agentName: "refactor-bot",
+			projectId: "prj_xxxxxxxxxxxx",
+			prompt: "follow up",
+			parentRunId: parentId,
+			ref: "main",
+			projectsConfig: { root: "/data/projects", gitBinary: "git" },
+			projectSpawn: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+			refreshProjectFn: async (input) => {
+				refreshRef = input.ref;
+				const updated = await repos.projects.recordRefresh({
+					id: input.id,
+					headSha: "feedface".repeat(5),
+				});
+				return { project: updated, headSha: "feedface".repeat(5), ref: input.ref ?? "main" };
+			},
+		});
+
+		expect(refreshRef).toBe(`burrow/${parentId}`);
+	});
+
+	test("rejects a parent run from a different project", async () => {
+		await repos.projects.create({
+			id: "prj_yyyyyyyyyyyy",
+			gitUrl: "https://github.com/x/z.git",
+			localPath: "/data/projects/x/z",
+			defaultBranch: "main",
+		});
+		const otherParent = await repos.runs.create({
+			agentName: "refactor-bot",
+			projectId: "prj_yyyyyyyyyyyy",
+			prompt: "elsewhere",
+			renderedAgentJson: makeAgentJson(),
+			trigger: "manual",
+		});
+		const { client } = makeBurrowClient();
+		await expect(
+			spawnRun({
+				repos,
+				burrowClientPool: await makePool(repos, client),
+				agentName: "refactor-bot",
+				projectId: "prj_xxxxxxxxxxxx",
+				prompt: "follow up",
+				parentRunId: otherParent.id,
+			}),
+		).rejects.toBeInstanceOf(ValidationError);
+	});
+
+	test("a missing parent run id is a NotFoundError", async () => {
+		const { client } = makeBurrowClient();
+		await expect(
+			spawnRun({
+				repos,
+				burrowClientPool: await makePool(repos, client),
+				agentName: "refactor-bot",
+				projectId: "prj_xxxxxxxxxxxx",
+				prompt: "follow up",
+				parentRunId: "run_nonexistent0",
+			}),
+		).rejects.toThrow();
+	});
+
+	test("omitting parentRunId leaves parent_run_id null (root run)", async () => {
+		const { client } = makeBurrowClient();
+		const { run } = await spawnRun({
+			repos,
+			burrowClientPool: await makePool(repos, client),
+			agentName: "refactor-bot",
+			projectId: "prj_xxxxxxxxxxxx",
+			prompt: "fresh",
+		});
+		expect(run.parentRunId).toBeNull();
+	});
+});

--- a/src/runs/spawn/dispatch.ts
+++ b/src/runs/spawn/dispatch.ts
@@ -110,6 +110,15 @@ export async function spawnRun(input: SpawnRunInput): Promise<SpawnRunResult> {
 	const baseAgent = readCachedAgent(agentRow.renderedJson, agentRow.name);
 	const burrowConfig = parseBurrowConfig(baseAgent.sections.burrow_config);
 
+	// warren-4b11: continuation runs ("re-run with follow-up") seed their
+	// workspace from the prior run's pushed branch instead of the project
+	// default branch. Resolve the parent's branch up front and feed it as the
+	// refresh ref so the local clone is checked out to the parent branch tip
+	// before burrow forks the new run branch off it. The parent link is also
+	// recorded on the new run row below so the UI can render a chain indicator
+	// and chain cost/token totals are derivable by walking the link.
+	const baseRef = await resolveContinuationRef(input, project);
+
 	// Refresh the project clone to origin/<ref> so the run sees the
 	// latest commits. Skipped only when the caller didn't wire the
 	// projects-config + spawn seam (tests that pre-stage their own
@@ -122,7 +131,7 @@ export async function spawnRun(input: SpawnRunInput): Promise<SpawnRunResult> {
 					repo: input.repos.projects,
 					config: input.projectsConfig,
 					id: project.id,
-					...(input.ref !== undefined ? { ref: input.ref } : {}),
+					...(baseRef !== undefined ? { ref: baseRef } : {}),
 					spawn: input.projectSpawn,
 					...(input.now !== undefined ? { now: input.now } : {}),
 					...(input.warrenConfigs !== undefined ? { warrenConfigs: input.warrenConfigs } : {}),
@@ -175,6 +184,9 @@ export async function spawnRun(input: SpawnRunInput): Promise<SpawnRunResult> {
 		...(input.seedId !== undefined ? { seedId: input.seedId } : {}),
 		...(input.plotId !== undefined && input.plotId !== "" ? { plotId: input.plotId } : {}),
 		...(input.mode !== undefined ? { mode: input.mode } : {}),
+		...(input.parentRunId !== undefined && input.parentRunId !== ""
+			? { parentRunId: input.parentRunId }
+			: {}),
 		now: input.now?.(),
 	});
 
@@ -284,6 +296,44 @@ export async function spawnRun(input: SpawnRunInput): Promise<SpawnRunResult> {
 		await rollback(input, run.id, burrow, placement.client);
 		throw err;
 	}
+}
+
+/**
+ * Resolve the git ref the project clone should be refreshed to before the
+ * burrow forks the new run branch (warren-4b11).
+ *
+ * - No `parentRunId` → the caller's explicit `ref` (or undefined, which
+ *   refreshProject resolves to the project's tracked default branch).
+ * - `parentRunId` set → the parent run's pushed branch, recomposed from the
+ *   same prefix precedence the parent's spawn used
+ *   (`composeRunBranch(resolveRunBranchPrefix(...), parentRunId)`). We read
+ *   the project defaults here (a lightweight pre-refresh peek) only to get
+ *   the prefix; the working tree's `.warren/` is stable across a project's
+ *   runs, so this matches the branch the parent actually pushed.
+ *
+ * The parent must belong to the same project — a continuation forks the
+ * parent's branch on the same origin, so a cross-project parent would be a
+ * meaningless base. We reject it with a typed ValidationError rather than
+ * silently checking out a branch that doesn't exist on this origin.
+ */
+async function resolveContinuationRef(
+	input: SpawnRunInput,
+	project: { id: string; localPath: string },
+): Promise<string | undefined> {
+	if (input.parentRunId === undefined || input.parentRunId === "") return input.ref;
+	const parent = await input.repos.runs.require(input.parentRunId);
+	if (parent.projectId !== project.id) {
+		throw new ValidationError(
+			`parent run ${parent.id} belongs to a different project; a continuation must reuse the same project's branch`,
+			{ recoveryHint: "re-run with a parentRunId from the same project, or omit it" },
+		);
+	}
+	const defaults = await readProjectDefaults(input.warrenConfigs, project.id, project.localPath);
+	const prefix = resolveRunBranchPrefix({
+		projectDefault: defaults?.runBranchPrefix,
+		envDefault: input.runBranchPrefixDefault,
+	});
+	return composeRunBranch(prefix, parent.id);
 }
 
 async function provisionBurrow(

--- a/src/runs/spawn/types.ts
+++ b/src/runs/spawn/types.ts
@@ -84,6 +84,15 @@ export interface SpawnRunInput {
 	readonly projectSpawn?: ProjectSpawnFn;
 	/** Branch, tag, or SHA to refresh to. Defaults to the project's tracked default branch. */
 	readonly ref?: string;
+	/**
+	 * Continuation parent (warren-4b11). When set, this run is a "re-run with
+	 * follow-up" of a prior terminal run: its workspace is seeded from the
+	 * parent's pushed branch (`${prefix}/${parentRunId}`) instead of the
+	 * project default branch, and the link is recorded on `runs.parent_run_id`.
+	 * The parent must belong to the same project. Empty / unset → a root run.
+	 * Overrides `ref` when both are provided — the continuation base wins.
+	 */
+	readonly parentRunId?: string;
 	/** Override the project refresher; defaults to `refreshProject`. */
 	readonly refreshProjectFn?: typeof refreshProject;
 	/**

--- a/src/server/handlers/runs.dispatch.test.ts
+++ b/src/server/handlers/runs.dispatch.test.ts
@@ -147,6 +147,48 @@ describe("POST /runs — spawn flow", () => {
 		expect(persisted.seedId).toBe("seed-123");
 	});
 
+	test("continueFromRunId persists onto runs.parent_run_id (warren-4b11)", async () => {
+		const project = (await repos.projects.listAll())[0];
+		if (!project) throw new Error("project missing");
+
+		const parent = await repos.runs.create({
+			agentName: "refactor-bot",
+			projectId: project.id,
+			prompt: "first pass",
+			renderedAgentJson: { name: "refactor-bot", version: 1, sections: { system: "x" } },
+			trigger: "manual",
+		});
+
+		const calls: { method: string; path: string; body: unknown }[] = [];
+		const burrowClient = makeBurrowClient(
+			{ burrowId: "bur_cont00000000", burrowRunId: "run_contrun00000", workspacePath: "/tmp/ws" },
+			calls,
+		);
+		const deps = await depsFor(repos, burrowClient);
+		handle = startServer(deps, {
+			transport: { kind: "tcp", hostname: "127.0.0.1", port: 0 },
+			auth: NO_AUTH,
+			logger: silentLogger,
+		});
+
+		const res = await fetch(`${tcpUrl(handle)}/runs`, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				agent: "refactor-bot",
+				project: project.id,
+				prompt: "follow up",
+				continueFromRunId: parent.id,
+			}),
+		});
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as { run: { id: string; parentRunId: string | null } };
+		expect(body.run.parentRunId).toBe(parent.id);
+
+		const persisted = await repos.runs.require(body.run.id);
+		expect(persisted.parentRunId).toBe(parent.id);
+	});
+
 	test("invalid body params → 400 validation_error", async () => {
 		const calls: { method: string; path: string; body: unknown }[] = [];
 		const burrowClient = makeBurrowClient(

--- a/src/server/handlers/runs/dispatch.ts
+++ b/src/server/handlers/runs/dispatch.ts
@@ -89,6 +89,12 @@ export function createRunHandler(deps: ServerDeps): RouteHandler {
 		const modelOverride = optionalString(body, "modelOverride");
 		const seedId = optionalString(body, "seedId");
 		const plotId = optionalString(body, "plotId");
+		// warren-4b11: "re-run with follow-up" — base the workspace on the
+		// prior run's pushed branch and record the parent link. Accept both
+		// `continueFromRunId` (the UI affordance name) and `parentRunId` (the
+		// column name); the former wins when both are present.
+		const parentRunId =
+			optionalString(body, "continueFromRunId") ?? optionalString(body, "parentRunId");
 		const dispatcherHandle = optionalString(body, "dispatcherHandle");
 
 		const interactiveAgent = optionalString(body, "interactiveAgent");
@@ -126,6 +132,7 @@ export function createRunHandler(deps: ServerDeps): RouteHandler {
 			modelOverride,
 			seedId,
 			plotId,
+			...(parentRunId !== undefined ? { parentRunId } : {}),
 			dispatcherHandle,
 			warrenConfigs: deps.warrenConfigs,
 			runBranchPrefixDefault: deps.runBranchPrefixDefault,

--- a/src/ui/src/api/types.ts
+++ b/src/ui/src/api/types.ts
@@ -104,6 +104,14 @@ export interface RunRow {
 	 */
 	plotId: string | null;
 	/**
+	 * Continuation back-link (warren-4b11). Set when this run was spawned as
+	 * a "re-run with follow-up" of a prior terminal run: its workspace was
+	 * seeded from the parent's pushed branch instead of the project default
+	 * branch. Null for root runs. The Runs list renders a `↪ from run_xxx`
+	 * chain indicator and RunDetail links back to the parent.
+	 */
+	parentRunId: string | null;
+	/**
 	 * Run mode discriminator (pl-0344 step 1 / warren-67b6, step 4 /
 	 * warren-b3b9). `'batch'` is the legacy one-shot dispatch; `'interactive'`
 	 * is the respawn-per-turn primitive bound to a Plot. Pinned at row
@@ -219,6 +227,14 @@ export interface CreateRunInput {
 	mode?: "batch" | "interactive";
 	interactiveAgent?: string;
 	dispatcherHandle?: string;
+	/**
+	 * Optional continuation parent (warren-4b11). When set, the new run is
+	 * spawned as a "re-run with follow-up": its workspace is seeded from the
+	 * parent's pushed branch instead of the project default branch, and the
+	 * link is recorded on `runs.parent_run_id`. The parent must belong to
+	 * the same project.
+	 */
+	continueFromRunId?: string;
 }
 
 export interface SpawnRunResponse {

--- a/src/ui/src/pages/NewRun.tsx
+++ b/src/ui/src/pages/NewRun.tsx
@@ -27,6 +27,12 @@ export interface NewRunRouteState {
 	agent?: string;
 	plotId?: string;
 	prompt?: string;
+	/**
+	 * Continuation parent (warren-4b11). When RunDetail's "Re-run with
+	 * follow-up" navigates here, it carries the prior run id so the new run
+	 * is spawned with that run's pushed branch as the workspace base.
+	 */
+	continueFromRunId?: string;
 }
 
 function readRouteState(state: unknown): NewRunRouteState {
@@ -37,6 +43,7 @@ function readRouteState(state: unknown): NewRunRouteState {
 	if (typeof s.agent === "string") out.agent = s.agent;
 	if (typeof s.plotId === "string") out.plotId = s.plotId;
 	if (typeof s.prompt === "string") out.prompt = s.prompt;
+	if (typeof s.continueFromRunId === "string") out.continueFromRunId = s.continueFromRunId;
 	return out;
 }
 
@@ -182,8 +189,13 @@ export function NewRunPage() {
 			...(trimmedProvider.length > 0 ? { providerOverride: trimmedProvider } : {}),
 			...(trimmedModel.length > 0 ? { modelOverride: trimmedModel } : {}),
 			...(hasPlot && trimmedPlotId.length > 0 ? { plotId: trimmedPlotId } : {}),
+			...(continueFromRunId !== undefined ? { continueFromRunId } : {}),
 		});
 	};
+
+	// warren-4b11: a continuation pre-fills the parent id from route state
+	// and is fixed for the life of the form — there's no picker for it.
+	const continueFromRunId = initialState.continueFromRunId;
 
 	const noAgents = !agents.isLoading && (agents.data?.agents.length ?? 0) === 0;
 	const noProjects = !projects.isLoading && (projects.data?.projects.length ?? 0) === 0;
@@ -206,6 +218,12 @@ export function NewRunPage() {
 				title="Dispatch run"
 				description="Spawn an agent against a project repo inside a fresh sandbox."
 			/>
+
+			{continueFromRunId !== undefined ? (
+				<p className="font-mono text-sm text-(--color-muted-foreground)">
+					↪ from {continueFromRunId}
+				</p>
+			) : null}
 
 			{noAgents ? (
 				<Card>

--- a/src/ui/src/pages/RunDetail.tsx
+++ b/src/ui/src/pages/RunDetail.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CircleStop, ExternalLink, Send, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import {
 	buildPreviewLoginUrl,
 	formatPreviewUrl,
@@ -31,6 +31,7 @@ import { Textarea } from "@/components/ui/textarea.tsx";
 import { useEventStream } from "@/hooks/useEventStream.ts";
 import { formatError } from "@/lib/format-error.ts";
 import { formatTimestamp, relativeTime } from "@/lib/utils.ts";
+import type { NewRunRouteState } from "@/pages/NewRun.tsx";
 
 /**
  * Event kinds whose arrival means the warren run row may have advanced
@@ -55,6 +56,7 @@ const REFETCH_TRIGGER_KINDS: ReadonlySet<string> = new Set([
 export function RunDetailPage() {
 	const { id = "" } = useParams<{ id: string }>();
 	const qc = useQueryClient();
+	const navigate = useNavigate();
 
 	const run = useQuery({
 		queryKey: ["runs", id],
@@ -168,14 +170,34 @@ export function RunDetailPage() {
 					</p>
 				</div>
 				<div className="flex flex-col items-end gap-1">
-					<Button
-						variant="destructive"
-						onClick={() => cancel.mutate()}
-						disabled={cancel.isPending || isTerminal}
-					>
-						<CircleStop className="h-4 w-4" />
-						{cancel.isPending ? "Cancelling…" : "Cancel"}
-					</Button>
+					{isTerminal ? (
+						<Button
+							variant="outline"
+							onClick={() =>
+								navigate("/runs/new", {
+									state: {
+										continueFromRunId: r.id,
+									agent: r.agentName,
+									project: r.projectId ?? undefined,
+									plotId: r.plotId ?? undefined,
+									prompt: r.prompt,
+								} satisfies NewRunRouteState,
+								})
+							}
+						>
+							<Send className="h-4 w-4" />
+							Re-run with follow-up
+						</Button>
+					) : (
+						<Button
+							variant="destructive"
+							onClick={() => cancel.mutate()}
+							disabled={cancel.isPending || isTerminal}
+						>
+							<CircleStop className="h-4 w-4" />
+							{cancel.isPending ? "Cancelling…" : "Cancel"}
+						</Button>
+					)}
 					<CancelStatus mutation={cancel} />
 				</div>
 			</header>
@@ -217,6 +239,16 @@ export function RunDetailPage() {
 				{r.plotId !== null ? (
 					<MetaCard label="Plot">
 						<PlotMetaCardContent plotId={r.plotId} />
+					</MetaCard>
+				) : null}
+				{r.parentRunId !== null ? (
+					<MetaCard label="Continued from">
+						<Link
+							to={`/runs/${encodeURIComponent(r.parentRunId)}`}
+							className="font-mono text-xs underline hover:text-(--color-primary)"
+						>
+							↪ {r.parentRunId}
+						</Link>
 					</MetaCard>
 				) : null}
 			</div>

--- a/src/ui/src/pages/Runs.tsx
+++ b/src/ui/src/pages/Runs.tsx
@@ -257,6 +257,14 @@ export function RunsPage() {
 											>
 												{r.id}
 											</Link>
+											{r.parentRunId !== null ? (
+												<Link
+													to={`/runs/${encodeURIComponent(r.parentRunId)}`}
+													className="block font-mono text-xs text-(--color-muted-foreground) hover:underline"
+												>
+													↪ from {r.parentRunId}
+												</Link>
+											) : null}
 										</TableCell>
 										<TableCell className="whitespace-nowrap">{r.agentName}</TableCell>
 										<TableCell className="whitespace-nowrap font-mono text-xs">


### PR DESCRIPTION
## Summary

feat(runs): re-run a terminated run as a continuation on the same branch (warren-4b11)

## Run

- **Warren run:** `run_qkzk5rjsha8r`
- **Agent:** pi
- **Cost:** $8.93 (286 in / 54.9k out / 13.2M cache-r)

## Seeds

- warren-4b11 — Re-prompt / re-trigger a terminated run — continue the same conversation against the same workspace

## Commits (1)

- 5994943 feat(runs): re-run a terminated run as a continuation on the same branch (warren-4b11)

## Files changed

```
src/client/client.ts                               |    6 +-
 src/client/types.ts                                |    6 +
 src/db/migrations/0019_whole_gunslinger.sql        |    1 +
 src/db/migrations/meta/0019_snapshot.json          |  963 +++++++++++++++++
 src/db/migrations/meta/_journal.json               |    7 +
 .../migrations/postgres/0012_silent_silverclaw.sql |    1 +
 src/db/migrations/postgres/meta/0012_snapshot.json | 1111 ++++++++++++++++++++
 src/db/migrations/postgres/meta/_journal.json      |    7 +
 src/db/repos/runs.ts                               |   38 +-
 src/db/schema/postgres.ts                          |    3 +
 src/db/schema/sqlite.ts                            |   11 +
 src/runs/spawn/continuation.test.ts                |  169 +++
 src/runs/spawn/dispatch.ts                         |   52 +-
 src/runs/spawn/types.ts                            |    9 +
 src/server/handlers/runs.dispatch.test.ts          |   42 +
 src/server/handlers/runs/dispatch.ts               |    7 +
 src/ui/src/api/types.ts                            |   16 +
 src/ui/src/pages/NewRun.tsx                        |   18 +
 src/ui/src/pages/RunDetail.tsx                     |   50 +-
 src/ui/src/pages/Runs.tsx                          |    8 +
 20 files changed, 2492 insertions(+), 33 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-4b11. use ml. commit when done.
```

</details>

---

🤖 Opened by warren run `run_qkzk5rjsha8r`