### PR TITLE
fix(ui): capability-aware empty-state copy

### DIFF
--- a/src/ui-tests/capability-layer.test.ts
+++ b/src/ui-tests/capability-layer.test.ts
@@ -15,7 +15,9 @@
  *      can't be added to an ungated file without this test noticing;
  *   2. `AuthGate` decides from `/whoami`, never from a localStorage token;
  *   3. the two dispatch forms are route-guarded;
- *   4. nav entries whose destination is readOperator carry a capability.
+ *   4. nav entries whose destination is readOperator carry a capability;
+ *   5. no empty-state instruction points a spectator at a control the gate
+ *      removed (warren-b67b).
  */
 
 import { describe, expect, test } from "bun:test";
@@ -206,6 +208,76 @@ describe("redacted wire fields render on presence (warren-f53e)", () => {
 		// The rendered envelope (system prompt, canopy paths) is dropped for
 		// a spectator, so its half of the panel is operator-only.
 		expect(agents).toMatch(/<OperatorOnly capability="readOperator">\s*<AgentDefinitionInternals/);
+	});
+});
+
+/**
+ * Empty-state copy is capability-aware (warren-b67b).
+ *
+ * `OperatorOnly` removes the dispatch CTA and the add-project form for a
+ * public visitor, but the empty states kept the operator instruction —
+ * "Dispatch one above." pointed at nothing, so every empty list on
+ * `app.warren.run` was a dead end. The instruction now goes through
+ * `useOperatorHint`: an operator keeps it, a spectator gets the (already
+ * neutral) title alone.
+ */
+describe("empty states don't point a spectator at a hidden control (warren-b67b)", () => {
+	test("the hint hook yields the copy only for a caller holding the capability", () => {
+		const guard = read("components", "OperatorOnly.tsx");
+		expect(guard).toMatch(/export function useOperatorHint\(/);
+		expect(guard).toMatch(/return caps\.can\(capability\) \? hint : undefined;/);
+	});
+
+	test("EmptyState drops the description row when the hint is undefined", () => {
+		// Not cosmetic, and the reason this is a hook and not an
+		// `<OperatorOnly>` inside the slot: that would render nothing but
+		// still cost the row's `gap-2`.
+		expect(read("components", "ui", "empty-state.tsx")).toMatch(/\{description \? \(/);
+	});
+
+	test("the two dispatch lists gate their instruction on `dispatch`", () => {
+		for (const page of ["Runs.tsx", "PlanRuns.tsx"]) {
+			const src = read("pages", page);
+			expect(src).toMatch(/useOperatorHint\("Dispatch one above\."\)/);
+			expect(src).toMatch(/description=\{emptyHint\}/);
+		}
+	});
+
+	test("the projects list gates its instruction on `admin`, like AddProjectForm", () => {
+		// `POST /projects` is `admin`, not `dispatch` (warren-b875) — gating
+		// the copy on `dispatch` would print it for a caller who still can't
+		// see the form.
+		const projects = read("pages", "Projects.tsx");
+		expect(projects).toMatch(/useOperatorHint\("Add one with a GitHub URL above\.", "admin"\)/);
+		expect(projects).toMatch(/description=\{emptyHint\}/);
+	});
+
+	/**
+	 * The scaling half: gated copy travels as `useOperatorHint("…")` and
+	 * reaches the slot as an expression, so a description STRING LITERAL that
+	 * points at an on-page control ("… above") is by construction ungated.
+	 * That catches a fourth page without this test naming it.
+	 *
+	 * One named exemption, in the style of `GATED_ELSEWHERE` above:
+	 * `ready-plans.tsx` lives inside a `readOperator` tab that `PlanRuns.tsx`
+	 * drops for a spectator, so its "choose one above" never reaches one.
+	 *
+	 * Expression descriptions are outside the guard by design — the Agents
+	 * page's copy is a JSX fragment and its spectator issues are tracked
+	 * separately.
+	 */
+	test("no ungated empty-state literal points at an on-page control", () => {
+		const GATED_ELSEWHERE = new Set(["ready-plans.tsx"]);
+		const offenders: string[] = [];
+		for (const file of UI_FILES) {
+			const name = file.slice(file.lastIndexOf("/") + 1);
+			if (GATED_ELSEWHERE.has(name)) continue;
+			const literals = readFileSync(file, "utf8").match(/description="[^"]*"/g) ?? [];
+			if (literals.some((literal) => / above/.test(literal))) {
+				offenders.push(file.slice(UI_SRC.length + 1));
+			}
+		}
+		expect(offenders).toEqual([]);
 	});
 });
 

--- a/src/ui/src/components/OperatorOnly.tsx
+++ b/src/ui/src/components/OperatorOnly.tsx
@@ -52,3 +52,32 @@ export function OperatorRoute({
 	if (!caps.can(capability)) return <Navigate to="/runs" replace />;
 	return children;
 }
+
+/**
+ * Copy-level counterpart of `OperatorOnly`: return `hint` only for a caller
+ * holding `capability`, `undefined` otherwise (warren-b67b).
+ *
+ * The empty states were written for operators, so they instruct the reader
+ * to use the very control `OperatorOnly` removed — "Dispatch one above."
+ * points at nothing for a public visitor, which makes every empty list on
+ * `app.warren.run` a dead end. The `EmptyState` title already says
+ * "nothing here" on its own, so a spectator loses the instruction line
+ * rather than gaining a second, redundant one.
+ *
+ * A hook, not a wrapper component, because `EmptyState.description` is a
+ * slot: `<OperatorOnly>` inside it renders nothing but the description row
+ * still gets its `gap-2`, so a spectator pays 8px for an empty div.
+ * Returning `undefined` drops the row entirely.
+ *
+ * Call it unconditionally at the top of the component like any other hook —
+ * the empty branch it feeds renders conditionally, the hook must not.
+ * Defaults to `dispatch` to match `OperatorOnly`; pass the capability that
+ * gates the control the copy points at.
+ */
+export function useOperatorHint(
+	hint: ReactNode,
+	capability: CapabilityName = "dispatch",
+): ReactNode {
+	const caps = useCapabilities();
+	return caps.can(capability) ? hint : undefined;
+}

--- a/src/ui/src/pages/PlanRuns.tsx
+++ b/src/ui/src/pages/PlanRuns.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { planRunsApi, projectsApi } from "@/api/client.ts";
 import type { CapabilityName, PlanRunRow, PlanRunState, RunRow } from "@/api/types.ts";
-import { OperatorOnly } from "@/components/OperatorOnly.tsx";
+import { OperatorOnly, useOperatorHint } from "@/components/OperatorOnly.tsx";
 import { PlanRunStateBadge } from "@/components/PlanRunStateBadge.tsx";
 import { Alert } from "@/components/ui/alert.tsx";
 import { Button } from "@/components/ui/button.tsx";
@@ -105,6 +105,7 @@ export function PlanRunsPage() {
 		defaultDirections: { startedAt: "desc" },
 	});
 
+	const emptyHint = useOperatorHint("Dispatch one above.");
 	const canReadReady = caps.can(READY_TAB_CAPABILITY);
 	const visibleTabs = canReadReady ? TABS : TABS.filter((t) => t.value !== "ready");
 	const activeTab = tab === "ready" && !canReadReady ? "plan-runs" : tab;
@@ -190,10 +191,7 @@ export function PlanRunsPage() {
 								</Alert>
 							</div>
 						) : planRuns.data?.planRuns.length === 0 ? (
-							<EmptyState
-								title="No plan runs match this filter"
-								description="Dispatch one above."
-							/>
+							<EmptyState title="No plan runs match this filter" description={emptyHint} />
 						) : (
 							<Table>
 								<TableHeader>

--- a/src/ui/src/pages/Projects.tsx
+++ b/src/ui/src/pages/Projects.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { projectsApi } from "@/api/client.ts";
 import type { ProjectRow } from "@/api/types.ts";
-import { OperatorOnly } from "@/components/OperatorOnly.tsx";
+import { OperatorOnly, useOperatorHint } from "@/components/OperatorOnly.tsx";
 import { RefreshProjectsCTA } from "@/components/RefreshProjectsCTA.tsx";
 import { Alert } from "@/components/ui/alert.tsx";
 import { Button } from "@/components/ui/button.tsx";
@@ -85,6 +85,9 @@ export function ProjectsPage() {
 		mutationFn: (id: string) => projectsApi.refresh(id),
 		onSuccess: () => qc.invalidateQueries({ queryKey: ["projects"] }),
 	});
+	// `admin`, not the hook's `dispatch` default: `POST /projects` is an admin
+	// route (warren-b875), which is what gates `AddProjectForm` below.
+	const emptyHint = useOperatorHint("Add one with a GitHub URL above.", "admin");
 
 	return (
 		<div className="space-y-6">
@@ -127,7 +130,7 @@ export function ProjectsPage() {
 							</Alert>
 						</div>
 					) : projects.data?.projects.length === 0 ? (
-						<EmptyState title="No projects yet" description="Add one with a GitHub URL above." />
+						<EmptyState title="No projects yet" description={emptyHint} />
 					) : (
 						<Table>
 							<TableHeader>

--- a/src/ui/src/pages/Runs.tsx
+++ b/src/ui/src/pages/Runs.tsx
@@ -3,7 +3,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { agentsApi, projectsApi, runsApi } from "@/api/client.ts";
-import { OperatorOnly } from "@/components/OperatorOnly.tsx";
+import { OperatorOnly, useOperatorHint } from "@/components/OperatorOnly.tsx";
 import { StateBadge } from "@/components/StateBadge.tsx";
 import { Alert } from "@/components/ui/alert.tsx";
 import { Button } from "@/components/ui/button.tsx";
@@ -95,6 +95,7 @@ export function RunsPage() {
 		queryFn: ({ signal }) => runsApi.list(filterApi, signal),
 		refetchInterval: 5000,
 	});
+	const emptyHint = useOperatorHint("Dispatch one above.");
 
 	// Click cycles: inactive → desc → asc → (back to started/desc default).
 	const toggleSort = (key: SortKey): void => {
@@ -219,7 +220,7 @@ export function RunsPage() {
 							</Alert>
 						</div>
 					) : runs.data?.runs.length === 0 ? (
-						<EmptyState title="No runs match this filter" description="Dispatch one above." />
+						<EmptyState title="No runs match this filter" description={emptyHint} />
 					) : (
 						<Table>
 							<TableHeader>


### PR DESCRIPTION
## Summary
- Empty states on Runs, Plan runs and Projects told an anonymous visitor to "Dispatch one above." / "Add one with a GitHub URL above." — controls `OperatorOnly` had already removed, so every empty list on a public instance was a dead end
- The instruction now travels through `useOperatorHint`, a copy-level counterpart of `OperatorOnly` living in the same module and built on the same `useCapabilities().can()` check the issue pointed at
- Gated on the capability that gates the control the copy points at: `dispatch` for the two run lists, `admin` for the projects add form (`POST /projects` is `admin`, warren-b875)
- A spectator gets the title alone — already neutral ("No runs match this filter", "No projects yet"). Returning `undefined` rather than nesting `<OperatorOnly>` inside the slot matters: `EmptyState` then drops the description row instead of rendering an empty one that still costs its `gap-2`

Scope kept to the empty-state copy on those three pages; the Agents and Login spectator issues are tracked separately.

Closes #642 (warren-b67b)

## Test plan
- [x] `bun run check:all` — 12/12 gates (see the environment note below)
- [x] `bun run build:ui`
- [x] New `capability-layer.test.ts` block: per-page assertions plus a sweep that fails any literal `description="… above …"` (ungated by construction), so a fourth page can't reintroduce this without the test naming it. `ready-plans.tsx` is the one named exemption — its whole tab is `readOperator`
- [x] End to end against a real `WARREN_AUTH=public` instance (headless chromium over CDP; the SPA is a HashRouter):
  - spectator — all three lists render the title alone, one child node, no leftover gap, and no dispatch/add control anywhere
  - operator (token in localStorage) — both instructions return, wording unchanged
  - while `/whoami` is in flight the hint stays hidden, since `can()` is fail-closed, so nothing flashes on first paint

## Notes
- Repo-wide grep confirms these three were the only spectator-reachable empty states of this class. `pages/ready-plans.tsx` has similar copy but its tab is dropped for a spectator; `NewRun.tsx` / `NewPlanRun.tsx` sit behind `OperatorRoute`
- Article II: no budget moved. Coverage slack stays inside the 0.75pt limit — functions 89.69% vs floor 89.30%, lines 92.15% vs floor 91.85% — so no floor raise is due with this change
- **Environment note (Article I — stating it rather than waiving it):** on the tree as pushed, `check:coverage` is green on CI's ubuntu runners but red on a non-FHS host. `scripts/cloud-armor.test.ts` pins `PATH=<stub>:/usr/bin:/bin` for the dry-run spawn, so `#!/usr/bin/env bash` cannot resolve where bash lives outside those dirs (NixOS) and its four dry-run tests fail with `env: 'bash': No such file or directory`. Unrelated to this diff and pre-existing (reproduced on a clean `main`). The 12/12 above was measured with a one-line fix applied locally — appending the inherited PATH after the stub dir, which preserves the stub's shadowing — deliberately kept out of this PR to keep it to one concern. Happy to send it separately if wanted