### PR TITLE
Remove the "src/server/main/index.ts": 548 entry from scripts/file-size…

### DIFF
--- a/scripts/file-size-budgets.json
+++ b/scripts/file-size-budgets.json
@@ -12,7 +12,6 @@
 		"src/runtime/k8s/provider.ts": 507,
 		"src/server/handlers/agents.test.ts": 533,
 		"src/server/handlers/plan-runs.ts": 505,
-		"src/server/main/index.ts": 548,
 		"src/triggers/tick.test.ts": 539,
 		"src/server/server.test.ts": 536,
 		"src/server/types.ts": 508,


### PR DESCRIPTION
## Summary

chore(size): drop satisfied src/server/main/index.ts budget entry

## Run

- **Warren run:** `run_9nf4t2vfvsac`
- **Agent:** pi
- **Cost:** $0.132 (10 in / 951 out / 182.7k cache-r)

## Seeds

- warren-e252 — Remove the "src/server/main/index.ts": 548 entry from scripts/file-size-budgets.json (delete that single line). Do NOT add a budget entry for the new sibling src/server/main/plan-run-wiring.ts -- it must default-pass under the 500-line threshold (confirm `wc -l src/server/main/plan-run-wiring.ts` shows < 500). Per docs/CONSTITUTION.md Article VI (refactors prove runtime paths -- file moves have broken production here before), before declaring done RE-RUN the repo-wide search for the path across ALL file types -- `git grep -n "server/main/index"` and `git grep -n "main/plan-run-wiring"` -- PLUS an explicit sweep of Dockerfile, docker-compose.yml, .github/workflows/*.yml, src/supervisor/ (supervisor/main.ts + main.test.ts warrenCmd MUST still resolve `bun run src/server/main/index.ts`), src/cli/commands/serve.ts (bootServer import must still resolve), src/server/main/index.test.ts, and docs/ -- and fix any stale reference. Verify: `bun run check:size` exits 0 AND `bun run check:dups` exits 0 AND `bun run check:all` is fully green (every gate stays green; both resulting files default-pass under the 500-line threshold).

## Commits (1)

- f79d7bc chore(size): drop satisfied src/server/main/index.ts budget entry

## Files changed

```
scripts/file-size-budgets.json | 1 -
 1 file changed, 1 deletion(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
work on sd warren-e252
```

</details>

---

🤖 Opened by warren run `run_9nf4t2vfvsac`