### PR TITLE
Ratchet coverage floors up to current levels (unblock pre-commit hook)

### DIFF
--- a/scripts/coverage-budgets.json
+++ b/scripts/coverage-budgets.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "Coverage floors enforced by scripts/check-coverage.ts (warren-e4b1, pl-7b06 step 17). Set just below the current baseline (functions 86.25%, lines 91.62% as of 2026-05-27) to absorb measurement noise. The ratchet only goes UP — raise these numbers as coverage improves; never lower them. To grow past a budget: add tests first, then raise the floor.",
-	"functions": 86.87,
-	"lines": 90.23
+	"_comment": "Coverage floors enforced by scripts/check-coverage.ts (warren-e4b1, pl-7b06 step 17). Set just below the current baseline (functions 87.59%, lines 90.82% as of 2026-05-29, warren-f65e) to absorb measurement noise. The ratchet only goes UP — raise these numbers as coverage improves; never lower them. To grow past a budget: add tests first, then raise the floor.",
+	"functions": 87.09,
+	"lines": 90.32
 }


### PR DESCRIPTION
## Summary

chore: ratchet coverage floors up to current levels (warren-f65e)

## Run

- **Warren run:** `run_he40vww331bx`
- **Agent:** pi
- **Cost:** $0.510 (42 in / 5.1k out / 373.4k cache-r)

## Seeds

- warren-f65e — Ratchet coverage floors up to current levels (unblock pre-commit hook)

## Commits (1)

- de0e340 chore: ratchet coverage floors up to current levels (warren-f65e)

## Files changed

```
scripts/coverage-budgets.json | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-f65e. use ml. commit when done.
```

</details>

---

🤖 Opened by warren run `run_he40vww331bx`