### PR TITLE
Patch version bump for Run Analytics dashboard (package.json version + …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] — 2026-05-29
+
+Run Analytics dashboard (pl-ad0f / warren-a00a): context-usage and
+agent-behavior mining built on the existing Cost Analytics architecture.
+Pure, dialect-agnostic aggregator modules under `src/runs/analytics/`,
+thin `RouteHandler` factories, two new read-only endpoints, and a new
+UI page with recharts visualizations.
+
+### Added
+
+- **`runs(analytics)`** — run-level analytics aggregator
+  (`src/runs/analytics/run-metrics.ts`) and `GET /analytics/runs`
+  handler: KPIs (run count, success rate, avg/median/p95 duration, avg
+  context tokens, avg/total cost), a runs-per-day time-series bucketed
+  by state, per-agent and per-model/provider breakdowns, a
+  failure-reason breakdown, and top-seeds-by-context — all honoring
+  `projectId` + `from`/`to` filters (warren-368e, warren-0692).
+- **`runs(analytics)`** — command-mining
+  (`src/runs/analytics/command-mining.ts`) and derived-insights
+  (`src/runs/analytics/insights.ts`) aggregators plus the
+  `GET /analytics/behavior` handler: command frequency/failure/retry
+  ranking with `tool_result.is_error` correlation via `tool_use_id`,
+  retry-loop + stuck-score detection, os-eco command highlighting
+  (ml/sd/gh/bun check:all), and typed severity-ranked insight callouts
+  (warren-8976, warren-1788, warren-5d50).
+- **`db`** — `EventsRepo.listToolEventsForRuns(runIds, {limit?})`
+  returning capped `tool_use`/`tool_result` rows for behavior mining
+  (warren-e355).
+- **`ui(analytics)`** — RunAnalytics page reachable from the nav,
+  mirroring the CostAnalytics filter UX: KPI cards, recharts graphs
+  (runs-over-time, avg-context-per-agent, top-seeds-by-context,
+  failure-reason), per-agent/model tables, insights callout cards, a
+  command-category bar, and a stuck-command leaderboard with os-eco
+  highlighting (warren-df6e, warren-638a, warren-436a).
+- **`ui(deps)`** — recharts (`^3.8.1`) added to `src/ui` as the first
+  chart library, with the bundle-size ratchet re-baselined accordingly
+  (warren-876c).
+
 ## [0.7.2] — 2026-05-28
 
 Frontend design-system revamp (pl-55a3 / warren-6358) plus a wave of

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3,7 +3,7 @@
 openapi: 3.1.0
 info:
   title: warren HTTP API
-  version: 0.7.2
+  version: 0.7.3
   description: >-
     Auto-generated from `src/server/handlers/index.ts`'s `ROUTE_TABLE`. Run `bun run gen:openapi` to
     refresh; CI fails if this schema drifts from the handler module. Request/response bodies are

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@os-eco/warren-cli",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"description": "Self-hostable control plane for ephemeral cloud agents — spawn sandboxed agents at your GitHub repos, watch them work live, steer them, get a branch back",
 	"type": "module",
 	"bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@
  * `Client` class is deferred to V2 (SPEC §8.3).
  */
 
-export const VERSION = "0.7.2";
+export const VERSION = "0.7.3";


### PR DESCRIPTION
## Summary

chore(release): bump version to 0.7.3 for Run Analytics dashboard (warren-f062)

## Run

- **Warren run:** `run_tydb6mnnzh24`
- **Agent:** pi
- **Cost:** $1.05 (56 in / 9.4k out / 877.0k cache-r)

## Seeds

- warren-f062 — Patch version bump for Run Analytics dashboard (package.json version + src/index.ts VERSION, keep in sync; add CHANGELOG.md entry)

## Commits (1)

- cd8f3fd chore(release): bump version to 0.7.3 for Run Analytics dashboard (warren-f062)

## Files changed

```
CHANGELOG.md      | 38 ++++++++++++++++++++++++++++++++++++++
 docs/openapi.yaml |  2 +-
 package.json      |  2 +-
 src/index.ts      |  2 +-
 4 files changed, 41 insertions(+), 3 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-f062. use ml. commit when done.
```

</details>

---

🤖 Opened by warren run `run_tydb6mnnzh24`