### PR TITLE
Remove the "src/client/client.ts": 569 entry from scripts/file-size-bud…

### DIFF
--- a/scripts/file-size-budgets.json
+++ b/scripts/file-size-budgets.json
@@ -2,7 +2,6 @@
 	"_comment": "Per-file line-count budgets (warren-4553). New files default to `threshold`. Listed files are grandfathered at their commit-time line count and may not grow beyond it. Refactor + lower budgets over time; ratchet only goes down.",
 	"threshold": 500,
 	"budgets": {
-		"src/client/client.ts": 569,
 		"src/db/repos/runs.test.ts": 538,
 		"src/db/schema/sqlite.ts": 564,
 		"src/plots/aggregate.ts": 506,


### PR DESCRIPTION
## Summary

chore(ratchet): remove satisfied client.ts file-size budget entry

## Run

- **Warren run:** `run_mhcbgq207r7w`
- **Agent:** pi
- **Cost:** $0.191 (14 in / 1.7k out / 237.5k cache-r)

## Seeds

- warren-f854 — Remove the "src/client/client.ts": 569 entry from scripts/file-size-budgets.json (delete that single line). Do NOT add a budget entry for the new sibling src/client/client-helpers.ts — it must default-pass under the 500-line threshold (confirm `wc -l src/client/client-helpers.ts` shows < 500). Per docs/CONSTITUTION.md Article VI (refactors prove runtime paths — file moves have broken production here before), before declaring done run a repo-wide search for the old single-file assumption AND the new path across ALL file types: `git grep -n "client/client"` and `git grep -n "client-helpers"` (rg is not installed in this sandbox; use git grep) PLUS an explicit sweep of Dockerfile, docker-compose.yml, .github/workflows/*.yml, src/supervisor/ spawn/config strings, scripts/acceptance/, and docs/ — fix any stale reference. NOTE: the moved symbols pollUntilTerminal / sleepWithSignal / PollUntilTerminalInput were module-local (never exported) so no external importer references them by path; the two POLL constants remain reachable via src/client/index.ts through client.ts's re-export — confirm `git grep -n DEFAULT_POLL_INTERVAL_MS` and `git grep -n DEFAULT_POLL_TIMEOUT_MS` still resolve to the src/client/index.ts public surface. Verify: `bun run check:size` exits 0 AND `bun run check:dups` exits 0 AND `bun run check:all` is fully green (every gate stays green; src/client/client.ts and src/client/client-helpers.ts both default-pass under the 500-line threshold; the raised coverage lines floor 92.98 from step 1 still passes against the 93.23% actual).

## Commits (1)

- ab0b3d0 chore(ratchet): remove satisfied client.ts file-size budget entry

## Files changed

```
scripts/file-size-budgets.json | 1 -
 1 file changed, 1 deletion(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-f854
```

</details>

---

🤖 Opened by warren run `run_mhcbgq207r7w`