### PR TITLE
docs(readme): add Discord badge/section and reposition intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,19 @@
 
 Spawn cloud agents at your GitHub repos. Watch them work live, steer them mid-run, get a branch back.
 
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/4r6r5jUEFE)
 [![CI](https://github.com/jayminwest/warren/actions/workflows/ci.yml/badge.svg)](https://github.com/jayminwest/warren/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 [**Watch the demo**](https://youtu.be/daa7y8g9BkM)
 
-> A network of interconnected burrows. Agents that operate in isolation, self-manage, self-repair, and self-improve.
+> The Coolify of coding agents. Self-hosted control plane: point it at a repo, bring your own key, agents run in sandboxes on your infra, PRs come out.
 
-Warren is a self-hostable control plane for ephemeral coding agents. Runs are short-lived and sandboxed: they complete a task, validate the changes, push a branch, and spin down. Point it at your repos, dispatch from a browser or CLI, watch the events stream live, and reap the result. **One container, one volume, one HTTP API, one UI.**
+Warren is a self-hostable control plane for ephemeral coding agents. It's harness-agnostic — run pi, Claude Code, and other agents behind one interface — on your own infrastructure with your own API keys. Runs are short-lived and sandboxed: they complete a task, validate the changes, push a branch, and spin down. Point it at your repos, dispatch from a browser or CLI, watch the events stream live, and reap the result. **One container, one volume, one HTTP API, one UI.**
+
+## Community
+
+Questions, help, or feedback? [Join the Discord](https://discord.gg/4r6r5jUEFE).
 
 Warren runs against a swappable **runtime provider**, selected once at boot by `WARREN_RUNTIME` (`src/runtime/registry.ts`), behind one contract (`src/runtime/contract.ts`). Two topologies, same domain code:
 


### PR DESCRIPTION
## Summary

docs(readme): add Discord badge/section and reposition intro

## Run

- **Warren run:** `run_g6rpr05br9dv`
- **Agent:** pi
- **Cost:** $0.188 (20 in / 2.3k out / 141.9k cache-r)

## Commits (1)

- 950d36b docs(readme): add Discord badge/section and reposition intro

## Files changed

```
README.md | 9 +++++++--
 1 file changed, 7 insertions(+), 2 deletions(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
Update Warren's README.md for the new positioning and Discord launch. Two changes:

1. Discord visibility: add a Discord badge at the very top of README.md alongside any existing badges, linking to https://discord.gg/4r6r5jUEFE — use a static shields.io badge, e.g. [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/4r6r5jUEFE). Also add a short 'Community' section near the top (after the intro, before Quick Start) with one sentence inviting people to the Discord using the same link.

2. Positioning rewrite: replace the current about/tagline line ('control plane and UI for cloud-based custom agents that operate in isolation, self-manage, self-repair, and self-improve' or similar) with:

"The Coolify of coding agents. Self-hosted control plane: point it at a repo, bring your own key, agents run in sandboxes on your infra, PRs come out."

Adjust surrounding intro prose so it flows: mention Warren is harness-agnostic (pi, Claude Code, etc.) and runs on your infrastructure with your API keys. Do NOT change Quick Start, deploy instructions, roadmap, or other sections beyond what the intro needs. Tone: plain, confident, no marketing fluff, no emojis.

Note: another branch 'readme-discord-positioning' may exist locally elsewhere with similar changes — ignore it, work from main.
```

</details>

---

🤖 Opened by warren run `run_g6rpr05br9dv`