### PR TITLE
CLI + diagnostics: scope warren run/doctor burrow access as explicit lo…

### DIFF
--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -221,6 +221,34 @@ describe("runDoctor", () => {
 		]);
 	});
 
+	test("under WARREN_RUNTIME=k8s, skips burrow/bwrap/stale probes and says so", async () => {
+		const { context } = captureContext({
+			WARREN_API_TOKEN: "tok",
+			CANOPY_REPO_URL: "https://example.com/agents.git",
+			WARREN_RUNTIME: "k8s",
+		});
+		const result = await runDoctor(
+			context,
+			{
+				existsSync: () => true,
+				// A throwing probe would fail the check under local; under k8s it must
+				// never be consulted at all.
+				probeBurrow: async () => {
+					throw new Error("burrow must not be probed under k8s");
+				},
+			},
+			{},
+		);
+		const names = result.checks.map((c) => c.name);
+		expect(names).not.toContain("bwrap");
+		expect(names).not.toContain("stale_burrow_workspaces");
+		expect(names).not.toContain("burrow_reachable");
+		const runtime = result.checks.find((c: DoctorCheck) => c.name === "runtime_backend");
+		expect(runtime?.ok).toBe(true);
+		expect(runtime?.message).toContain("k8s");
+		expect(result.exitCode).toBe(0);
+	});
+
 	test("warren_db reports the resolved dialect for WARREN_DB_URL", async () => {
 		const { context } = captureContext({
 			WARREN_API_TOKEN: "tok",

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -17,14 +17,11 @@
  */
 
 import { existsSync } from "node:fs";
-import { BurrowClient } from "../../burrow-client/client.ts";
-import { loadBurrowClientConfigFromEnv } from "../../burrow-client/config.ts";
 import { ValidationError } from "../../core/errors.ts";
 import type { AnyWarrenDb } from "../../db/client.ts";
 import { DrizzleAdapter } from "../../db/repos/drizzle-adapter.ts";
 import { createRepos } from "../../db/repos/index.ts";
 import {
-	checkBurrowReachable,
 	checkBwrap,
 	checkCanopyClean,
 	checkCanopyClone,
@@ -41,6 +38,8 @@ import { checkStaleBurrowWorkspaces } from "../../diagnostics/stale-workspaces.t
 import { loadPreviewPortRangeFromEnv, PreviewPortAllocator } from "../../preview/port-allocator.ts";
 import { loadProjectsConfigFromEnv } from "../../projects/config.ts";
 import { loadWorkspaceGcConfigFromEnv } from "../../runs/reap/gc.ts";
+import { doctorBurrowCheck } from "../../runtime/local/diagnostics/burrow.ts";
+import { resolveRuntimeKind } from "../../runtime/registry.ts";
 import type { CliContext, EnvLike } from "../output.ts";
 import { writeJsonLine } from "../output.ts";
 
@@ -83,6 +82,12 @@ export async function runDoctor(
 ): Promise<DoctorResult> {
 	const exists = deps.existsSync ?? existsSync;
 	const checks: DoctorCheck[] = [];
+	// Burrow/bwrap/stale-workspace probes only make sense for the LOCAL backend,
+	// where warren co-tenants a burrow daemon. Under `WARREN_RUNTIME=k8s` agents
+	// run in pods with no co-tenanted burrow, so we skip them cleanly and emit a
+	// single informational line saying so — mirroring the `/readyz` behavior
+	// (warren-c128, src/server/handlers/diagnostics.ts).
+	const isLocalTopology = resolveRuntimeKind(context.env) === "local";
 
 	checks.push(envCheck("WARREN_API_TOKEN", context.env, args.noAuth ?? false));
 	checks.push(canopyRepoUrlCheck(context.env));
@@ -95,18 +100,31 @@ export async function runDoctor(
 
 	checks.push(projectsRootCheck(context.env, exists));
 
-	checks.push(await checkBwrap({ spawn: context.spawn }));
+	if (isLocalTopology) {
+		checks.push(await checkBwrap({ spawn: context.spawn }));
+	}
 
 	checks.push(await checkWarrenConfig({ projects: deps.projects ?? [] }));
 	checks.push(await checkWarrenConfigDeprecations({ projects: deps.projects ?? [] }));
 
 	checks.push(await previewPortAllocatorCheck(context.env, deps.db));
 
-	checks.push(await staleBurrowWorkspacesCheck(context.env, deps.db));
+	if (isLocalTopology) {
+		checks.push(await staleBurrowWorkspacesCheck(context.env, deps.db));
+	}
 
 	checks.push(checkPreviewAuthStrength({ env: context.env }));
 
-	checks.push(await burrowCheck(context.env, deps.probeBurrow));
+	if (isLocalTopology) {
+		checks.push(await doctorBurrowCheck(context.env, deps.probeBurrow));
+	} else {
+		checks.push({
+			name: "runtime_backend",
+			ok: true,
+			message:
+				"k8s: burrow / bwrap / stale-workspace probes skipped (agents run in pods, no co-tenanted burrow)",
+		});
+	}
 
 	for (const check of checks) {
 		writeJsonLine(context.stdio.stdout, check);
@@ -230,56 +248,4 @@ async function previewPortAllocatorCheck(
 	// against the runs table. Dialect-polymorphic since warren-adfb.
 	const allocator = new PreviewPortAllocator(DrizzleAdapter.for(db), range);
 	return checkPreviewPortAllocator({ probe: allocator });
-}
-
-async function burrowCheck(
-	env: EnvLike,
-	override?: (env: EnvLike) => Promise<void>,
-): Promise<DoctorCheck> {
-	if (override !== undefined) {
-		try {
-			await override(env);
-			return { name: "burrow_reachable", ok: true };
-		} catch (err) {
-			if (err instanceof ValidationError) {
-				return {
-					name: "burrow_reachable",
-					ok: false,
-					message: err.message,
-					...(err.recoveryHint !== undefined ? { hint: err.recoveryHint } : {}),
-				};
-			}
-			return {
-				name: "burrow_reachable",
-				ok: false,
-				message: err instanceof Error ? err.message : String(err),
-				hint: "check that burrow serve is running and WARREN_BURROW_SOCKET / WARREN_BURROW_HOST point to it",
-			};
-		}
-	}
-	let client: BurrowClient;
-	try {
-		const config = loadBurrowClientConfigFromEnv(env);
-		client = new BurrowClient({ config });
-	} catch (err) {
-		if (err instanceof ValidationError) {
-			return {
-				name: "burrow_reachable",
-				ok: false,
-				message: err.message,
-				...(err.recoveryHint !== undefined ? { hint: err.recoveryHint } : {}),
-			};
-		}
-		return {
-			name: "burrow_reachable",
-			ok: false,
-			message: err instanceof Error ? err.message : String(err),
-			hint: "check that burrow serve is running and WARREN_BURROW_SOCKET / WARREN_BURROW_HOST point to it",
-		};
-	}
-	try {
-		return await checkBurrowReachable({ burrowClient: client });
-	} finally {
-		await client.close().catch(() => undefined);
-	}
 }

--- a/src/cli/commands/run.test.ts
+++ b/src/cli/commands/run.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { Burrow, Run as BurrowRun } from "@os-eco/burrow-cli";
-import { BurrowClient } from "../../burrow-client/index.ts";
 import { openDatabase, type WarrenDb } from "../../db/client.ts";
 import { createRepos, type Repos } from "../../db/repos/index.ts";
 import type { RunRow, RunTerminalState } from "../../db/schema.ts";
@@ -9,6 +8,7 @@ import {
 	RunEventBroker,
 	type SpawnRunResult,
 } from "../../runs/index.ts";
+import type { RuntimeProvider } from "../../runtime/contract.ts";
 import type { CliContext } from "../output.ts";
 import { runRun } from "./run.ts";
 
@@ -27,18 +27,40 @@ function captureContext(): { context: CliContext; out: string[]; err: string[] }
 	return { context, out, err };
 }
 
-function fakeBurrowClient(): BurrowClient {
-	return new BurrowClient({
-		config: { transport: { kind: "unix", path: "/tmp/x.sock" } },
-		fetch: (async () => new Response(null, { status: 500 })) as unknown as typeof fetch,
-	});
+/**
+ * Minimal RuntimeProvider stub (warren-11cc). The run-command tests stub
+ * spawn/bridge/reap/fetchBurrowRunState, so the provider's methods are never
+ * actually driven here — it exists to satisfy the required `runtimeProvider`
+ * dep. `capabilities.previewPorts` is `false` so the preview sub-step stays
+ * dark (tests wire `previewSidecars` explicitly if they need it).
+ */
+function fakeProvider(): RuntimeProvider {
+	const notWired = () => {
+		throw new Error("fakeProvider: method not wired for this test");
+	};
+	return {
+		capabilities: {
+			previewPorts: false,
+			networkPolicy: "domain-allowlist",
+			longLived: true,
+			midRunSteering: true,
+			enforcedResourceLimits: true,
+			workspaceArchive: true,
+			workspaceGc: true,
+		},
+		create: notWired as never,
+		streamEvents: notWired as never,
+		status: notWired as never,
+		sendMessage: notWired as never,
+		cancel: notWired as never,
+		workspaceInfo: notWired as never,
+		finalize: notWired as never,
+		terminate: notWired as never,
+	};
 }
 
-async function fakeBurrowDeps(_repos: Repos): Promise<{
-	burrowClient: BurrowClient;
-}> {
-	const burrowClient = fakeBurrowClient();
-	return { burrowClient };
+function fakeRunDeps(_repos: Repos): { runtimeProvider: RuntimeProvider } {
+	return { runtimeProvider: fakeProvider() };
 }
 
 function buildSpawnStub(repos: Repos, agentName: string, projectId: string) {
@@ -128,7 +150,7 @@ describe("runRun", () => {
 		const { context } = captureContext();
 		const result = await runRun(
 			context,
-			{ repos, ...(await fakeBurrowDeps(repos)) },
+			{ repos, ...fakeRunDeps(repos) },
 			{ agent: "", project: "", prompt: "" },
 		);
 		expect(result.exitCode).toBe(2);
@@ -167,7 +189,7 @@ describe("runRun", () => {
 			context,
 			{
 				repos,
-				...(await fakeBurrowDeps(repos)),
+				...fakeRunDeps(repos),
 				broker,
 				spawn: buildSpawnStub(repos, "refactor-bot", projectId) as never,
 				bridge: bridgeStub,
@@ -216,7 +238,7 @@ describe("runRun", () => {
 			context,
 			{
 				repos,
-				...(await fakeBurrowDeps(repos)),
+				...fakeRunDeps(repos),
 				broker,
 				spawn: buildSpawnStub(repos, "refactor-bot", projectId) as never,
 				bridge: bridgeStub,
@@ -228,5 +250,71 @@ describe("runRun", () => {
 
 		expect(result.exitCode).toBe(1);
 		expect(result.state).toBe("failed");
+	});
+
+	test("reads the terminal state through provider.status when no override is wired", async () => {
+		const projectId = (await repos.projects.listAll())[0]?.id as string;
+		const broker = new RunEventBroker();
+		const { context } = captureContext();
+
+		const bridgeStub = (async (): Promise<BridgeRunStreamResult> => ({
+			written: 0,
+			skipped: 0,
+			errored: false,
+		})) as never;
+		const reapStub = (async (input: { runId: string; outcome: RunTerminalState }) => {
+			await repos.runs.markRunning(input.runId, new Date("2026-05-08T12:00:01.000Z"));
+			await repos.runs.finalize(input.runId, input.outcome, new Date("2026-05-08T12:00:02.000Z"));
+			return {
+				state: input.outcome,
+				mulchUpdated: 0,
+				mulchSkipped: 0,
+				mulchAppended: 0,
+				seedsClosed: 0,
+				seedsCreated: 0,
+				branchPushed: false,
+				errors: [],
+				alreadyTerminal: false,
+			};
+		}) as never;
+
+		// A provider whose `status()` reports the run's terminal phase; the run
+		// command's default terminal-state read must dispatch through it (warren-11cc).
+		const provider = fakeProvider();
+		let statusHandle: unknown;
+		const providerWithStatus: RuntimeProvider = {
+			...provider,
+			status: (async (handle: unknown) => {
+				statusHandle = handle;
+				return {
+					phase: "succeeded",
+					exitCode: 0,
+					lastEventSeq: 0,
+					lastEventTs: null,
+					exists: true,
+				};
+			}) as never,
+		};
+
+		const result = await runRun(
+			context,
+			{
+				repos,
+				runtimeProvider: providerWithStatus,
+				broker,
+				spawn: buildSpawnStub(repos, "refactor-bot", projectId) as never,
+				bridge: bridgeStub,
+				reap: reapStub,
+			},
+			{ agent: "refactor-bot", project: projectId, prompt: "fix the bug" },
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.state).toBe("succeeded");
+		// The handle carried the burrow sandbox + run ids the spawn stub attached.
+		expect(statusHandle).toMatchObject({
+			sandboxId: "bur_aaaaaaaaaaaa",
+			providerRunId: "run_zzzzzzzzzzzz",
+		});
 	});
 });

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -20,8 +20,6 @@
  * UI does. The CLI prints a hint on first SIGINT, exits on the second.
  */
 
-import { withTransportMapping } from "../../burrow-client/client.ts";
-import type { BurrowClient } from "../../burrow-client/index.ts";
 import type { Repos } from "../../db/repos/index.ts";
 import type { RunTerminalState } from "../../db/schema.ts";
 import {
@@ -36,9 +34,8 @@ import {
 	spawnRun,
 	tailRunEvents,
 } from "../../runs/index.ts";
-import type { RuntimeProvider } from "../../runtime/contract.ts";
-import { createLocalSidecarsResolver } from "../../runtime/local/preview/sidecars.ts";
-import { resolveRuntimeProvider } from "../../runtime/registry.ts";
+import type { RunHandle, RuntimeProvider } from "../../runtime/contract.ts";
+import type { LocalSidecarsResolver } from "../../runtime/local/preview/sidecars.ts";
 import type { SeedsCliDeps } from "../../seeds-cli/index.ts";
 import { loadTriggerSchedulerConfigFromEnv } from "../../triggers/index.ts";
 import { createWarrenConfigCache, type WarrenConfigCache } from "../../warren-config/index.ts";
@@ -64,19 +61,20 @@ export interface RunArgs {
 export interface RunDeps {
 	readonly repos: Repos;
 	/**
-	 * The single local burrow client (warren-76c5). Shared by `spawnRun`,
-	 * `bridgeRunStream`, `reapRun`, and `fetchBurrowRunState` — multi-worker
-	 * pooling was retired with the K8s migration.
+	 * Boot-resolved runtime provider for the whole run lifecycle (warren-11cc).
+	 * REQUIRED: `main.ts` resolves it once (honoring `WARREN_RUNTIME`) via
+	 * `resolveLocalRunBackend` and threads it here; `spawnRun`, `bridgeRunStream`,
+	 * `reapRun`, and the terminal-state read all dispatch through it — the run
+	 * command no longer touches a burrow client. Tests inject a stub.
 	 */
-	readonly burrowClient: BurrowClient;
+	readonly runtimeProvider: RuntimeProvider;
 	/**
-	 * Resolved runtime provider for the spawn seam (warren-c42c). Optional: when
-	 * omitted the command resolves the boot-selected backend via
-	 * `resolveRuntimeProvider` (honoring `WARREN_RUNTIME`) over `burrowClient`.
-	 * `spawnRun` dispatches through it — the spawn path no longer takes a burrow
-	 * client. Tests inject a stub here (or stub `spawn` outright).
+	 * Preview sidecar seam (warren-11cc), capability-gated by `main.ts` on
+	 * `runtimeProvider.capabilities.previewPorts`. Present only for the local
+	 * backend; absent under `WARREN_RUNTIME=k8s`, so reap's preview sub-step goes
+	 * dark exactly as it does for a project without preview config.
 	 */
-	readonly runtimeProvider?: RuntimeProvider;
+	readonly previewSidecars?: LocalSidecarsResolver;
 	/** Optional broker injection — defaults to a fresh broker per run. */
 	readonly broker?: RunEventBroker;
 	/** Override the bridge factory (tests). Defaults to the live `bridgeRunStream`. */
@@ -85,8 +83,11 @@ export interface RunDeps {
 	readonly spawn?: typeof spawnRun;
 	/** Override reap (tests). Defaults to the live `reapRun`. */
 	readonly reap?: typeof reapRun;
-	/** Override the burrow run state lookup (tests). */
-	readonly fetchBurrowRunState?: (burrowRunId: string) => Promise<RunTerminalState>;
+	/**
+	 * Override the terminal-state lookup (tests). Defaults to a
+	 * `provider.status(handle)` read — the provider seam, not a burrow client.
+	 */
+	readonly fetchBurrowRunState?: (handle: RunHandle) => Promise<RunTerminalState>;
 	/**
 	 * Auto-open-PR config (warren-f6af). Defaults to
 	 * `loadAutoOpenPrConfigFromEnv(process.env)`. Tests pass an explicit
@@ -146,18 +147,18 @@ export async function runRun(
 		deps.runBranchPrefixDefault === null
 			? undefined
 			: (deps.runBranchPrefixDefault ?? loadRunBranchPrefixFromEnv());
-	const fetchBurrowRunState =
-		deps.fetchBurrowRunState ?? defaultFetchBurrowRunState(deps.burrowClient);
-	// Resolve the active runtime provider once (honoring WARREN_RUNTIME) and share
-	// it across spawn + the stream bridge (warren-1fce): the bridge streams,
-	// polls, and cancels through the provider seam, not a burrow client.
-	const runtimeProvider =
-		deps.runtimeProvider ?? resolveRuntimeProvider({ burrowClient: () => deps.burrowClient });
+	// The active runtime provider is boot-resolved in `main.ts` (honoring
+	// WARREN_RUNTIME) and shared across spawn + the stream bridge + reap + the
+	// terminal-state read: every burrow interaction crosses the provider seam,
+	// not a burrow client (warren-11cc).
+	const runtimeProvider = deps.runtimeProvider;
+	const fetchBurrowRunState = deps.fetchBurrowRunState ?? defaultFetchRunState(runtimeProvider);
 	const seedsCli: SeedsCliDeps = deps.seedsCli ?? {
 		sdBinary: loadTriggerSchedulerConfigFromEnv().sdBinary,
 		spawn: defaultSpawn,
 	};
 
+	let handle: RunHandle | undefined;
 	let spawnResult: SpawnRunResult;
 	try {
 		spawnResult = await spawn({
@@ -179,6 +180,11 @@ export async function runRun(
 	}
 
 	const runId = spawnResult.run.id;
+	handle = {
+		runId,
+		sandboxId: spawnResult.burrow.id,
+		providerRunId: spawnResult.burrowRun.id,
+	};
 	writeJsonLine(context.stdio.stdout, {
 		event: "run.spawned",
 		runId,
@@ -236,7 +242,7 @@ export async function runRun(
 
 	let outcome: RunTerminalState;
 	try {
-		outcome = await fetchBurrowRunState(spawnResult.burrowRun.id);
+		outcome = await fetchBurrowRunState(handle);
 	} catch (err) {
 		context.stdio.stderr.write(`warren: failed to read burrow run state: ${formatError(err)}\n`);
 		// Best-effort: assume failed so the warren row finalizes rather than stays running.
@@ -250,11 +256,9 @@ export async function runRun(
 			outcome,
 			repos: deps.repos,
 			runtimeProvider,
-			// warren-e24d: preview sidecar seam, gated on the runtime's preview-port
-			// capability (absent under K8s).
-			...(runtimeProvider.capabilities.previewPorts
-				? { previewSidecars: createLocalSidecarsResolver(deps.burrowClient) }
-				: {}),
+			// warren-11cc: preview sidecar seam, capability-gated by main.ts on the
+			// runtime's preview-port capability (absent under K8s).
+			...(deps.previewSidecars !== undefined ? { previewSidecars: deps.previewSidecars } : {}),
 			broker,
 			autoOpenPr,
 			seedsCli,
@@ -290,16 +294,17 @@ export async function runRun(
 	};
 }
 
-function defaultFetchBurrowRunState(
-	client: BurrowClient,
-): (burrowRunId: string) => Promise<RunTerminalState> {
-	return async (burrowRunId) => {
-		// warren-76c5: the self-host backend is a single local burrow — fetch the
-		// run's terminal state directly from the one client. A transport failure
-		// propagates so `runRun` maps it to a non-zero exit + stderr line.
-		const row = await withTransportMapping(client.config, () => client.http.runs.get(burrowRunId));
-		const state = row.state;
-		if (state === "succeeded" || state === "failed" || state === "cancelled") return state;
+function defaultFetchRunState(
+	provider: RuntimeProvider,
+): (handle: RunHandle) => Promise<RunTerminalState> {
+	return async (handle) => {
+		// warren-11cc: read the run's terminal state through the provider seam
+		// (`status()` never throws on a missing run — it reports `exists:false`).
+		// A non-terminal or absent run maps to `failed` so the warren row
+		// finalizes rather than stranding as running.
+		const status = await provider.status(handle);
+		const phase = status.phase;
+		if (phase === "succeeded" || phase === "failed" || phase === "cancelled") return phase;
 		return "failed";
 	};
 }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -11,7 +11,6 @@
  */
 
 import { Command } from "commander";
-import { BurrowClient } from "../burrow-client/index.ts";
 import { WarrenClient } from "../client/index.ts";
 import type { PlanRunState } from "../client/types.ts";
 import { openDatabase } from "../db/client.ts";
@@ -20,6 +19,7 @@ import { VERSION } from "../index.ts";
 import { loadProjectsConfigFromEnv } from "../projects/config.ts";
 import { seedBuiltinAgents } from "../registry/builtins/index.ts";
 import { requireCanopyRegistryConfigFromEnv } from "../registry/config.ts";
+import { resolveLocalRunBackend } from "../runtime/local/diagnostics/burrow.ts";
 import { runAddProject } from "./commands/add-project.ts";
 import { runConfigMigrate } from "./commands/config-migrate.ts";
 import { runMigrateToPostgres } from "./commands/db.ts";
@@ -116,14 +116,22 @@ export function buildProgram(context: CliContext): Command {
 					// a canopy library (warren-d3e9). Idempotent against existing
 					// rows.
 					await seedBuiltinAgents(repos.agents, undefined, context.now);
-					// warren-76c5: multi-worker pooling is retired — the self-host
-					// backend is a single local burrow built from WARREN_BURROW_* env
-					// vars, which spawn / bridge / reap / state-fetch all share.
-					const burrowClient = BurrowClient.fromEnv(context.env);
+					// warren-11cc: resolve the run backend once (honoring WARREN_RUNTIME).
+					// The local backend lazily builds a single burrow client + preview
+					// seam; under k8s no burrow client is constructed. Direct burrow
+					// access is confined to `resolveLocalRunBackend`
+					// (src/runtime/local/diagnostics/burrow.ts).
+					const backend = resolveLocalRunBackend(context.env);
 					try {
 						const result = await runRun(
 							context,
-							{ repos, burrowClient },
+							{
+								repos,
+								runtimeProvider: backend.runtimeProvider,
+								...(backend.previewSidecars !== undefined
+									? { previewSidecars: backend.previewSidecars }
+									: {}),
+							},
 							{
 								agent,
 								project,
@@ -135,7 +143,7 @@ export function buildProgram(context: CliContext): Command {
 						);
 						return result.exitCode;
 					} finally {
-						await burrowClient.close().catch(() => undefined);
+						await backend.close();
 					}
 				});
 				process.exit(exitCode);

--- a/src/diagnostics/checks-sandbox.ts
+++ b/src/diagnostics/checks-sandbox.ts
@@ -4,14 +4,13 @@
  * stays under the 500-line global limit; re-exported verbatim from
  * `./checks.ts`, so every importer keeps resolving unchanged.
  *
- * Covers: bwrap bring-up, the canopy clone's existence + cleanliness,
- * and burrow socket reachability (single-client + pool variants).
+ * Covers: bwrap bring-up and the canopy clone's existence + cleanliness.
+ * Burrow socket reachability lives in the allowlisted local-topology module
+ * `src/runtime/local/diagnostics/burrow.ts` (warren-11cc) so this diagnostics
+ * surface stays free of any direct burrow client import.
  */
 
 import { existsSync } from "node:fs";
-import type { BurrowClient } from "../burrow-client/client.ts";
-import { withTransportMapping } from "../burrow-client/client.ts";
-import { probeBurrowClient } from "../burrow-client/index.ts";
 import type { SpawnFn } from "../projects/clone.ts";
 import { type CanopyRegistryConfig, loadCanopyRegistryConfigFromEnv } from "../registry/config.ts";
 import type { DiagnosticCheck, EnvLike, ExistsFn } from "./checks.ts";
@@ -171,47 +170,4 @@ export async function checkCanopyClean(deps: {
 			hint: "POST /agents/refresh to hard-reset the canopy clone to origin/HEAD",
 		};
 	}
-}
-
-/**
- * Probe burrow's socket via `BurrowClient.probe()`. Wraps transport
- * errors into the same readable shape `withTransportMapping` produces
- * for §4.3 spawn-flow callers. Used by `warren doctor`, which probes a
- * single env-derived client. The server's /readyz handler uses
- * `checkBurrowPoolReachable` instead so a multi-worker deploy surfaces
- * every failing worker.
- */
-export async function checkBurrowReachable(deps: {
-	readonly burrowClient: BurrowClient;
-}): Promise<DiagnosticCheck> {
-	try {
-		await withTransportMapping(deps.burrowClient.config, () => deps.burrowClient.probe());
-		return { name: "burrow_reachable", ok: true };
-	} catch (err) {
-		return {
-			name: "burrow_reachable",
-			ok: false,
-			message: err instanceof Error ? err.message : String(err),
-			hint: "check that burrow serve is running and WARREN_BURROW_SOCKET / WARREN_BURROW_HOST point to it",
-		};
-	}
-}
-
-/**
- * Probe the single local burrow for the server's /readyz handler (warren-76c5).
- * Multi-worker aggregation was retired with the K8s migration — the self-host
- * backend is one local burrow — so this is a single `/healthz` probe shaped as
- * the readyz check envelope.
- */
-export async function checkBurrowPoolReachable(client: BurrowClient): Promise<DiagnosticCheck> {
-	const result = await probeBurrowClient(client);
-	if (result.ok) {
-		return { name: "burrow_reachable", ok: true };
-	}
-	return {
-		name: "burrow_reachable",
-		ok: false,
-		message: `${result.workerName}: ${result.error?.message ?? "unknown"}`,
-		hint: "check that burrow serve is running and WARREN_BURROW_SOCKET / WARREN_BURROW_HOST point to it",
-	};
 }

--- a/src/diagnostics/checks.ts
+++ b/src/diagnostics/checks.ts
@@ -8,8 +8,10 @@
  * the three sibling test files), which all import from `./checks.ts`,
  * keeps resolving unchanged.
  *
- *   - checks-sandbox.ts — bwrap bring-up, the canopy clone's existence
- *     + cleanliness, and burrow socket reachability (single + pool).
+ *   - checks-sandbox.ts — bwrap bring-up and the canopy clone's
+ *     existence + cleanliness. Burrow socket reachability lives in the
+ *     allowlisted `src/runtime/local/diagnostics/burrow.ts` module
+ *     (warren-11cc), out of this diagnostics surface.
  *   - checks-config.ts — per-project `.warren/` parsing (fatal +
  *     deprecation), resolved DB dialect, live `SELECT 1` reachability.
  *   - checks-preview.ts — preview port + live-count saturation and
@@ -51,8 +53,6 @@ export {
 export {
 	BWRAP_PROBE_TIMEOUT_MS,
 	CANOPY_GIT_TIMEOUT_MS,
-	checkBurrowPoolReachable,
-	checkBurrowReachable,
 	checkBwrap,
 	checkCanopyClean,
 	checkCanopyClone,

--- a/src/runtime/local/diagnostics/burrow.test.ts
+++ b/src/runtime/local/diagnostics/burrow.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { doctorBurrowCheck, resolveLocalRunBackend } from "./burrow.ts";
+
+describe("resolveLocalRunBackend", () => {
+	test("local topology resolves a provider with the preview sidecar seam", async () => {
+		const backend = resolveLocalRunBackend({ WARREN_RUNTIME: "local" });
+		expect(backend.runtimeProvider.capabilities.previewPorts).toBe(true);
+		expect(backend.previewSidecars).toBeDefined();
+		// close() tears down the lazily-built burrow client without throwing.
+		await backend.close();
+	});
+
+	test("unset WARREN_RUNTIME defaults to the local backend", async () => {
+		const backend = resolveLocalRunBackend({});
+		expect(backend.runtimeProvider.capabilities.previewPorts).toBe(true);
+		expect(backend.previewSidecars).toBeDefined();
+		await backend.close();
+	});
+
+	test("k8s topology resolves a provider with no preview seam and a no-op close", async () => {
+		const backend = resolveLocalRunBackend({ WARREN_RUNTIME: "k8s" });
+		expect(backend.runtimeProvider.capabilities.previewPorts).toBe(false);
+		expect(backend.previewSidecars).toBeUndefined();
+		// No burrow client was ever constructed under k8s, so close() is a no-op.
+		await backend.close();
+	});
+});
+
+describe("doctorBurrowCheck", () => {
+	test("returns ok when the override probe resolves", async () => {
+		const check = await doctorBurrowCheck({}, async () => undefined);
+		expect(check).toEqual({ name: "burrow_reachable", ok: true });
+	});
+
+	test("maps an override probe failure to a check failure", async () => {
+		const check = await doctorBurrowCheck({}, async () => {
+			throw new Error("ECONNREFUSED /var/run/burrow.sock");
+		});
+		expect(check.ok).toBe(false);
+		expect(check.message).toContain("ECONNREFUSED");
+	});
+});

--- a/src/runtime/local/diagnostics/burrow.ts
+++ b/src/runtime/local/diagnostics/burrow.ts
@@ -1,0 +1,160 @@
+/**
+ * Local-topology burrow access — the SINGLE allowlisted home for direct
+ * `burrow-client` imports on the CLI + diagnostics surface (warren-11cc).
+ *
+ * Bucket 8 of the burrow-client eviction routed everything the
+ * `RuntimeProvider` can serve (run dispatch via `provider.create`, sandbox
+ * health via `provider.status`) through the seam. What is left is genuinely
+ * local-topology-specific: probing the co-tenanted burrow daemon's unix socket
+ * and constructing the local burrow client the `LocalProvider` runs against.
+ * Neither has a provider-neutral home — they only exist because the LOCAL
+ * backend co-tenants a burrow daemon — so they are scoped HERE, under
+ * `src/runtime/local/`, out of `src/cli/` and `src/diagnostics/`, with this
+ * doc comment stating why. Under `WARREN_RUNTIME=k8s` there is no burrow at all
+ * (agents run in pods), so callers skip these probes entirely (mirroring the
+ * `/readyz` behavior from warren-c128, `src/server/handlers/diagnostics.ts`).
+ *
+ * Covers: burrow socket reachability (single-client + local probe variants),
+ * the `warren doctor` env-derived burrow check, and the `warren run`
+ * local-backend resolver (burrow client + provider + capability-gated preview
+ * seam).
+ */
+
+import { withTransportMapping } from "../../../burrow-client/client.ts";
+import { BurrowClient, probeBurrowClient } from "../../../burrow-client/index.ts";
+import { ValidationError } from "../../../core/errors.ts";
+import type { DiagnosticCheck } from "../../../diagnostics/checks.ts";
+import type { RuntimeProvider } from "../../contract.ts";
+import { resolveRuntimeProvider } from "../../registry.ts";
+import { createLocalSidecarsResolver, type LocalSidecarsResolver } from "../preview/sidecars.ts";
+
+type EnvLike = Readonly<Record<string, string | undefined>>;
+
+const BURROW_UNREACHABLE_HINT =
+	"check that burrow serve is running and WARREN_BURROW_SOCKET / WARREN_BURROW_HOST point to it";
+
+/**
+ * Probe burrow's socket via `BurrowClient.probe()`. Wraps transport errors into
+ * the same readable shape `withTransportMapping` produces for §4.3 spawn-flow
+ * callers. Used by `warren doctor`, which probes a single env-derived client.
+ */
+export async function checkBurrowReachable(deps: {
+	readonly burrowClient: BurrowClient;
+}): Promise<DiagnosticCheck> {
+	try {
+		await withTransportMapping(deps.burrowClient.config, () => deps.burrowClient.probe());
+		return { name: "burrow_reachable", ok: true };
+	} catch (err) {
+		return {
+			name: "burrow_reachable",
+			ok: false,
+			message: err instanceof Error ? err.message : String(err),
+			hint: BURROW_UNREACHABLE_HINT,
+		};
+	}
+}
+
+/**
+ * Probe the single local burrow for the server's /readyz handler (warren-76c5).
+ * Multi-worker aggregation was retired with the K8s migration — the self-host
+ * backend is one local burrow — so this is a single `/healthz` probe shaped as
+ * the readyz check envelope.
+ */
+export async function checkBurrowPoolReachable(client: BurrowClient): Promise<DiagnosticCheck> {
+	const result = await probeBurrowClient(client);
+	if (result.ok) {
+		return { name: "burrow_reachable", ok: true };
+	}
+	return {
+		name: "burrow_reachable",
+		ok: false,
+		message: `${result.workerName}: ${result.error?.message ?? "unknown"}`,
+		hint: BURROW_UNREACHABLE_HINT,
+	};
+}
+
+/**
+ * `warren doctor`'s burrow-socket check (moved out of `cli/commands/doctor.ts`,
+ * warren-11cc). When `override` is supplied (tests) it drives that instead of
+ * touching a socket; otherwise it builds a single env-derived `BurrowClient` and
+ * probes it, mapping `ValidationError` config failures to a check failure with
+ * the config's recovery hint.
+ */
+export async function doctorBurrowCheck(
+	env: EnvLike,
+	override?: (env: EnvLike) => Promise<void>,
+): Promise<DiagnosticCheck> {
+	if (override !== undefined) {
+		try {
+			await override(env);
+			return { name: "burrow_reachable", ok: true };
+		} catch (err) {
+			return burrowFailure(err);
+		}
+	}
+	let client: BurrowClient;
+	try {
+		client = BurrowClient.fromEnv(env);
+	} catch (err) {
+		return burrowFailure(err);
+	}
+	try {
+		return await checkBurrowReachable({ burrowClient: client });
+	} finally {
+		await client.close().catch(() => undefined);
+	}
+}
+
+function burrowFailure(err: unknown): DiagnosticCheck {
+	if (err instanceof ValidationError) {
+		return {
+			name: "burrow_reachable",
+			ok: false,
+			message: err.message,
+			...(err.recoveryHint !== undefined ? { hint: err.recoveryHint } : {}),
+		};
+	}
+	return {
+		name: "burrow_reachable",
+		ok: false,
+		message: err instanceof Error ? err.message : String(err),
+		hint: BURROW_UNREACHABLE_HINT,
+	};
+}
+
+/** The `warren run` local backend: a resolved provider plus its capability-gated seams. */
+export interface LocalRunBackend {
+	readonly runtimeProvider: RuntimeProvider;
+	/** Preview sidecar resolver (present iff `capabilities.previewPorts`). */
+	readonly previewSidecars?: LocalSidecarsResolver;
+	/** Close any burrow client this backend lazily constructed. */
+	close(): Promise<void>;
+}
+
+/**
+ * Resolve the runtime backend for `warren run` (warren-11cc). Mirrors how
+ * `bootServer` + `preview-gc-wiring.ts` wire the server: build the burrow client
+ * lazily, thread `resolveRuntimeProvider` over it (honoring `WARREN_RUNTIME`),
+ * and gate the preview sidecar seam on `capabilities.previewPorts`. Under
+ * `WARREN_RUNTIME=k8s` the provider never calls the burrow factory and
+ * `previewPorts` is `false`, so no burrow client is ever constructed and
+ * `close()` is a no-op.
+ */
+export function resolveLocalRunBackend(env: EnvLike): LocalRunBackend {
+	let client: BurrowClient | undefined;
+	const getClient = (): BurrowClient => {
+		if (client === undefined) client = BurrowClient.fromEnv(env);
+		return client;
+	};
+	const runtimeProvider = resolveRuntimeProvider({ burrowClient: getClient }, env);
+	const previewSidecars = runtimeProvider.capabilities.previewPorts
+		? createLocalSidecarsResolver(getClient())
+		: undefined;
+	return {
+		runtimeProvider,
+		...(previewSidecars !== undefined ? { previewSidecars } : {}),
+		close: async () => {
+			if (client !== undefined) await client.close().catch(() => undefined);
+		},
+	};
+}

--- a/src/server/handlers/diagnostics.ts
+++ b/src/server/handlers/diagnostics.ts
@@ -8,7 +8,6 @@
 
 import { DrizzleAdapter } from "../../db/repos/drizzle-adapter.ts";
 import {
-	checkBurrowPoolReachable,
 	checkBwrap,
 	checkCanopyClean,
 	checkCanopyClone,
@@ -24,6 +23,7 @@ import { checkStaleBurrowWorkspaces } from "../../diagnostics/stale-workspaces.t
 import { createRunPreviewsRepo, DEFAULT_MAX_LIVE } from "../../preview/eviction/index.ts";
 import { DEFAULT_PREVIEW_PORT_RANGE, PreviewPortAllocator } from "../../preview/port-allocator.ts";
 import type { SpawnFn } from "../../projects/clone.ts";
+import { checkBurrowPoolReachable } from "../../runtime/local/diagnostics/burrow.ts";
 import { resolveRuntimeKind } from "../../runtime/registry.ts";
 import { jsonResponse } from "../response.ts";
 import type { RouteHandler, ServerDeps } from "../types.ts";


### PR DESCRIPTION
## Summary

refactor(cli): provider-routed run/doctor, burrow probes scoped to local-topology diagnostics (warren-11cc)

## Run

- **Warren run:** `run_fkqx7csnxyam`
- **Agent:** pi
- **Cost:** $3.83 (101 in / 45.3k out / 4.0M cache-r)

## Seeds

- warren-11cc — CLI + diagnostics: scope warren run/doctor burrow access as explicit local-topology tooling

## Commits (1)

- c7122af refactor(cli): provider-routed run/doctor, burrow probes scoped to local-topology diagnostics (warren-11cc)

## Files changed

```
src/cli/commands/doctor.test.ts              |  28 +++++
 src/cli/commands/doctor.ts                   |  82 ++++----------
 src/cli/commands/run.test.ts                 | 116 ++++++++++++++++---
 src/cli/commands/run.ts                      |  85 +++++++-------
 src/cli/main.ts                              |  22 ++--
 src/diagnostics/checks-sandbox.ts            |  52 +--------
 src/diagnostics/checks.ts                    |   8 +-
 src/runtime/local/diagnostics/burrow.test.ts |  42 +++++++
 src/runtime/local/diagnostics/burrow.ts      | 160 +++++++++++++++++++++++++++
 src/server/handlers/diagnostics.ts           |   2 +-
 10 files changed, 425 insertions(+), 172 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
Implement seeds issue warren-11cc on this branch (you are on a dedicated run branch off k8s-migration; commit here, do NOT push or switch branches — warren pushes and opens the PR when you finish).

## Issue warren-11cc
Title: CLI + diagnostics: scope warren run/doctor burrow access as explicit local-topology tooling

Bucket 8 of the burrow-client eviction. src/cli/main.ts, cli/commands/run.ts, cli/commands/doctor.ts, and src/diagnostics/checks-sandbox.ts talk to burrow directly. Decision + implementation: route what the provider can serve (run dispatch via provider.create, sandbox checks via provider health) and explicitly scope the rest (burrow socket probe, stale-workspace check) as local-topology diagnostics living under src/runtime/local/diagnostics/ (or an allowlisted CLI module) with a doc comment stating why. Under WARREN_RUNTIME=k8s doctor skips burrow probes cleanly (mirror the /readyz behavior from warren-c128, src/server/handlers/diagnostics.ts). Acceptance: burrow imports confined to the allowlisted local-diagnostics module; doctor output correct under both runtimes; check:all green.

## Context — eight sibling buckets already landed (read the recent git log on this branch)
- The whole spawn/watchdog/stream/bridges/cancel/reap/preview surface is provider-only now. Latest: warren-e24d (1cd445e4) re-homed preview/gc behind RuntimeCapabilities (workspaceGc flag, previewPorts reuse) with seam factories createLocalSidecarsResolver / createLocalWorkspaceDestroyer under src/runtime/local/, and reapRun no longer takes burrowClient (runtimeProvider REQUIRED).
- Known burrow-reading call sites relevant to YOU (from the e24d verifier's map):
  - src/cli/commands/run.ts reads deps.burrowClient for a resolveRuntimeProvider fallback AND createLocalSidecarsResolver — route through the boot-resolved provider + capability-gated seams instead (mirror how src/server/main/index.ts + preview-gc-wiring.ts do it).
  - src/cli/main.ts and cli/commands/doctor.ts, src/diagnostics/checks-sandbox.ts talk to burrow directly.
  - Do NOT touch ServerDeps.burrowClient itself or src/server/main/index.ts boot wiring beyond what CLI routing forces — the ServerDeps eviction + lint boundary is warren-f796, landing right after you.
- /readyz prior art (warren-c128): under WARREN_RUNTIME=k8s, src/server/handlers/diagnostics.ts drops the burrow/bwrap/stale-workspace probes entirely. doctor must mirror that: k8s → skip burrow probes cleanly with output that says so, not error.

## Constraints
- Quality gates are terminal: bun install && cd src/ui && bun install, then bun run check:all must be 12/12 green before you commit and again before you finish.
- Strict TS: noUncheckedIndexedAccess, no any, .ts import extensions, tab indent, 100-char width; Biome warnings fail. Coverage ratchet only goes up — port tests, don't delete. File-size budgets exist (check:size).
- Commit message: refactor(cli): provider-routed run/doctor, burrow probes scoped to local-topology diagnostics (warren-11cc)

## Definition of done
1. grep -rn "burrow-client|@os-eco/burrow" src/cli/ src/diagnostics/ (non-test) → imports confined to the single allowlisted local-diagnostics module (under src/runtime/local/diagnostics/ or one clearly-named CLI module with a doc comment explaining the local-topology scoping).
2. warren run dispatches via the boot-resolved provider under both WARREN_RUNTIME values (unit-tested); doctor output correct under both (k8s skips burrow probes cleanly — test both paths).
3. check:all 12/12; committed with the message above.
4. Final summary: files changed with rationale, the allowlisted module path, doctor behavior matrix (local vs k8s), and risk notes for warren-f796.

```

</details>

---

🤖 Opened by warren run `run_fkqx7csnxyam`