### PR TITLE
Create a NEW sibling src/client/client-helpers.ts and MOVE into it (exp…

### DIFF
--- a/src/client/client-helpers.ts
+++ b/src/client/client-helpers.ts
@@ -1,0 +1,72 @@
+import { WarrenClientError } from "./errors.ts";
+
+/** Default poll cadence for {@link WarrenClient.waitForRun}. */
+export const DEFAULT_POLL_INTERVAL_MS = 2_000;
+
+/** Default overall budget for {@link WarrenClient.waitForRun}. */
+export const DEFAULT_POLL_TIMEOUT_MS = 30 * 60 * 1_000;
+
+export interface PollUntilTerminalInput<Row> {
+	readonly label: string;
+	readonly id: string;
+	readonly opts: {
+		intervalMs?: number;
+		timeoutMs?: number;
+		signal?: AbortSignal;
+		onTick?: (row: Row) => void;
+	};
+	readonly fetchRow: () => Promise<Row>;
+	readonly isTerminal: (row: Row) => boolean;
+	readonly stateOf: (row: Row) => string;
+}
+
+/**
+ * Generic poll loop shared by {@link WarrenClient.waitForRun} and
+ * {@link WarrenClient.waitForPlanRun}: fetch a row, fire `onTick`, return
+ * once terminal, else sleep and retry until the timeout/abort fires.
+ */
+export async function pollUntilTerminal<Row>(input: PollUntilTerminalInput<Row>): Promise<Row> {
+	const { label, id, opts } = input;
+	const interval = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+	const timeout = opts.timeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+	const deadline = Date.now() + timeout;
+	for (;;) {
+		if (opts.signal?.aborted) {
+			throw new DOMException(`waitFor ${label} aborted`, "AbortError");
+		}
+		const row = await input.fetchRow();
+		opts.onTick?.(row);
+		if (input.isTerminal(row)) return row;
+		if (Date.now() + interval >= deadline) {
+			throw new WarrenClientError(
+				408,
+				"wait_timeout",
+				`${label} ${id} did not reach a terminal state within ${timeout}ms (last state: ${input.stateOf(row)})`,
+			);
+		}
+		await sleepWithSignal(interval, opts.signal);
+	}
+}
+
+/**
+ * Promise-based delay that resolves early if `signal` aborts. Used by
+ * {@link WarrenClient.waitForRun}. Throws `AbortError` on abort so the
+ * outer poll loop can propagate the cancellation.
+ */
+export function sleepWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new DOMException("waitForRun aborted", "AbortError"));
+			return;
+		}
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(new DOMException("waitForRun aborted", "AbortError"));
+		};
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,3 +1,4 @@
+import { pollUntilTerminal } from "./client-helpers.ts";
 import { type EnvLike, loadWarrenClientConfigFromEnv, type WarrenClientConfig } from "./config.ts";
 import { WarrenClientError, WarrenUnreachableError } from "./errors.ts";
 import { errorFromResponse, readNdjsonStream } from "./ndjson.ts";
@@ -46,11 +47,7 @@ import {
 
 export const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
 
-/** Default poll cadence for {@link WarrenClient.waitForRun}. */
-export const DEFAULT_POLL_INTERVAL_MS = 2_000;
-
-/** Default overall budget for {@link WarrenClient.waitForRun}. */
-export const DEFAULT_POLL_TIMEOUT_MS = 30 * 60 * 1_000;
+export { DEFAULT_POLL_INTERVAL_MS, DEFAULT_POLL_TIMEOUT_MS } from "./client-helpers.ts";
 
 export interface WaitForRunOptions {
 	/** Poll cadence. Defaults to {@link DEFAULT_POLL_INTERVAL_MS}. */
@@ -486,69 +483,4 @@ export class WarrenClient {
 			throw err;
 		}
 	}
-}
-
-interface PollUntilTerminalInput<Row> {
-	readonly label: string;
-	readonly id: string;
-	readonly opts: {
-		intervalMs?: number;
-		timeoutMs?: number;
-		signal?: AbortSignal;
-		onTick?: (row: Row) => void;
-	};
-	readonly fetchRow: () => Promise<Row>;
-	readonly isTerminal: (row: Row) => boolean;
-	readonly stateOf: (row: Row) => string;
-}
-
-/**
- * Generic poll loop shared by {@link WarrenClient.waitForRun} and
- * {@link WarrenClient.waitForPlanRun}: fetch a row, fire `onTick`, return
- * once terminal, else sleep and retry until the timeout/abort fires.
- */
-async function pollUntilTerminal<Row>(input: PollUntilTerminalInput<Row>): Promise<Row> {
-	const { label, id, opts } = input;
-	const interval = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-	const timeout = opts.timeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
-	const deadline = Date.now() + timeout;
-	for (;;) {
-		if (opts.signal?.aborted) {
-			throw new DOMException(`waitFor ${label} aborted`, "AbortError");
-		}
-		const row = await input.fetchRow();
-		opts.onTick?.(row);
-		if (input.isTerminal(row)) return row;
-		if (Date.now() + interval >= deadline) {
-			throw new WarrenClientError(
-				408,
-				"wait_timeout",
-				`${label} ${id} did not reach a terminal state within ${timeout}ms (last state: ${input.stateOf(row)})`,
-			);
-		}
-		await sleepWithSignal(interval, opts.signal);
-	}
-}
-
-/**
- * Promise-based delay that resolves early if `signal` aborts. Used by
- * {@link WarrenClient.waitForRun}. Throws `AbortError` on abort so the
- * outer poll loop can propagate the cancellation.
- */
-function sleepWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
-	return new Promise<void>((resolve, reject) => {
-		if (signal?.aborted) {
-			reject(new DOMException("waitForRun aborted", "AbortError"));
-			return;
-		}
-		const timer = setTimeout(() => {
-			signal?.removeEventListener("abort", onAbort);
-			resolve();
-		}, ms);
-		const onAbort = () => {
-			clearTimeout(timer);
-			reject(new DOMException("waitForRun aborted", "AbortError"));
-		};
-		signal?.addEventListener("abort", onAbort, { once: true });
-	});
 }


