### PR TITLE
Replace previewAuth non-null assertions with narrowed validatePreviewCo…

### DIFF
--- a/.canopy/agent.json
+++ b/.canopy/agent.json
@@ -12,7 +12,7 @@
     "tags": [
       "agent"
     ],
-    "model": "claude-opus-4-8",
+    "model": "claude-sonnet-5",
     "source": "builtin",
     "runtime": "pi",
     "provider": "anthropic"

--- a/.canopy/agent.json
+++ b/.canopy/agent.json
@@ -12,7 +12,7 @@
     "tags": [
       "agent"
     ],
-    "model": "claude-sonnet-5",
+    "model": "claude-opus-4-8",
     "source": "builtin",
     "runtime": "pi",
     "provider": "anthropic"

--- a/src/server/handlers/runs/preview.ts
+++ b/src/server/handlers/runs/preview.ts
@@ -1,11 +1,17 @@
 import { ValidationError } from "../../../core/errors.ts";
+import type { PreviewAuth } from "../../../preview/cookie.ts";
 import { createRunPreviewsRepo } from "../../../preview/eviction/index.ts";
 import { teardownPreview } from "../../../preview/teardown.ts";
 import { jsonResponse } from "../../response.ts";
 import type { RouteHandler, ServerDeps } from "../../types.ts";
 import { optionalString, readJsonBodyOrEmpty, requireParam } from "../index.ts";
 
-function validatePreviewConfig(deps: ServerDeps, mode: "subdomain" | "path"): void {
+/**
+ * Validate that the preview surface is configured for `mode` and return the
+ * narrowed {@link PreviewAuth}, so callers avoid non-null assertions on the
+ * optional `deps.previewAuth`.
+ */
+function validatePreviewConfig(deps: ServerDeps, mode: "subdomain" | "path"): PreviewAuth {
 	if (deps.previewAuth === undefined) {
 		throw new ValidationError("preview surface is not configured on this warren", {
 			recoveryHint:
@@ -18,6 +24,7 @@ function validatePreviewConfig(deps: ServerDeps, mode: "subdomain" | "path"): vo
 				"set WARREN_PREVIEW_HOST to enable subdomain-mode previews, or switch to WARREN_PREVIEW_MODE=path",
 		});
 	}
+	return deps.previewAuth;
 }
 
 /**
@@ -58,11 +65,10 @@ export function previewLoginHandler(deps: ServerDeps): RouteHandler {
 	return async (ctx) => {
 		const runId = requireParam(ctx, "id");
 		const mode: "subdomain" | "path" = deps.previewMode ?? "subdomain";
-		validatePreviewConfig(deps, mode);
+		const previewAuth = validatePreviewConfig(deps, mode);
 
 		const token = ctx.url.searchParams.get("token");
-		// biome-ignore lint/style/noNonNullAssertion: checked by validatePreviewConfig
-		if (!deps.previewAuth!.verifyLoginToken(token)) {
+		if (!previewAuth.verifyLoginToken(token)) {
 			return jsonResponse(401, {
 				error: {
 					code: "unauthorized",
@@ -93,8 +99,7 @@ export function previewLoginHandler(deps: ServerDeps): RouteHandler {
 		}
 
 		const now = deps.now?.() ?? new Date();
-		// biome-ignore lint/style/noNonNullAssertion: checked by validatePreviewConfig
-		const cookie = deps.previewAuth!.signCookie(runId, now);
+		const cookie = previewAuth.signCookie(runId, now);
 		return new Response(null, {
 			status: 302,
 			headers: {


### PR DESCRIPTION
## Summary

Replace previewAuth non-null assertions with narrowed validatePreviewConfig return (warren-2141)

## Run

- **Warren run:** `run_a1j8jp04g6t5`
- **Agent:** pi
- **Cost:** $0.249 (32 in / 3.3k out / 222.7k cache-r)

## Seeds

- warren-2141 — Replace previewAuth non-null assertions with narrowed validatePreviewConfig return

## Commits (1)

- 83bd65f Replace previewAuth non-null assertions with narrowed validatePreviewConfig return (warren-2141)

## Files changed

```
.canopy/agent.json                  |  2 +-
 .seeds/issues.jsonl                 |  4 ++--
 src/server/handlers/runs/preview.ts | 17 +++++++++++------
 3 files changed, 14 insertions(+), 9 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-2141
```

</details>

---

🤖 Opened by warren run `run_a1j8jp04g6t5`