### PR TITLE
fix(ci): force npm package manager for Polygraph/Nx indexing

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,3 @@
+{
+  "cli": { "packageManager": "npm" }
+}


### PR DESCRIPTION
## Problem

Polygraph's repo indexer runs `nx init`, detects **bun** from `bun.lock` + `bunfig.toml`, and runs `bun install` — but the indexing container has no `bun` on PATH, so indexing fails with `/bin/sh: 1: bun: not found`.

## Fix

Nx's `detectPackageManager` reads `nx.json` → `cli.packageManager` before any lockfile. Pinning `npm` makes the indexer use npm (available) instead of bun. Single new file, inert for real Bun workflows. warren's `@os-eco/*` deps are published and resolve under npm.

```json
{ "cli": { "packageManager": "npm" } }
```

Validated on **plot** ([PR #19](https://github.com/jayminwest/plot/pull/19)) — indexing went green after merge.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a45930d460a55d2281a9567/sessions/fixing-indexing-ceb22558)
<!-- polygraph-session-end -->