### PR TITLE
Decompose src/server/main/index.ts (547 lines, budget 548 -- the furthe…

### DIFF
--- a/src/server/main/index.ts
+++ b/src/server/main/index.ts
@@ -26,19 +26,9 @@
  * - `./preview-wiring.ts` — preview signed-cookie + proxy assembly
  */
 
-import { join } from "node:path";
 import { openDatabase } from "../../db/client.ts";
 import { DrizzleAdapter } from "../../db/repos/drizzle-adapter.ts";
 import { createRepos } from "../../db/repos/index.ts";
-import {
-	autoTransitionPlotToDone,
-	bootPlanRunCoordinator,
-	createPlanRunSpawn,
-	createPrMergeChecker,
-	createResolveExecution,
-	defaultPlotStatusSetter,
-	loadPlanRunCoordinatorConfigFromEnv,
-} from "../../plan-runs/index.ts";
 import {
 	loadPreviewEvictionConfigFromEnv,
 	startPreviewEvictionWorker,
@@ -46,23 +36,17 @@ import {
 import { loadPreviewLaunchConfigFromEnv } from "../../preview/launch/index.ts";
 import { loadPreviewPortRangeFromEnv, PreviewPortAllocator } from "../../preview/port-allocator.ts";
 import { loadProjectsConfigFromEnv } from "../../projects/config.ts";
-import { parseGitHubUrl } from "../../projects/index.ts";
 import { seedBuiltinAgents } from "../../registry/builtins/index.ts";
 import { loadCanopyRegistryConfigFromEnv } from "../../registry/config.ts";
 import {
-	composeRunBranch,
 	loadAutoOpenPrConfigFromEnv,
 	loadRunBranchPrefixFromEnv,
 	RunEventBroker,
 	reapRun,
-	resolveDispatcherHandle,
-	resolveRunBranchPrefix,
 } from "../../runs/index.ts";
-import { buildPrContent, openPullRequest } from "../../runs/pr.ts";
 import { loadWorkspaceGcConfigFromEnv, startWorkspaceGcWorker } from "../../runs/reap/gc.ts";
 import { resolveLocalBootBackend } from "../../runtime/local/boot-backend.ts";
 import { resolveRuntimeKind } from "../../runtime/registry.ts";
-import { showSeed } from "../../seeds-cli/index.ts";
 import { loadWarrenServerConfigFromFile } from "../../server-config/index.ts";
 import { loadTriggerSchedulerConfigFromEnv } from "../../triggers/index.ts";
 import { createWarrenConfigCache } from "../../warren-config/index.ts";
@@ -76,12 +60,12 @@ import { buildServerDeps } from "./deps.ts";
 import { bootBackgroundDetectors } from "./detector-wiring.ts";
 import {
 	bridgeLoggerFromPino,
-	planRunLoggerFromPino,
 	previewEvictionLoggerFromPino,
 	schedulerLoggerFromPino,
 	workspaceGcLoggerFromPino,
 } from "./logging.ts";
 import { bootObservability, captureBootFailure } from "./observability-wiring.ts";
+import { bootPlanRunCoordinatorWiring } from "./plan-run-wiring.ts";
 import { createPreviewAuthAndProxy } from "./preview-wiring.ts";
 import { bootK8sRuntime, resolveBootRuntimeProvider } from "./runtime-wiring.ts";
 import { closeDatabase, defaultSpawn, redactDbUrl, resolvePgPoolMax } from "./utils.ts";
@@ -286,113 +270,21 @@ export async function bootServer(opts: BootServerOptions = {}): Promise<WarrenSe
 		);
 	}
 
-	// Plan-run coordinator (pl-a258 / warren-2623). Polls active plan_runs
-	// rows on a 10s tick by default; same single-flight + disabled-via-env
-	// shape as bootScheduler so operators reading logs see identical
-	// lifecycle semantics.
-	const planRunCoordinatorConfig = loadPlanRunCoordinatorConfigFromEnv(env);
-	const planRunCoordinator = bootPlanRunCoordinator({
+	// Plan-run coordinator (pl-a258 / warren-2623). See plan-run-wiring.ts.
+	const planRunCoordinator = bootPlanRunCoordinatorWiring({
+		env,
 		repos,
-		showSeed: async (projectId, seedId) => {
-			const project = await repos.projects.require(projectId);
-			return showSeed(seedsCli, project.localPath, seedId);
-		},
-		checkPrMerged: createPrMergeChecker({ token: autoOpenPr.token }),
-		resolveExecution: createResolveExecution(repos), // pl-fb43 step 5: per-child execution repo
-		reopenPr:
-			autoOpenPr.enabled && autoOpenPr.token !== ""
-				? async (runId: string): Promise<string | null> => {
-						try {
-							const run = await repos.runs.get(runId);
-							if (run === null || run.projectId === null) return null;
-							const project = await repos.projects.get(run.projectId);
-							if (project === null) return null;
-							const warrenConfig = await warrenConfigs.get(run.projectId, project.localPath);
-							const prefix = resolveRunBranchPrefix({
-								projectDefault: warrenConfig.defaults?.runBranchPrefix,
-								envDefault: runBranchPrefixDefault,
-							});
-							const branch = composeRunBranch(prefix, runId);
-							const parsed = parseGitHubUrl(project.gitUrl);
-							const content = buildPrContent({
-								prompt: run.prompt,
-								runId: run.id,
-								agentName: run.agentName,
-								...(run.startedAt !== null ? { startedAt: run.startedAt } : {}),
-								...(run.endedAt !== null ? { endedAt: run.endedAt } : {}),
-								...(run.costUsd !== null ? { costUsd: run.costUsd } : {}),
-								...(run.tokensInput !== null ? { tokensInput: run.tokensInput } : {}),
-								...(run.tokensOutput !== null ? { tokensOutput: run.tokensOutput } : {}),
-								...(run.tokensCacheRead !== null ? { tokensCacheRead: run.tokensCacheRead } : {}),
-								...(autoOpenPr.warrenBaseUrl !== null
-									? { warrenBaseUrl: autoOpenPr.warrenBaseUrl }
-									: {}),
-							});
-							const result = await openPullRequest({
-								owner: parsed.owner,
-								repo: parsed.name,
-								head: branch,
-								base: project.defaultBranch,
-								title: content.title,
-								body: content.body,
-								token: autoOpenPr.token,
-							});
-							if (result.ok) return result.url;
-							logger.warn(
-								{ runId, reason: result.reason, message: result.message },
-								"plan_run.reopen_pr_failed",
-							);
-							return null;
-						} catch (err) {
-							logger.warn(
-								{ runId, reason: err instanceof Error ? err.message : String(err) },
-								"plan_run.reopen_pr_error",
-							);
-							return null;
-						}
-					}
-				: undefined,
-		spawn: createPlanRunSpawn({
-			repos,
-			runtimeProvider,
-			bridges: bridgesBoot.registry,
-			warrenConfigs,
-			projectsConfig,
-			projectSpawn: defaultSpawn,
-			seedsCli,
-			...(runBranchPrefixDefault !== undefined ? { runBranchPrefixDefault } : {}),
-			...(opts.now !== undefined ? { now: opts.now } : {}),
-		}),
-		// warren-b290 / pl-7937 step 5: auto-transition the bound Plot from
-		// `active` → `done` when every child of a Plot-bound PlanRun reaches a
-		// terminal state. Best-effort — see autoTransitionPlotToDone.
-		transitionPlot: async (planRun) => {
-			if (planRun.plotId === null) {
-				// Coordinator already guards on plotId, but narrow defensively
-				// so an unexpected null still produces a benign skip.
-				return { kind: "skipped", currentStatus: "unknown" };
-			}
-			const project = await repos.projects.require(planRun.projectId);
-			return autoTransitionPlotToDone({
-				setter: defaultPlotStatusSetter,
-				logger,
-				plotDir: join(project.localPath, ".plot"),
-				plotId: planRun.plotId,
-				handle: resolveDispatcherHandle(planRun.dispatcherHandle),
-				planRunId: planRun.id,
-			});
-		},
-		tickMs: planRunCoordinatorConfig.tickMs,
-		disabled: planRunCoordinatorConfig.disabled,
-		mergeTimeoutMs: planRunCoordinatorConfig.mergeTimeoutMs,
-		logger: planRunLoggerFromPino(logger),
+		runtimeProvider,
+		bridges: bridgesBoot.registry,
+		warrenConfigs,
+		projectsConfig,
+		autoOpenPr,
+		seedsCli,
+		projectSpawn: defaultSpawn,
+		logger,
+		...(runBranchPrefixDefault !== undefined ? { runBranchPrefixDefault } : {}),
 		...(opts.now !== undefined ? { now: opts.now } : {}),
 	});
-	if (planRunCoordinatorConfig.disabled) {
-		logger.info({}, "plan-run coordinator disabled via WARREN_PLAN_RUN_DISABLED");
-	} else {
-		logger.info({ tickMs: planRunCoordinatorConfig.tickMs }, "plan-run coordinator running");
-	}
 
 	// Background detectors (each gated by its own env flag): the pause
 	// detector (warren-2976), run heartbeat watchdog (warren-285d), send-off

--- a/src/server/main/plan-run-wiring.ts
+++ b/src/server/main/plan-run-wiring.ts
@@ -1,0 +1,213 @@
+/**
+ * Plan-run coordinator boot wiring (pl-a258 / warren-2623). Extracted
+ * from `bootServer` in `index.ts` so the orchestrator stays under the
+ * per-file size budget, mirroring the sibling `*-wiring.ts` precedent
+ * (preview-wiring.ts, detector-wiring.ts, observability-wiring.ts).
+ *
+ * Polls active `plan_runs` rows on a 10s tick by default; same
+ * single-flight + disabled-via-env shape as `bootScheduler` so operators
+ * reading logs see identical lifecycle semantics. Returns the coordinator
+ * handle so the caller can call `.stop()` on it in teardown.
+ */
+
+import { join } from "node:path";
+import type { Repos } from "../../db/repos/index.ts";
+import {
+	autoTransitionPlotToDone,
+	bootPlanRunCoordinator,
+	createPlanRunSpawn,
+	createPrMergeChecker,
+	createResolveExecution,
+	defaultPlotStatusSetter,
+	loadPlanRunCoordinatorConfigFromEnv,
+	type PlanRunCoordinatorHandle,
+} from "../../plan-runs/index.ts";
+import type { SpawnFn } from "../../projects/clone.ts";
+import type { ProjectsConfig } from "../../projects/config.ts";
+import { parseGitHubUrl } from "../../projects/index.ts";
+import {
+	type AutoOpenPrConfig,
+	composeRunBranch,
+	resolveDispatcherHandle,
+	resolveRunBranchPrefix,
+} from "../../runs/index.ts";
+import { buildPrContent, openPullRequest } from "../../runs/pr.ts";
+import type { RuntimeProvider } from "../../runtime/contract.ts";
+import type { SeedsCliDeps } from "../../seeds-cli/index.ts";
+import { showSeed } from "../../seeds-cli/index.ts";
+import type { WarrenConfigCache } from "../../warren-config/index.ts";
+import type { EnvLike } from "../config.ts";
+import type { BridgeRegistry, Logger } from "../types.ts";
+import { planRunLoggerFromPino } from "./logging.ts";
+
+type ReopenPrDeps = Pick<
+	PlanRunWiringInput,
+	"repos" | "warrenConfigs" | "autoOpenPr" | "runBranchPrefixDefault" | "logger"
+>;
+
+type RunRow = NonNullable<Awaited<ReturnType<Repos["runs"]["get"]>>>;
+
+/** Build the optional `buildPrContent` fields (only-if-present spreads). */
+function buildReopenPrContent(
+	run: RunRow,
+	autoOpenPr: AutoOpenPrConfig,
+): { title: string; body: string } {
+	const content = buildPrContent({
+		prompt: run.prompt,
+		runId: run.id,
+		agentName: run.agentName,
+		...(run.startedAt !== null ? { startedAt: run.startedAt } : {}),
+		...(run.endedAt !== null ? { endedAt: run.endedAt } : {}),
+		...(run.costUsd !== null ? { costUsd: run.costUsd } : {}),
+		...(run.tokensInput !== null ? { tokensInput: run.tokensInput } : {}),
+		...(run.tokensOutput !== null ? { tokensOutput: run.tokensOutput } : {}),
+		...(run.tokensCacheRead !== null ? { tokensCacheRead: run.tokensCacheRead } : {}),
+		...(autoOpenPr.warrenBaseUrl !== null ? { warrenBaseUrl: autoOpenPr.warrenBaseUrl } : {}),
+	});
+	return { title: content.title, body: content.body };
+}
+
+/**
+ * Build the `reopenPr` coordinator seam — reopens a run's PR when auto-open
+ * is enabled. Returns `undefined` when auto-open is disabled / tokenless.
+ */
+function createReopenPr(
+	deps: ReopenPrDeps,
+): ((runId: string) => Promise<string | null>) | undefined {
+	const { repos, warrenConfigs, autoOpenPr, runBranchPrefixDefault, logger } = deps;
+	if (!autoOpenPr.enabled || autoOpenPr.token === "") return undefined;
+	return async (runId: string): Promise<string | null> => {
+		try {
+			const run = await repos.runs.get(runId);
+			if (run === null || run.projectId === null) return null;
+			const project = await repos.projects.get(run.projectId);
+			if (project === null) return null;
+			const warrenConfig = await warrenConfigs.get(run.projectId, project.localPath);
+			const prefix = resolveRunBranchPrefix({
+				projectDefault: warrenConfig.defaults?.runBranchPrefix,
+				envDefault: runBranchPrefixDefault,
+			});
+			const branch = composeRunBranch(prefix, runId);
+			const parsed = parseGitHubUrl(project.gitUrl);
+			const content = buildReopenPrContent(run, autoOpenPr);
+			const result = await openPullRequest({
+				owner: parsed.owner,
+				repo: parsed.name,
+				head: branch,
+				base: project.defaultBranch,
+				title: content.title,
+				body: content.body,
+				token: autoOpenPr.token,
+			});
+			if (result.ok) return result.url;
+			logger.warn(
+				{ runId, reason: result.reason, message: result.message },
+				"plan_run.reopen_pr_failed",
+			);
+			return null;
+		} catch (err) {
+			logger.warn(
+				{ runId, reason: err instanceof Error ? err.message : String(err) },
+				"plan_run.reopen_pr_error",
+			);
+			return null;
+		}
+	};
+}
+
+export interface PlanRunWiringInput {
+	readonly env: EnvLike;
+	readonly repos: Repos;
+	readonly runtimeProvider: RuntimeProvider;
+	readonly bridges: BridgeRegistry;
+	readonly warrenConfigs: WarrenConfigCache;
+	readonly projectsConfig: ProjectsConfig;
+	readonly autoOpenPr: AutoOpenPrConfig;
+	readonly runBranchPrefixDefault?: string;
+	readonly seedsCli: SeedsCliDeps;
+	readonly projectSpawn: SpawnFn;
+	readonly logger: Logger;
+	readonly now?: () => Date;
+}
+
+/**
+ * Boot the plan-run coordinator (pl-a258 / warren-2623). Loads its
+ * env-driven config, constructs the coordinator (including the reopen-PR
+ * and Plot-transition closures), emits the disabled/running log itself,
+ * and returns the handle for teardown.
+ */
+export function bootPlanRunCoordinatorWiring(input: PlanRunWiringInput): PlanRunCoordinatorHandle {
+	const {
+		env,
+		repos,
+		runtimeProvider,
+		bridges,
+		warrenConfigs,
+		projectsConfig,
+		autoOpenPr,
+		runBranchPrefixDefault,
+		seedsCli,
+		projectSpawn,
+		logger,
+		now,
+	} = input;
+
+	const planRunCoordinatorConfig = loadPlanRunCoordinatorConfigFromEnv(env);
+	const planRunCoordinator = bootPlanRunCoordinator({
+		repos,
+		showSeed: async (projectId, seedId) => {
+			const project = await repos.projects.require(projectId);
+			return showSeed(seedsCli, project.localPath, seedId);
+		},
+		checkPrMerged: createPrMergeChecker({ token: autoOpenPr.token }),
+		resolveExecution: createResolveExecution(repos), // pl-fb43 step 5: per-child execution repo
+		reopenPr: createReopenPr({
+			repos,
+			warrenConfigs,
+			autoOpenPr,
+			logger,
+			...(runBranchPrefixDefault !== undefined ? { runBranchPrefixDefault } : {}),
+		}),
+		spawn: createPlanRunSpawn({
+			repos,
+			runtimeProvider,
+			bridges,
+			warrenConfigs,
+			projectsConfig,
+			projectSpawn,
+			seedsCli,
+			...(runBranchPrefixDefault !== undefined ? { runBranchPrefixDefault } : {}),
+			...(now !== undefined ? { now } : {}),
+		}),
+		// warren-b290 / pl-7937 step 5: auto-transition the bound Plot from
+		// `active` → `done` when every child of a Plot-bound PlanRun reaches a
+		// terminal state. Best-effort — see autoTransitionPlotToDone.
+		transitionPlot: async (planRun) => {
+			if (planRun.plotId === null) {
+				// Coordinator already guards on plotId, but narrow defensively
+				// so an unexpected null still produces a benign skip.
+				return { kind: "skipped", currentStatus: "unknown" };
+			}
+			const project = await repos.projects.require(planRun.projectId);
+			return autoTransitionPlotToDone({
+				setter: defaultPlotStatusSetter,
+				logger,
+				plotDir: join(project.localPath, ".plot"),
+				plotId: planRun.plotId,
+				handle: resolveDispatcherHandle(planRun.dispatcherHandle),
+				planRunId: planRun.id,
+			});
+		},
+		tickMs: planRunCoordinatorConfig.tickMs,
+		disabled: planRunCoordinatorConfig.disabled,
+		mergeTimeoutMs: planRunCoordinatorConfig.mergeTimeoutMs,
+		logger: planRunLoggerFromPino(logger),
+		...(now !== undefined ? { now } : {}),
+	});
+	if (planRunCoordinatorConfig.disabled) {
+		logger.info({}, "plan-run coordinator disabled via WARREN_PLAN_RUN_DISABLED");
+	} else {
+		logger.info({ tickMs: planRunCoordinatorConfig.tickMs }, "plan-run coordinator running");
+	}
+	return planRunCoordinator;
+}


### PR DESCRIPTION
## Summary

refactor(server): extract plan-run coordinator wiring into sibling module

## Run

- **Warren run:** `run_mdsnyjgr3981`
- **Agent:** pi
- **Cost:** $0.209 (10 in / 1.4k out / 320.4k cache-r)

## Seeds

- warren-8e91 — Decompose src/server/main/index.ts (547 lines, budget 548 -- the furthest-over grandfathered file in scripts/file-size-budgets.json NOT already covered by an open seed and NOT excluded as a parity-pinned schema barrel; warren-c65d targeted it but is CLOSED/incomplete, plan pl-c34d done) below the 500-line global limit by extracting the plan-run coordinator wiring into a new sibling src/server/main/plan-run-wiring.ts, mirroring the established *-wiring.ts precedent already in this directory (preview-wiring.ts, detector-wiring.ts, observability-wiring.ts, deps.ts, logging.ts, utils.ts). MOVE the contiguous block at src/server/main/index.ts lines 289-395 -- the comment `// Plan-run coordinator (pl-a258 / warren-2623)...` through the closing `}` of the `if (planRunCoordinatorConfig.disabled) { ... } else { logger.info({ tickMs: planRunCoordinatorConfig.tickMs }, "plan-run coordinator running"); }` log -- into a new exported function `bootPlanRunCoordinatorWiring(...)` in src/server/main/plan-run-wiring.ts. That block comprises: `const planRunCoordinatorConfig = loadPlanRunCoordinatorConfigFromEnv(env);`, the `const planRunCoordinator = bootPlanRunCoordinator({ ... })` construction INCLUDING its inline closures -- `showSeed` (calls showSeed(seedsCli, project.localPath, seedId)), `checkPrMerged: createPrMergeChecker({ token: autoOpenPr.token })`, `resolveExecution: createResolveExecution(repos)`, the conditional `reopenPr` async closure (the large block referencing repos/warrenConfigs/runBranchPrefixDefault/autoOpenPr/logger + resolveRunBranchPrefix/composeRunBranch/parseGitHubUrl/buildPrContent/openPullRequest), `spawn: createPlanRunSpawn({ repos, burrowClientPool, bridges: bridgesBoot.registry, warrenConfigs, projectsConfig, projectSpawn: defaultSpawn, seedsCli, runBranchPrefixDefault, now })`, and the `transitionPlot` async closure (referencing repos/logger/join + autoTransitionPlotToDone/defaultPlotStatusSetter/resolveDispatcherHandle) -- plus the `tickMs`/`disabled`/`mergeTimeoutMs`/`logger: planRunLoggerFromPino(logger)`/`now` fields and the trailing `if (disabled) { logger.info(...) } else { logger.info(...) }` log. The new `bootPlanRunCoordinatorWiring(args)` takes the in-scope values that block references as a typed args object (at minimum: env, repos, burrowClientPool, bridges [bridgesBoot.registry], warrenConfigs, projectsConfig, autoOpenPr, runBranchPrefixDefault, seedsCli, projectSpawn [defaultSpawn], logger, and now?: () => Date), loads the config, constructs the coordinator, emits the disabled/running log itself, and RETURNS the coordinator so the caller can call `.stop()` on it in teardown. Carry into plan-run-wiring.ts ONLY the imports that block uses: `join` from "node:path"; `loadPlanRunCoordinatorConfigFromEnv, bootPlanRunCoordinator, createPlanRunSpawn, createPrMergeChecker, createResolveExecution, defaultPlotStatusSetter, autoTransitionPlotToDone, resolveDispatcherHandle` from "../../plan-runs/index.ts"; `showSeed` from "../../seeds-cli/index.ts"; `resolveRunBranchPrefix, composeRunBranch` from "../../runs/index.ts"; `parseGitHubUrl` from "../../projects/index.ts"; `buildPrContent, openPullRequest` from "../../runs/pr.ts"; `planRunLoggerFromPino` from "./logging.ts"; plus type-only imports for the args object field types (Repos/BurrowClientPool/BridgeRegistry/WarrenConfigCache/ProjectsConfig/Logger/SpawnFn/etc. as typecheck demands) -- keep ONE copy of any shared helper, do NOT duplicate (jscpd check:dups will flag copy-paste). In src/server/main/index.ts: replace lines 289-395 with `const planRunCoordinator = bootPlanRunCoordinatorWiring({ env, repos, burrowClientPool, bridges: bridgesBoot.registry, warrenConfigs, projectsConfig, autoOpenPr, runBranchPrefixDefault, seedsCli, projectSpawn: defaultSpawn, logger, ...(opts.now !== undefined ? { now: opts.now } : {}) });` and REMOVE from main/index.ts the now-unused top-of-file imports that ONLY the moved block used (loadPlanRunCoordinatorConfigFromEnv, bootPlanRunCoordinator, createPlanRunSpawn, createPrMergeChecker, createResolveExecution, defaultPlotStatusSetter, autoTransitionPlotToDone, resolveDispatcherHandle, showSeed, resolveRunBranchPrefix, composeRunBranch, parseGitHubUrl, buildPrContent, openPullRequest, planRunLoggerFromPino) -- typecheck will flag any import that is now unused OR any that is still needed elsewhere; verify whether `join` from "node:path" is still used elsewhere in main/index.ts after the move (grep `join(` in the file) and drop it only if unused. The existing `await planRunCoordinator.stop();` call inside the returned handle's `stop()` teardown MUST remain unchanged (it now stops the coordinator returned by the wiring function). Do NOT alter bootServer's public signature, the BootServerOptions/WarrenServerHandle interfaces, the `export { resolvePgPoolMax } from "./utils.ts";` re-export, the `if (import.meta.main)` CLI entry, or any teardown ordering. Do NOT add a budget entry for plan-run-wiring.ts -- it must default-pass under the 500-line threshold. CRITICAL (docs/CONSTITUTION.md Article VI -- refactors prove runtime paths; file moves have broken production here before): src/server/main/index.ts is exec'd by the supervisor as `bun run src/server/main/index.ts` (see src/supervisor/main.test.ts:128,365 warrenCmd) and src/cli/commands/serve.ts imports bootServer from it -- this is an EXTRACTION into a sibling, NOT a rename/move; the path src/server/main/index.ts MUST remain and still export bootServer + be import.meta.main. AFTER extracting, run a repo-wide search for the old single-file assumption AND the new path across ALL file types -- `git grep -n "main/plan-run-wiring"` and `git grep -n "server/main/index"` (rg may be unavailable in the sandbox; use git grep) -- PLUS an explicit sweep of Dockerfile, docker-compose.yml, .github/workflows/*.yml, src/supervisor/ (supervisor/main.ts spawn + main.test.ts warrenCmd must still resolve `bun run src/server/main/index.ts`), src/cli/commands/serve.ts (bootServer import), src/server/main/index.test.ts, and docs/ -- and fix any stale reference. Verify: `wc -l src/server/main/index.ts src/server/main/plan-run-wiring.ts` each shows < 500 (expect ~440 / ~130) AND `bun run typecheck` is clean AND `bun test src/server/main/index.test.ts` passes with the same test count as before AND `bun run check:dups` exits 0 AND `bun run check:all` is fully green.

## Commits (1)

- 0edfe93 refactor(server): extract plan-run coordinator wiring into sibling module

## Files changed

```
src/server/main/index.ts           | 134 +++--------------------
 src/server/main/plan-run-wiring.ts | 213 +++++++++++++++++++++++++++++++++++++
 2 files changed, 226 insertions(+), 121 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-8e91
```

</details>

---

🤖 Opened by warren run `run_mdsnyjgr3981`