### PR DESCRIPTION
## Summary

Extract polling helpers into src/client/client-helpers.ts (warren-3f09)

## Run

- **Warren run:** `run_7cm58ef0j9kz`
- **Agent:** pi
- **Cost:** $0.123 (14 in / 1.5k out / 142.1k cache-r)

## Seeds

- warren-3f09 — Create a NEW sibling src/client/client-helpers.ts and MOVE into it (exporting each) the file-local polling helpers currently in src/client/client.ts: the interface `PollUntilTerminalInput<Row>` (lines ~491-504), the generic async function `pollUntilTerminal<Row>` (lines ~510-535), and the function `sleepWithSignal` (lines ~538-554). ALSO MOVE the two module constants that pollUntilTerminal references as fallback defaults — `DEFAULT_POLL_INTERVAL_MS` (line 50, value 2_000, with its `/** Default poll cadence for {@link WarrenClient.waitForRun}. */` doc comment) and `DEFAULT_POLL_TIMEOUT_MS` (line 53, value 30 * 60 * 1_000, with its doc comment) — because both are part of the PUBLIC surface re-exported by src/client/index.ts (which named-imports them from ./client.ts); moving them to client-helpers.ts and re-exporting from client.ts avoids a client.ts ↔ client-helpers.ts circular import. Do NOT move `DEFAULT_PROBE_TIMEOUT_MS` (line 47) — it is used by WarrenClient.probe() (line 101) and stays in client.ts. Carry into client-helpers.ts ONLY the import its moved symbols use: `import { WarrenClientError } from "./errors.ts";` (DOMException, setTimeout, clearTimeout, Date, AbortSignal are globals — no import needed). In src/client/client.ts: delete the two moved const declarations (lines 50 and 53, with their doc comments and surrounding blank lines) and the moved interface + two functions (lines ~491-554); add near the existing top-of-file imports: `import { pollUntilTerminal, sleepWithSignal } from "./client-helpers.ts";`; add `export { DEFAULT_POLL_INTERVAL_MS, DEFAULT_POLL_TIMEOUT_MS } from "./client-helpers.ts";` to PRESERVE the public surface (src/client/index.ts named-imports both from ./client.ts — the re-export keeps that resolving unchanged; do NOT edit index.ts). The existing `{@link DEFAULT_POLL_INTERVAL_MS}` / `{@link DEFAULT_POLL_TIMEOUT_MS}` JSDoc references in the WaitForRunOptions/WaitForPlanRunOptions interfaces (lines ~56/58/67/69) still resolve via the re-export. Do NOT alter any function body, signature, error message, constant value, or WarrenClient's public API. Do NOT add a budget entry for client-helpers.ts — it must default-pass under the 500-line threshold. Verify: `wc -l src/client/client.ts` shows < 500 (expect ~487) AND `wc -l src/client/client-helpers.ts` shows < 500 (expect ~70) AND `bun run typecheck` is clean (src/client/index.ts named re-exports still resolve) AND `bun test src/client/` is green with the same test count as before AND `bun run check:dups` exits 0.

## Commits (1)

- fe83b3f Extract polling helpers into src/client/client-helpers.ts (warren-3f09)

## Files changed

```
src/client/client-helpers.ts | 72 ++++++++++++++++++++++++++++++++++++++++++++
 src/client/client.ts         | 72 ++------------------------------------------
 2 files changed, 74 insertions(+), 70 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-3f09
```

</details>

---

🤖 Opened by warren run `run_7cm58ef0j9kz`