### PR TITLE
Fix stale README version tag and add version-sync gate test

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Engineering teams self-hosting their own agent infrastructure. The deployment un
 
 ## Status
 
-Stable (`0.9.10`), running on GKE in continuous use against real GitHub repos, with the Kubernetes runtime (`WARREN_RUNTIME=k8s`, pod-per-run) as the supported hosted target on GKE Autopilot. The end-to-end path is covered by 38 scenario-based acceptance tests in [`scripts/acceptance/`](scripts/acceptance/): manual runs, cron triggers, K8s pod dispatch (OOM fast-fail, steer delivery), Postgres backend, per-run preview environments, restart recovery, cost tracking, cost analytics, seeds-extensions roundtrip, serial plan-run dispatch, plan-run + Plot composition, Plot-workbench loop. The active frontier is the org-readiness cluster: SSO, remote workers, MCP, audit, budgets, GitHub App auth. See [ROADMAP.md](ROADMAP.md).
+Stable (`0.10.1`), running on GKE in continuous use against real GitHub repos, with the Kubernetes runtime (`WARREN_RUNTIME=k8s`, pod-per-run) as the supported hosted target on GKE Autopilot. The end-to-end path is covered by 38 scenario-based acceptance tests in [`scripts/acceptance/`](scripts/acceptance/): manual runs, cron triggers, K8s pod dispatch (OOM fast-fail, steer delivery), Postgres backend, per-run preview environments, restart recovery, cost tracking, cost analytics, seeds-extensions roundtrip, serial plan-run dispatch, plan-run + Plot composition, Plot-workbench loop. The active frontier is the org-readiness cluster: SSO, remote workers, MCP, audit, budgets, GitHub App auth. See [ROADMAP.md](ROADMAP.md).
 
 ## What you get
 

--- a/src/version-sync.test.ts
+++ b/src/version-sync.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { VERSION } from "./index.ts";
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+
+function readVersionFromPackageJson(): string {
+	const pkg = JSON.parse(readFileSync(resolve(REPO_ROOT, "package.json"), "utf8")) as {
+		version?: string;
+	};
+	if (!pkg.version) throw new Error("package.json is missing a version field");
+	return pkg.version;
+}
+
+/**
+ * The README "Status" section carries a human-facing version tag of the
+ * form ``Stable (`X.Y.Z`)``. It is the same version surfaced by
+ * package.json and src/index.ts, so it must never drift out of sync.
+ */
+function readVersionFromReadme(): string {
+	const readme = readFileSync(resolve(REPO_ROOT, "README.md"), "utf8");
+	const match = readme.match(/Stable \(`(\d+\.\d+\.\d+(?:-[\w.]+)?)`\)/);
+	if (!match?.[1]) {
+		throw new Error("README.md is missing a `Stable (`X.Y.Z`)` version tag");
+	}
+	return match[1];
+}
+
+describe("version sync", () => {
+	it("keeps README, package.json, and src/index.ts on the same version", () => {
+		const pkgVersion = readVersionFromPackageJson();
+		const readmeVersion = readVersionFromReadme();
+		expect(readmeVersion).toBe(pkgVersion);
+		expect(VERSION).toBe(pkgVersion);
+	});
+});


### PR DESCRIPTION
## Summary

Fix stale README version tag and add version-sync gate test

## Run

- **Warren run:** `run_9d34y3n0yq09`
- **Agent:** pi
- **Cost:** $0.371 (38 in / 3.9k out / 284.1k cache-r)

## Commits (1)

- 095b64d Fix stale README version tag and add version-sync gate test

## Files changed

```
README.md                |  2 +-
 src/version-sync.test.ts | 37 +++++++++++++++++++++++++++++++++++++
 2 files changed, 38 insertions(+), 1 deletion(-)
```

## Prompt

<details><summary>Show prompt</summary>

```
README's version badge is stale vs package.json. Fix it, then add a check to the gate suite that fails if they ever diverge again.
```

</details>

---

🤖 Opened by warren run `run_9d34y3n0yq09`