### PR TITLE
deps: bump @os-eco/burrow-cli 0.3.11 -> 0.3.12 (pi-chat runtime)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN apt-get update \
 # /usr/local sits under /usr so the symlink targets resolve inside the sandbox.
 ENV BUN_INSTALL=/usr/local
 RUN bun install -g \
-    @os-eco/burrow-cli@0.3.11 \
+    @os-eco/burrow-cli@0.3.12 \
     @os-eco/canopy-cli@0.2.4 \
     @os-eco/seeds-cli@0.5.9 \
     @os-eco/mulch-cli@0.10.7 \

--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@os-eco/warren-cli",
       "dependencies": {
-        "@os-eco/burrow-cli": "^0.3.11",
+        "@os-eco/burrow-cli": "^0.3.12",
         "@os-eco/plot-cli": "^0.4.0",
         "commander": "^15.0.0",
         "croner": "^10.0.1",
@@ -137,7 +138,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@os-eco/burrow-cli": ["@os-eco/burrow-cli@0.3.11", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^14.0.3", "drizzle-orm": "^0.45.2", "p-queue": "^9.2.0", "pino": "^10.3.1", "pino-pretty": "^13.1.3", "smol-toml": "^1.6.1", "zod": "^4.4.3" }, "bin": { "burrow": "src/cli/main.ts", "bw": "src/cli/main.ts" } }, "sha512-s/AFL8NtpzAxXa/N4E/imFV3xOAwZWk0qBVb8AG3Jm+1AzGlQwlnfb6B9c6l2Tdj1NHs3NRYcACszCeNwMgTnQ=="],
+    "@os-eco/burrow-cli": ["@os-eco/burrow-cli@0.3.12", "", { "dependencies": { "chalk": "^5.6.2", "commander": "^15.0.0", "drizzle-orm": "^0.45.2", "p-queue": "^9.2.0", "pino": "^10.3.1", "pino-pretty": "^13.1.3", "smol-toml": "^1.6.1", "zod": "^4.4.3" }, "bin": { "burrow": "src/cli/main.ts", "bw": "src/cli/main.ts" } }, "sha512-7ojyoiM71BVz/s53gGItquAdVL5tFkyIS7hECOuLrtvQgNdoA2BqI0UfGM2EIkT0gC6iSARrLwgYq2HhtaS/cQ=="],
 
     "@os-eco/plot-cli": ["@os-eco/plot-cli@0.4.0", "", { "dependencies": { "pino": "^10.3.1" }, "bin": { "plot": "src/index.ts" } }, "sha512-Y//wUlLEpPt0OCJaFHRL7XIGVoSVhv0mYgOvSWZs6Qx6j1eA7cx0JuCnt43ikw/0b7K02teCWmYEC4CNz3gLlw=="],
 
@@ -582,8 +583,6 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
-
-    "@os-eco/burrow-cli/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "jscpd/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"typescript": "^6.0.3"
 	},
 	"dependencies": {
-		"@os-eco/burrow-cli": "^0.3.11",
+		"@os-eco/burrow-cli": "^0.3.12",
 		"@os-eco/plot-cli": "^0.4.0",
 		"commander": "^15.0.0",
 		"croner": "^10.0.1",


### PR DESCRIPTION
## Summary
- Bumps `@os-eco/burrow-cli` to **0.3.12** in both pin locations (Dockerfile global install + `package.json`/`bun.lock`), per the dual-pin convention.

## Why
The deployed Leveret conversation path (`conv_4v2b2rewmq6r`) was dead on arrival: both anchoring runs failed `never_started` because burrow-side dispatch errored with `agent 'pi-chat' is not registered`. The `pi-chat` runtime (burrow #37–#40) landed after the `v0.3.11` tag, so the published 0.3.11 in the image never shipped it. burrow 0.3.12 was just released with the runtime included.

## Verification
- `bun test`: 2583 pass / 0 fail
- full `check:all` ran via the prepare hook on commit — all green
- confirmed `node_modules/@os-eco/burrow-cli/src/runtime/pi-chat.ts` present after lockfile regen

🤖 Generated with [Claude Code](https://claude.com/claude-code)