### PR TITLE
feat(release): announce new releases in Discord #releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,66 @@ jobs:
       deploy: true
       version: ${{ needs.release.outputs.version }}
 
+  # Announce the release in Discord #releases. This is a sibling of `deploy`,
+  # not a step inside `release`: the release is already cut and tagged by the
+  # time this runs, so a Discord outage must show as its own red job rather
+  # than turn a successful release red.
+  #
+  # The notes are read back from the release itself (`gh release view`) rather
+  # than re-parsed from CHANGELOG.md, so Discord can never disagree with what
+  # GitHub published, and the post is proof the release exists.
+  announce:
+    needs: release
+    if: needs.release.outputs.release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Post release notes to Discord
+        env:
+          # Discord channel webhook — docs/project-setup.md §6. Unlike
+          # AUTO_MERGE_PAT, its absence breaks nothing in the release
+          # pipeline, so a fork with no Discord server skips instead of
+          # failing. A webhook that is present but REJECTED is fatal.
+          WEBHOOK: ${{ secrets.DISCORD_RELEASES_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.release.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK}" ]; then
+            echo "::warning::DISCORD_RELEASES_WEBHOOK is not configured; skipping the Discord announcement (docs/project-setup.md §6)."
+            exit 0
+          fi
+          URL="https://github.com/${REPO}/releases/tag/v${VERSION}"
+          FULL=$(gh release view "v${VERSION}" --repo "${REPO}" --json body --jq .body)
+          # Discord caps an embed description at 4096 characters. Truncate on
+          # whole lines, never mid-character: a split UTF-8 sequence would
+          # produce a payload jq cannot encode.
+          NOTES=$(printf '%s\n' "${FULL}" | awk -v cap=3500 '{ n += length($0) + 1; if (n > cap) exit; print }')
+          if [ "${NOTES}" != "${FULL}" ]; then
+            NOTES="${NOTES}"$'\n\n'"… [read the full notes on GitHub](${URL})"
+          fi
+          jq -n \
+            --arg title "warren v${VERSION}" \
+            --arg url "${URL}" \
+            --arg notes "${NOTES}" \
+            --arg image "ghcr.io/${REPO}:v${VERSION}" \
+            '{
+              username: "warren",
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $notes,
+                color: 5793266,
+                footer: { text: ("docker pull " + $image) }
+              }]
+            }' > payload.json
+          curl --fail-with-body -sS --max-time 30 --retry 3 --retry-connrefused \
+            -H "Content-Type: application/json" \
+            -X POST -d @payload.json "${WEBHOOK}"
+          echo "Announced v${VERSION} in Discord."
+
   # AUTO_MERGE_PAT is a silent single point of failure (warren-8b5f). GitHub
   # suppresses workflow runs for GITHUB_TOKEN-authored pushes, so auto-merge.yml
   # must merge with a PAT; when that PAT expires, PRs simply stop merging, main

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -86,6 +86,24 @@ This is safe because the auto-merge workflow already scopes to `github.repositor
 
 Keep the required status check (e.g. `ci`) so PRs still must pass CI before merging.
 
+## 6. Add the `DISCORD_RELEASES_WEBHOOK` secret (optional)
+
+The `announce` job in `.github/workflows/release.yml` posts each new release to a Discord channel. It reads the notes back from the GitHub release, so Discord shows the same curated `CHANGELOG.md` section.
+
+In Discord, make the webhook:
+
+**Server Settings → Integrations → Webhooks → New Webhook**
+
+Point it at the `#releases` channel, name it `warren`, then copy the webhook URL.
+
+Give the URL to GitHub:
+
+```bash
+gh secret set DISCORD_RELEASES_WEBHOOK --repo owner/repo
+```
+
+The job skips with a warning when the secret is absent, so a fork without a Discord server still releases. A webhook that Discord rejects fails the job.
+
 ## Quick setup script
 
 For a new repo, run all the API calls at once:


### PR DESCRIPTION
## Summary

- Adds an `announce` job to `.github/workflows/release.yml` that posts each new release to a Discord channel webhook.
- Documents the `DISCORD_RELEASES_WEBHOOK` secret in `docs/project-setup.md` §6.

The job is a sibling of `deploy`, not a step inside `release`, on the same reasoning as `pat-heartbeat`: by the time it runs the release is already tagged, published and rolled out, so a Discord outage shows as its own red job rather than turning a successful release red. No `needs` edge points back into it.

Notes are read back from the published release (`gh release view --json body`) rather than re-parsed from `CHANGELOG.md`. There is then no second parser that can disagree with what GitHub published, and a successful read is proof the release exists.

Two edges worth naming for review:

- **Truncation cuts on whole lines** at ~3500 chars against Discord's 4096 embed cap. Cutting on a byte count can split a UTF-8 sequence, and `jq` cannot encode the result.
- **A missing `DISCORD_RELEASES_WEBHOOK` warns and skips; a rejected webhook fails the job.** This deliberately differs from `pat-heartbeat`, which hard-fails when `AUTO_MERGE_PAT` is absent. The failure modes differ: a dead PAT silently breaks the merge queue and stops releases, whereas an absent Discord webhook breaks nothing. A fork with no Discord server should still be able to release.

## Changes

- `.github/workflows/release.yml` — new `announce` job
- `docs/project-setup.md` — new §6

## Test plan

- [x] `bun run check:all` — 12/12 gates pass (pre-commit hook)
- [x] Payload built against the real v0.12.2 notes: valid JSON, correct render
- [x] Payload built against a 14KB synthetic body with accented characters and emoji at the cut boundary: truncated to 3135 chars, valid JSON, "read the full notes" link appended
- [x] v0.12.2 payload delivered to the live webhook; Discord returned the message object
- [x] `DISCORD_RELEASES_WEBHOOK` secret set on this repo

Not exercised end-to-end until the next real release, since `announce` is gated on `needs.release.outputs.release == 'true'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
