### PR TITLE
chore(ui): drop dead InteractiveAgentsConfig and stale plot comments

### DIFF
--- a/src/ui/src/App.tsx
+++ b/src/ui/src/App.tsx
@@ -64,9 +64,7 @@ export function App() {
 									</AuthGate>
 								}
 							>
-								{/* Runs is the home surface. The former Plot-first
-						    landing (DefaultLanding, warren-e59a) died with the
-						    plot deletion pass — warren-1f12 / pl-3a79 step 10. */}
+								{/* Runs is the home surface (warren-1f12 / pl-3a79 step 10). */}
 								<Route index element={<Navigate to="/runs" replace />} />
 								<Route path="/runs" element={<RunsPage />} />
 								{/* The two dispatch forms are the only pages whose whole

--- a/src/ui/src/api/types.ts
+++ b/src/ui/src/api/types.ts
@@ -146,9 +146,8 @@ export interface RunRow {
 	cloneKind: CloneKind | null;
 	/**
 	 * Run mode discriminator (pl-0344 step 1 / warren-67b6). Pinned at row
-	 * creation; warren-side only (burrow doesn't know about run mode). The
-	 * retired `interactive` / `conversation` values are gone from the enum
-	 * (warren-d622, warren-ee27), so `batch` is the only member today.
+	 * creation; warren-side only (burrow doesn't know about run mode).
+	 * `batch` is the only member today.
 	 */
 	mode: RunMode;
 	renderedAgentJson: unknown;
@@ -437,11 +436,6 @@ export interface CronTrigger {
 
 export type Trigger = CronTrigger;
 
-export interface InteractiveAgentsConfig {
-	brainstormRuntime?: "claude-code" | "sapling" | "pi";
-	plannerRuntime?: "claude-code" | "sapling" | "pi";
-}
-
 export interface DefaultsConfig {
 	defaultRole?: string;
 	defaultBranch?: string;
@@ -461,11 +455,6 @@ export interface DefaultsConfig {
 	 * verify which prefix is in effect.
 	 */
 	runBranchPrefix?: string;
-	/**
-	 * warren-b802: per-project override of the burrow runtime backing
-	 * the interactive built-in agents (brainstorm / planner).
-	 */
-	interactiveAgents?: InteractiveAgentsConfig;
 	qualityGate?: string;
 }
 

--- a/src/ui/src/components/ErrorBoundary.tsx
+++ b/src/ui/src/components/ErrorBoundary.tsx
@@ -5,13 +5,11 @@ import { Button } from "@/components/ui/button.tsx";
 /**
  * Route-level error boundary (warren-1f12).
  *
- * Motivation is a concrete production incident, not defensive habit: the
- * plot deletion pass dropped `runs.plot_id` server-side while RunDetail
- * still rendered a `r.plotId !== null` MetaCard. On the wire the field
- * became *absent*, so the guard read `undefined !== null` → true, and the
- * child dereferenced `plotId.length` → TypeError during render. With no
- * boundary mounted, React unmounted the entire root and every
- * `/#/runs/:id` deep link served a blank white page.
+ * Motivation is a concrete production incident, not defensive habit: a
+ * wire-shape drift left RunDetail reading a field the server had stopped
+ * sending, so a guard treated the absent value as present and a child
+ * threw during render. With no boundary mounted, React unmounted the
+ * entire root and every `/#/runs/:id` deep link served a blank white page.
  *
  * The stale field is fixed; this makes the *failure mode* survivable. A
  * throw inside the routed page now degrades to one error card with the

--- a/src/ui/src/components/StatusIndicator.tsx
+++ b/src/ui/src/components/StatusIndicator.tsx
@@ -13,10 +13,6 @@
  * inline `statusVariant()` switch in `RunDetail.tsx`) all delegate
  * here so adding a new state or swapping a colour token is a
  * one-line change rather than a multi-file grep.
- *
- * The `plot` kind was dropped in warren-f53e / pl-b82d step 19: the
- * surfaces it served were deleted in pl-3a79 and nothing rendered it
- * afterwards.
  */
 import {
 	Activity,

--- a/src/ui/src/components/ui/card.tsx
+++ b/src/ui/src/components/ui/card.tsx
@@ -16,10 +16,10 @@ import { cn } from "@/lib/utils.ts";
  *     promoted onto Card. Pairs with a translucent muted fill via
  *     a className override on call sites that need it.
  *
- * Phase 7 (warren-2221) will add an `interactive` variant (hover
- * border + shadow lift) once the PlotDetail decomposition surfaces
- * actual clickable-row sites — adding it now would just pay the
- * bundle-size cost for utilities no consumer references yet.
+ * An `interactive` variant (hover border + shadow lift) is deferred
+ * until clickable-row call sites exist — adding it now would just pay
+ * the bundle-size cost for utilities no consumer references yet
+ * (warren-2221).
  */
 const cardVariants = cva("border bg-(--color-card) text-(--color-fg)", {
 	variants: {

--- a/src/ui/src/components/ui/empty-state.tsx
+++ b/src/ui/src/components/ui/empty-state.tsx
@@ -6,12 +6,9 @@ import { cn } from "@/lib/utils.ts";
  * Phase 4 shared-state primitive (warren-36f0 / pl-55a3 step 5):
  *
  * EmptyState — a centered "nothing here yet" placeholder for list and
- * detail surfaces. Audit found ~12 ad-hoc empty branches across pages/
- * (Plots.tsx had its own local EmptyState, ProjectDetail.tsx had
- * EmptyHint, Runs/Projects/PlanRuns/PlotDetail used bare `<p>`
- * placeholders) — this primitive consolidates them so all empty
- * surfaces share the same vertical rhythm, icon size, and muted color
- * token.
+ * detail surfaces. Consolidates the former ad-hoc empty branches across
+ * pages so all empty surfaces share the same vertical rhythm, icon size,
+ * and muted color token.
  *
  * Slots:
  *   - `icon` — optional lucide-react icon component (constructor),

--- a/src/ui/src/components/ui/field.tsx
+++ b/src/ui/src/components/ui/field.tsx
@@ -6,9 +6,8 @@ import { Label } from "./label.tsx";
  * Phase 6 layout primitive (warren-e6b3 / pl-55a3 step 7):
  *
  * Field — wraps `<Label>` + control + optional description/error/hint
- * into the `space-y-1.5` stack that NewRun, NewPlanRun, ProjectDetail,
- * and the per-Plot form blocks all repeat by hand. Consolidating the
- * pattern means every form field gets:
+ * into the `space-y-1.5` stack that NewRun, NewPlanRun, and ProjectDetail
+ * all repeat by hand. Consolidating the pattern means every form field gets:
  *   - the same vertical rhythm,
  *   - the same `text-xs text-(--color-muted-foreground)` hint copy,
  *   - the same `text-(--color-destructive)` error voice,

--- a/src/ui/src/components/ui/filter-pill.tsx
+++ b/src/ui/src/components/ui/filter-pill.tsx
@@ -6,8 +6,7 @@ import { cn } from "@/lib/utils.ts";
  *
  * FilterPill — the canonical "rounded chip toggle" surface. Extracted
  * from Runs.tsx's inline FilterPill (the original implementation) so
- * Plots.tsx's `aria-pressed` toggles and any future filter strip can
- * share the active / hover / focus treatment.
+ * every filter strip can share the active / hover / focus treatment.
  *
  * Active pills paint with the primary token; inactive pills sit on
  * card with a subtle hover. `pressed` is mirrored to `aria-pressed`


### PR DESCRIPTION
## Summary
- Remove unused `InteractiveAgentsConfig` / `DefaultsConfig.interactiveAgents` from the UI wire types (residue from the deleted conversations surface)
- Rewrite UI comments that still cited deleted plot/conversation pages (`Plots.tsx`, `PlotDetail`, `DefaultLanding`, etc.), keeping the still-true rationale
- Skipped `skeleton.tsx` — already deleted elsewhere (`#638`)

Closes #640 (warren-bc6b)

## Test plan
- [x] `bun run check:all` (12/12 gates)
- [x] `bun run build:ui`
- [x] `rg 'interactiveAgents|InteractiveAgentsConfig' src/ui` → no matches
- [x] `rg -i 'plot|conversation|brainstorm' src/ui/src -g '*.ts' -g '*.tsx'` → no matches


Made with [Cursor](https://cursor.com)