### PR TITLE
fix(ui): repair the dead agent link and humanize wire enums for visitors

### DIFF
--- a/scripts/bundle-size-budgets.json
+++ b/scripts/bundle-size-budgets.json
@@ -6,20 +6,21 @@
 	"$comment_pl55a3_closeout_2026_05_29": "warren-bfc6 / pl-369d: pl-55a3 (warren-6358, frontend design-system revamp, v0.7.2) is now closed. The TEMPORARY overhaul ceilings raised across PR #197/#201 are collapsed to honest floors here. NOTE: pl-55a3 grew the bundle right up to its ceilings — the only metric with genuine room to ratchet down is gzip css (8500 → 8200). raw js, raw css, and gzip js are at their true floors and cannot drop. The first attempt at this closeout (commit c2a3ba5) set gzip js to 172580 from a number that was NOT produced by `bun run check:bundle-size` — it matched Vite's build-log reporter (~2KB cooler), so when CI ran the actual script the identical bytes gzipped to 173931 and the guard failed. Re-baselined from the actual check script on a clean --frozen-lockfile build (byte-identical to CI): gzip js 173931 / raw js 583998 / gzip css 8005 / raw css 40432 (largest chunk == totals — single js + single css asset). Budgets = those figures + a small churn headroom. The bulk of the js floor is the Phase 5 motion layer (framer-motion v12 via strict LazyMotion + domAnimation, NOT the full motion proxy). The 'ratchet only goes down' rule is back in force from here — future UI work must hold flat or shrink against THIS floor.",
 	"$comment_plot_ui_deletion_2026_07_26": "RATCHET DOWN (warren-1f12 / pl-3a79 step 10): the plot UI deletion removed ~3.8k LOC of pages and components (plot-detail/, PlotSummary, the Workspace surface, NewPlotButton, PlotStatusBadge, PlotMetaCardContent, DefaultLanding) plus the plotsApi client block and the plot type region. Re-baselined via `bun run check:bundle-size --update` on a clean --frozen-lockfile build: gzip js totals 299685 -> 285902, largest chunk 174236 -> 160480, gzip css 8362 -> 7897. Lowering, so it applies unconditionally. This is the new floor.",
 	"$comment_capability_layer_2026_07_27": "BOUNDED AUTO-RAISE (warren-f53e / pl-b82d step 19): the UI capability layer adds the useCapabilities hook, the OperatorOnly / OperatorRoute wrappers, and ~25 wrap sites across the pages, against which the deleted PLOT_STATUS registry and the RefreshProjectsCTA label prop return only a few hundred bytes. Net +673 B gzip js / +1984 B raw js — ordinary feature growth, well inside AUTO_RAISE_CAP, re-baselined via `bun run check:bundle-size --update` on a clean --frozen-lockfile build. No new dependency. The 'ratchet only goes down' rule resumes from here.",
+	"$comment_public_labels_2026_07_30": "BOUNDED AUTO-RAISE (warren-14fc / #641): src/ui/src/lib/labels.ts adds the visitor-facing label maps for run / plan-run failure reasons plus the plan-run child rollup, and the call sites that consume them. Net +607 B gzip js / +1211 B raw js — ordinary feature growth, well inside AUTO_RAISE_CAP, re-baselined via `bun run check:bundle-size --update` on a clean --frozen-lockfile build. No new dependency. CSS shrank (no new utilities) and is ratcheted down to its measured floor. The 'ratchet only goes down' rule resumes from here.",
 	"totals": {
 		"raw": {
-			"js": 944073,
-			"css": 38509
+			"js": 945284,
+			"css": 37779
 		},
 		"gzip": {
-			"js": 285757,
-			"css": 7899
+			"js": 286364,
+			"css": 7781
 		}
 	},
 	"largest": {
 		"gzip": {
-			"js": 160340,
-			"css": 7899
+			"js": 160918,
+			"css": 7781
 		}
 	}
 }

--- a/scripts/file-size-budgets.json
+++ b/scripts/file-size-budgets.json
@@ -15,7 +15,7 @@
 		"src/server/types.ts": 508,
 		"src/ui/src/api/client.ts": 728,
 		"src/ui/src/api/types.ts": 776,
-		"src/ui/src/pages/RunDetail.tsx": 1103,
+		"src/ui/src/pages/RunDetail.tsx": 1101,
 		"src/warren-config/schema.ts": 504
 	}
 }

--- a/src/ui/src/components/StatusIndicator.tsx
+++ b/src/ui/src/components/StatusIndicator.tsx
@@ -13,6 +13,11 @@
  * inline `statusVariant()` switch in `RunDetail.tsx`) all delegate
  * here so adding a new state or swapping a colour token is a
  * one-line change rather than a multi-file grep.
+ *
+ * `<RunFailureBadge>` at the bottom is the same idea for the OTHER
+ * enum a run row carries — its `failureReason`. It lives here rather
+ * than in the page so the "prose for the visitor, raw value in the
+ * tooltip" rule has one owner too (warren-14fc / #641).
  */
 import {
 	Activity,
@@ -29,6 +34,7 @@ import {
 } from "lucide-react";
 import type { ComponentProps } from "react";
 import { Badge } from "@/components/ui/badge.tsx";
+import { formatRunFailureReason, humanizeWireValue } from "@/lib/labels.ts";
 import { cn } from "@/lib/utils.ts";
 
 type BadgeVariant = NonNullable<ComponentProps<typeof Badge>["variant"]>;
@@ -74,7 +80,9 @@ const PLAN_RUN_CHILD_STATUS: Record<string, StatusMeta> = {
 	pending: { label: "pending", variant: "secondary", icon: CircleDashed, pulse: false },
 	dispatched: { label: "dispatched", variant: "queued", icon: PlayCircle, pulse: false },
 	running: { label: "running", variant: "running", icon: Activity, pulse: true },
-	pr_open: { label: "pr_open", variant: "queued", icon: GitPullRequest, pulse: false },
+	// The one status whose wire value is not already a readable word
+	// (warren-14fc / #641) — a public visitor should not be shown `pr_open`.
+	pr_open: { label: "PR open", variant: "queued", icon: GitPullRequest, pulse: false },
 	merged: { label: "merged", variant: "succeeded", icon: CheckCircle2, pulse: false },
 	failed: { label: "failed", variant: "failed", icon: XCircle, pulse: false },
 	skipped: { label: "skipped", variant: "cancelled", icon: MinusCircle, pulse: false },
@@ -118,14 +126,16 @@ const SECONDARY_META: StatusMeta = {
 
 /**
  * Look up the `StatusMeta` for a `(kind, status)` pair. Returns a
- * `secondary` fallback (with the original status string as the
- * label) when the kind or status is unknown so the UI keeps
- * rendering something useful instead of crashing.
+ * `secondary` fallback when the kind or status is unknown so the UI
+ * keeps rendering something useful instead of crashing. The unknown
+ * status is humanized rather than printed raw — the dashboard is
+ * public, so a status this registry has not caught up with must still
+ * not reach a visitor as `some_new_state` (warren-14fc / #641).
  */
 export function getStatusMeta(kind: StatusKind, status: string): StatusMeta {
 	const entry = REGISTRY[kind][status];
 	if (entry !== undefined) return entry;
-	return { ...SECONDARY_META, label: status };
+	return { ...SECONDARY_META, label: humanizeWireValue(status) };
 }
 
 export interface StatusIndicatorProps {
@@ -170,6 +180,20 @@ export function StatusIndicator({
 				/>
 			) : null}
 			{showLabel ? <span>{label ?? meta.label}</span> : null}
+		</Badge>
+	);
+}
+
+/**
+ * A failed run's `failureReason` as a pill. The label is prose so a
+ * public visitor is never shown `finalize_failed`; the raw
+ * discriminator stays in the tooltip so an operator can still read
+ * exactly what the server recorded.
+ */
+export function RunFailureBadge({ reason }: { reason: string }) {
+	return (
+		<Badge variant="cancelled" className="text-xs" title={`Failure reason: ${reason}`}>
+			{formatRunFailureReason(reason)}
 		</Badge>
 	);
 }

--- a/src/ui/src/lib/labels.test.ts
+++ b/src/ui/src/lib/labels.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+// Relative import, not the `@/` alias — this file runs under the repo-root
+// `bun test`, which resolves no `@/` (see use-capabilities.helpers.ts).
+import { RUN_FAILURE_REASONS } from "../../../core/wire.ts";
+import {
+	formatChildStateCounts,
+	formatPlanRunFailureReason,
+	formatRunFailureReason,
+	humanizeWireValue,
+} from "./labels.ts";
+
+/**
+ * Warren's dashboard is public, so the guarantee under test is narrow and
+ * absolute: nothing these helpers return may still look like a wire enum
+ * (warren-14fc / #641). The exhaustiveness case walks the canonical
+ * `RUN_FAILURE_REASONS` tuple from `src/core/wire.ts` rather than a local
+ * copy, so a reason added to the kernel without a label fails here.
+ */
+
+describe("humanizeWireValue", () => {
+	test("capitalises the first word and spaces the rest", () => {
+		expect(humanizeWireValue("no_model_response")).toBe("No model response");
+	});
+
+	test("upper-cases the pr acronym in any position", () => {
+		expect(humanizeWireValue("pr_open")).toBe("PR open");
+		expect(humanizeWireValue("pr_closed_without_merge")).toBe("PR closed without merge");
+	});
+
+	test("survives degenerate input", () => {
+		expect(humanizeWireValue("")).toBe("");
+		expect(humanizeWireValue("___")).toBe("___");
+		expect(humanizeWireValue("crashed")).toBe("Crashed");
+		expect(humanizeWireValue("__none__")).toBe("None");
+	});
+});
+
+describe("formatRunFailureReason", () => {
+	test("maps every canonical reason to prose", () => {
+		for (const reason of RUN_FAILURE_REASONS) {
+			const label = formatRunFailureReason(reason);
+			expect(label).not.toContain("_");
+			expect(label).not.toBe(reason);
+		}
+	});
+
+	test("uses the curated wording, not a mechanical de-underscore", () => {
+		expect(formatRunFailureReason("finalize_failed")).toBe("Finalize failed");
+		expect(formatRunFailureReason("oom_killed")).toBe("Out of memory");
+		expect(formatRunFailureReason("burrow_run_lost")).toBe("Sandbox run lost");
+	});
+
+	test("falls back to humanized prose for an unmapped reason", () => {
+		expect(formatRunFailureReason("some_future_reason")).toBe("Some future reason");
+	});
+});
+
+describe("formatPlanRunFailureReason", () => {
+	test("humanizes a bare discriminator", () => {
+		expect(formatPlanRunFailureReason("pr_closed_without_merge")).toBe("PR closed without merge");
+		expect(formatPlanRunFailureReason("parent_pr_merge_timeout")).toBe("Parent PR merge timeout");
+	});
+
+	test("keeps the free-text detail verbatim in parentheses", () => {
+		expect(formatPlanRunFailureReason("child_seed_not_found:warren-a")).toBe(
+			"Child seed not found (warren-a)",
+		);
+		expect(formatPlanRunFailureReason("dispatch_failed:burrow unreachable")).toBe(
+			"Dispatch failed (burrow unreachable)",
+		);
+	});
+
+	test("drops an empty detail rather than rendering empty parentheses", () => {
+		expect(formatPlanRunFailureReason("dispatch_failed:")).toBe("Dispatch failed");
+		expect(formatPlanRunFailureReason("dispatch_failed:   ")).toBe("Dispatch failed");
+	});
+});
+
+describe("formatChildStateCounts", () => {
+	test("renders an em-dash with no children", () => {
+		expect(formatChildStateCounts([])).toEqual({ text: "—", title: "No child seeds yet" });
+	});
+
+	test("spells out only the non-empty buckets", () => {
+		const summary = formatChildStateCounts([
+			{ state: "pending" },
+			{ state: "pending" },
+			{ state: "merged" },
+			{ state: "failed" },
+		]);
+		expect(summary.text).toBe("2 pending · 1 merged · 1 failed");
+		expect(summary.title).toBe(
+			"4 child seeds: 2 pending, 0 in flight, 1 merged, 0 skipped, 1 failed",
+		);
+	});
+
+	test("folds dispatched, running and pr_open into one in-flight bucket", () => {
+		const summary = formatChildStateCounts([
+			{ state: "dispatched" },
+			{ state: "running" },
+			{ state: "pr_open" },
+		]);
+		expect(summary.text).toBe("3 in flight");
+	});
+
+	test("counts skipped separately from merged", () => {
+		const summary = formatChildStateCounts([{ state: "merged" }, { state: "skipped" }]);
+		expect(summary.text).toBe("1 merged · 1 skipped");
+	});
+
+	test("singularises the tooltip for one child", () => {
+		expect(formatChildStateCounts([{ state: "running" }]).title).toBe(
+			"1 child seed: 0 pending, 1 in flight, 0 merged, 0 skipped, 0 failed",
+		);
+	});
+});

--- a/src/ui/src/lib/labels.ts
+++ b/src/ui/src/lib/labels.ts
@@ -1,0 +1,159 @@
+/**
+ * Visitor-facing labels for warren's wire vocabulary (warren-14fc / #641).
+ *
+ * Warren serves a PUBLIC read-only dashboard, so anything a component
+ * renders straight off the wire is read by anonymous visitors. Several
+ * surfaces were printing the raw discriminator — `finalize_failed`,
+ * `pr_closed_without_merge` — or internal shorthand (`2p / 0i / 3m / 1f`).
+ * This module is the ONE place a wire value becomes prose; call it instead
+ * of inlining a string literal in a component.
+ *
+ * Two rules the call sites follow:
+ *
+ *   - The raw value always survives in a `title` tooltip, so an operator
+ *     can still read the discriminator the server actually recorded.
+ *   - Unknown values degrade through `humanizeWireValue` rather than
+ *     leaking underscores, so a reason added server-side before this UI
+ *     ships still reads as prose.
+ *
+ * Status-PILL labels are deliberately NOT here: `components/StatusIndicator.tsx`
+ * is already the single registry for `{label, variant, icon, pulse}`, and a
+ * second copy of those labels is exactly the drift this file exists to
+ * prevent. It imports `humanizeWireValue` for its unknown-status fallback.
+ */
+import type { PlanRunChildState, RunFailureReason } from "@/api/types.ts";
+
+/**
+ * Snake-case words that read wrong when merely capitalised. Kept tiny on
+ * purpose — this is a display nicety, not a dictionary.
+ */
+const ACRONYMS: Readonly<Record<string, string>> = { pr: "PR" };
+
+/**
+ * Generic fallback: `no_model_response` → `No model response`,
+ * `pr_open` → `PR open`. Used wherever an explicit map has no entry.
+ */
+export function humanizeWireValue(raw: string): string {
+	const words = raw.split("_").filter((w) => w.length > 0);
+	if (words.length === 0) return raw;
+	return words
+		.map((w, i) => ACRONYMS[w] ?? (i === 0 ? `${w.charAt(0).toUpperCase()}${w.slice(1)}` : w))
+		.join(" ");
+}
+
+/**
+ * `RunFailureReason` → prose. Annotated `Record<string, string>` so a
+ * lookup with an arbitrary wire string type-checks, and `satisfies` so the
+ * compiler still fails the build when `src/core/wire.ts` grows a reason
+ * this map does not carry.
+ *
+ * `burrow_run_lost` / `burrow_unreachable` say "sandbox", not "burrow":
+ * burrow is the LocalProvider's substrate, an implementation detail a
+ * visitor has no name for. The raw value stays in the tooltip.
+ */
+const RUN_FAILURE_REASON_LABELS: Readonly<Record<string, string>> = {
+	never_started: "Never started",
+	no_model_response: "No model response",
+	crashed: "Crashed",
+	timed_out: "Timed out",
+	burrow_run_lost: "Sandbox run lost",
+	burrow_unreachable: "Sandbox unreachable",
+	dropped_commit: "Dropped commit",
+	finalize_failed: "Finalize failed",
+	provider_error: "Provider error",
+	oom_killed: "Out of memory",
+	evicted: "Evicted",
+} satisfies Record<RunFailureReason, string>;
+
+/** Prose for a run's `failureReason`. */
+export function formatRunFailureReason(reason: string): string {
+	return RUN_FAILURE_REASON_LABELS[reason] ?? humanizeWireValue(reason);
+}
+
+/**
+ * Plan-run failure text is NOT an enum — the coordinator writes free-form
+ * `reason` or `reason:detail` strings (`pr_closed_without_merge`,
+ * `dispatch_failed:burrow unreachable`, `child_seed_not_found:warren-a`).
+ * There is no closed set to map exhaustively, so humanize the
+ * discriminator half and keep the detail verbatim in parentheses.
+ */
+export function formatPlanRunFailureReason(reason: string): string {
+	const sep = reason.indexOf(":");
+	if (sep === -1) return humanizeWireValue(reason);
+	const label = humanizeWireValue(reason.slice(0, sep));
+	const detail = reason.slice(sep + 1).trim();
+	return detail.length === 0 ? label : `${label} (${detail})`;
+}
+
+/**
+ * Buckets for the plan-run child rollup, in display order. The list page
+ * used to render these as `2p / 0i / 3m / 1f` — undocumented single-letter
+ * jargon in a public table.
+ *
+ * `skipped` gets its own bucket rather than being folded into `merged`
+ * (which is what the letter form did): once the counts are spelled out,
+ * calling a child that was never dispatched "merged" is simply wrong.
+ *
+ * Container shape follows the `src/core/wire.ts` convention — a frozen
+ * `as const` tuple with the union derived FROM it, so display order is
+ * complete by construction and `Record<ChildBucket, …>` makes the
+ * compiler demand a label and a counter for every bucket.
+ */
+const CHILD_BUCKET_ORDER = ["pending", "inflight", "merged", "skipped", "failed"] as const;
+type ChildBucket = (typeof CHILD_BUCKET_ORDER)[number];
+
+const CHILD_BUCKET_LABELS: Record<ChildBucket, string> = {
+	pending: "pending",
+	inflight: "in flight",
+	merged: "merged",
+	skipped: "skipped",
+	failed: "failed",
+};
+
+function bucketFor(state: PlanRunChildState): ChildBucket {
+	switch (state) {
+		case "pending":
+			return "pending";
+		case "dispatched":
+		case "running":
+		case "pr_open":
+			return "inflight";
+		case "merged":
+			return "merged";
+		case "skipped":
+			return "skipped";
+		case "failed":
+			return "failed";
+	}
+}
+
+export interface ChildStateSummary {
+	/** Cell text — non-empty buckets only, e.g. `2 pending · 3 merged`. */
+	text: string;
+	/** Tooltip — the full breakdown, including the empty buckets. */
+	title: string;
+}
+
+/** Roll a plan-run's children up into a readable count line plus tooltip. */
+export function formatChildStateCounts(
+	children: readonly { state: PlanRunChildState }[],
+): ChildStateSummary {
+	const counts: Record<ChildBucket, number> = {
+		pending: 0,
+		inflight: 0,
+		merged: 0,
+		skipped: 0,
+		failed: 0,
+	};
+	for (const c of children) counts[bucketFor(c.state)] += 1;
+
+	const phrase = (b: ChildBucket): string => `${counts[b]} ${CHILD_BUCKET_LABELS[b]}`;
+	const nonEmpty = CHILD_BUCKET_ORDER.filter((b) => counts[b] > 0);
+	if (nonEmpty.length === 0) {
+		return { text: "—", title: "No child seeds yet" };
+	}
+	return {
+		text: nonEmpty.map(phrase).join(" · "),
+		title: `${children.length} child seed${children.length === 1 ? "" : "s"}: ${CHILD_BUCKET_ORDER.map(phrase).join(", ")}`,
+	};
+}

--- a/src/ui/src/pages/Agents.tsx
+++ b/src/ui/src/pages/Agents.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { agentsApi, projectsApi } from "@/api/client.ts";
 import type { AgentRow } from "@/api/types.ts";
 import { OperatorOnly } from "@/components/OperatorOnly.tsx";
@@ -49,7 +50,13 @@ export function AgentsPage() {
 		queryFn: ({ signal }) =>
 			agentsApi.list(projectFilter.length > 0 ? { projectId: projectFilter } : {}, signal),
 	});
-	const [openName, setOpenName] = useState<string | null>(null);
+	// `?agent=<name>` pre-expands one row. It is what the Run Analytics
+	// per-agent table links to (warren-14fc / #641): there is no
+	// agent-detail page, so the deep link lands the visitor on the list
+	// with the agent they clicked already open. Read once at mount — no
+	// in-page control rewrites the param, so there is nothing to sync.
+	const [searchParams] = useSearchParams();
+	const [openName, setOpenName] = useState<string | null>(() => searchParams.get("agent"));
 	const { sorted, sort, onSort } = useClientSort(agents.data?.agents ?? [], AGENT_COMPARATORS, {
 		initialKey: "name",
 		defaultDirections: { registeredAt: "desc", lastRefreshed: "desc" },

--- a/src/ui/src/pages/PlanRunDetail.tsx
+++ b/src/ui/src/pages/PlanRunDetail.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import { Spinner } from "@/components/ui/spinner.tsx";
 import { formatError } from "@/lib/format-error.ts";
+import { formatPlanRunFailureReason } from "@/lib/labels.ts";
 import { formatTimestamp, relativeTime } from "@/lib/utils.ts";
 import { PlanRunChildTable } from "./plan-run-detail/child-table.tsx";
 import { formatCostUsd } from "./RunDetail.tsx";
@@ -59,11 +60,10 @@ export function PlanRunDetailPage() {
 						<h1 className="font-mono text-xl font-semibold">{planRun.id}</h1>
 						<PlanRunStateBadge state={planRun.state} />
 						{planRun.state === "failed" && planRun.failureReason !== null ? (
-							<span
-								className="font-mono text-xs text-(--color-destructive)"
-								title={planRun.failureReason}
-							>
-								{planRun.failureReason}
+							// Prose for the visitor, raw reason in the tooltip for the
+							// operator (warren-14fc / #641).
+							<span className="text-xs text-(--color-destructive)" title={planRun.failureReason}>
+								{formatPlanRunFailureReason(planRun.failureReason)}
 							</span>
 						) : null}
 					</div>

--- a/src/ui/src/pages/PlanRuns.tsx
+++ b/src/ui/src/pages/PlanRuns.tsx
@@ -2,13 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { planRunsApi, projectsApi } from "@/api/client.ts";
-import type {
-	CapabilityName,
-	PlanRunChildState,
-	PlanRunRow,
-	PlanRunState,
-	RunRow,
-} from "@/api/types.ts";
+import type { CapabilityName, PlanRunRow, PlanRunState, RunRow } from "@/api/types.ts";
 import { OperatorOnly } from "@/components/OperatorOnly.tsx";
 import { PlanRunStateBadge } from "@/components/PlanRunStateBadge.tsx";
 import { Alert } from "@/components/ui/alert.tsx";
@@ -30,6 +24,7 @@ import {
 import { useCapabilities } from "@/hooks/use-capabilities.ts";
 import { type Comparator, compareStrings, useClientSort } from "@/hooks/use-client-sort.ts";
 import { formatError } from "@/lib/format-error.ts";
+import { formatChildStateCounts } from "@/lib/labels.ts";
 import { relativeTime } from "@/lib/utils.ts";
 import { formatCostUsd } from "./RunDetail.tsx";
 import { ReadyPlansView } from "./ready-plans.tsx";
@@ -273,7 +268,7 @@ function PlanRunListRow({
 		queryFn: ({ signal }) => planRunsApi.get(planRunId, signal),
 		refetchInterval: 5000,
 	});
-	const counts = summarizeChildren(detail.data?.children ?? []);
+	const counts = formatChildStateCounts(detail.data?.children ?? []);
 	const cost = summarizeCost(detail.data?.runs ?? []);
 	return (
 		<TableRow>
@@ -291,8 +286,8 @@ function PlanRunListRow({
 			<TableCell className="whitespace-nowrap font-mono text-xs">{planId}</TableCell>
 			<TableCell className="whitespace-nowrap font-mono text-xs">{projectLabel}</TableCell>
 			<TableCell className="whitespace-nowrap">{agentName}</TableCell>
-			<TableCell className="whitespace-nowrap font-mono text-xs text-(--color-muted-foreground)">
-				{counts}
+			<TableCell className="text-xs text-(--color-muted-foreground)" title={counts.title}>
+				{counts.text}
 			</TableCell>
 			<TableCell
 				className="whitespace-nowrap font-mono text-xs text-(--color-muted-foreground)"
@@ -333,22 +328,4 @@ function summarizeCost(runs: RunRow[]): {
 		}
 	}
 	return { sum, priced, total: runs.length };
-}
-
-function summarizeChildren(children: { state: PlanRunChildState }[]): string {
-	if (children.length === 0) return "—";
-	const buckets: Record<"pending" | "inflight" | "merged" | "failed", number> = {
-		pending: 0,
-		inflight: 0,
-		merged: 0,
-		failed: 0,
-	};
-	for (const c of children) {
-		if (c.state === "pending") buckets.pending += 1;
-		else if (c.state === "dispatched" || c.state === "running" || c.state === "pr_open")
-			buckets.inflight += 1;
-		else if (c.state === "merged" || c.state === "skipped") buckets.merged += 1;
-		else if (c.state === "failed") buckets.failed += 1;
-	}
-	return `${buckets.pending}p / ${buckets.inflight}i / ${buckets.merged}m / ${buckets.failed}f`;
 }

--- a/src/ui/src/pages/RunDetail.tsx
+++ b/src/ui/src/pages/RunDetail.tsx
@@ -14,7 +14,7 @@ import type {
 import { isActivePreviewState, isTerminalRunState } from "@/api/types.ts";
 import { OperatorOnly } from "@/components/OperatorOnly.tsx";
 import { StateBadge } from "@/components/StateBadge.tsx";
-import { StatusIndicator } from "@/components/StatusIndicator.tsx";
+import { RunFailureBadge, StatusIndicator } from "@/components/StatusIndicator.tsx";
 import { Alert } from "@/components/ui/alert.tsx";
 import { Badge } from "@/components/ui/badge.tsx";
 import { Button } from "@/components/ui/button.tsx";
@@ -124,9 +124,7 @@ export function RunDetailPage() {
 						<h1 className="font-mono text-xl font-semibold">{r.id}</h1>
 						<StateBadge state={r.state} />
 						{r.state === "failed" && r.failureReason !== null ? (
-							<Badge variant="cancelled" className="font-mono text-xs">
-								{r.failureReason}
-							</Badge>
+							<RunFailureBadge reason={r.failureReason} />
 						) : null}
 						{reap !== null && reap.branchPushed === true && reap.commitsAhead === 0 ? (
 							<Badge

--- a/src/ui/src/pages/plan-run-detail/child-table.tsx
+++ b/src/ui/src/pages/plan-run-detail/child-table.tsx
@@ -11,6 +11,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table.tsx";
+import { formatPlanRunFailureReason } from "@/lib/labels.ts";
 import { relativeTime } from "@/lib/utils.ts";
 
 /**
@@ -19,6 +20,10 @@ import { relativeTime } from "@/lib/utils.ts";
  * failure reason. Extracted from PlanRunDetail (warren-d17f / pl-0008 step 9)
  * so the Workspace Run tab can embed the same surface instead of forking a
  * second renderer.
+ *
+ * The failure column is coordinator free text (`reason` or `reason:detail`),
+ * so it goes through `formatPlanRunFailureReason` before a visitor sees it;
+ * the raw string stays in the cell's tooltip (warren-14fc / #641).
  */
 export function PlanRunChildTable({
 	planChildren,
@@ -108,8 +113,11 @@ export function PlanRunChildTable({
 												<span className="text-(--color-muted-foreground)">—</span>
 											)}
 										</TableCell>
-										<TableCell className="text-xs text-(--color-destructive)">
-											{c.failureReason ?? ""}
+										<TableCell
+											className="text-xs text-(--color-destructive)"
+											title={c.failureReason ?? undefined}
+										>
+											{c.failureReason === null ? "" : formatPlanRunFailureReason(c.failureReason)}
 										</TableCell>
 									</TableRow>
 								);

--- a/src/ui/src/pages/run-analytics/Charts.tsx
+++ b/src/ui/src/pages/run-analytics/Charts.tsx
@@ -14,11 +14,12 @@
  * Charts render a muted "No data in this window." placeholder rather
  * than an empty axis frame when their slice of the payload is empty.
  */
-import type {
-	RunDayBucket,
-	RunFailureBucket,
-	RunGroupBucket,
-	SeedContextBucket,
+import {
+	RUN_ANALYTICS_NONE_KEY,
+	type RunDayBucket,
+	type RunFailureBucket,
+	type RunGroupBucket,
+	type SeedContextBucket,
 } from "@/api/client.ts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
 import {
@@ -36,6 +37,7 @@ import {
 	XAxis,
 	YAxis,
 } from "@/components/ui/chart.tsx";
+import { formatRunFailureReason } from "@/lib/labels.ts";
 import { formatTokens } from "./format.ts";
 
 /**
@@ -211,25 +213,26 @@ export function TopSeedsByContextChart({ topSeeds }: { topSeeds: SeedContextBuck
 }
 
 export function FailureReasonChart({ byFailureReason }: { byFailureReason: RunFailureBucket[] }) {
+	// The slice name is what the legend, the slice label and the tooltip all
+	// render, so map it to prose before recharts ever sees it — the raw
+	// `finalize_failed` / `evicted` discriminators were reaching public
+	// visitors otherwise (warren-14fc / #641). Runs with no recorded reason
+	// come back under the analytics null key.
+	const data = byFailureReason.map((b) => ({
+		...b,
+		label: b.key === RUN_ANALYTICS_NONE_KEY ? "Unrecorded" : formatRunFailureReason(b.key),
+	}));
 	return (
 		<ChartFrame
 			title="Failure reasons"
 			subtitle="Failed runs grouped by recorded reason"
-			empty={byFailureReason.length === 0}
+			empty={data.length === 0}
 		>
 			<PieChart>
 				<Tooltip contentStyle={TOOLTIP_STYLE} />
 				<Legend wrapperStyle={{ fontSize: 11 }} />
-				<Pie
-					data={byFailureReason}
-					dataKey="runs"
-					nameKey="key"
-					cx="50%"
-					cy="50%"
-					outerRadius={80}
-					label
-				>
-					{byFailureReason.map((b, i) => (
+				<Pie data={data} dataKey="runs" nameKey="label" cx="50%" cy="50%" outerRadius={80} label>
+					{data.map((b, i) => (
 						<Cell key={b.key} fill={PIE_PALETTE[i % PIE_PALETTE.length]} />
 					))}
 				</Pie>

--- a/src/ui/src/pages/run-analytics/Tables.tsx
+++ b/src/ui/src/pages/run-analytics/Tables.tsx
@@ -5,8 +5,11 @@
  * Both dimensions share the `RunGroupBucket` wire shape, so one
  * `GroupTable` renders either. Buckets are pre-sorted server-side by
  * context desc; the null group key (`RUN_ANALYTICS_NONE_KEY`) renders
- * as an em-dash. Agent rows deep-link to `/agents/:name`; model rows
- * are plain monospace (no agents-by-model route in the UI).
+ * as an em-dash. Agent rows deep-link to the Agents list with that
+ * agent's row pre-expanded (`/agents?agent=<name>`, warren-14fc / #641 —
+ * they used to point at `/agents/:name`, a route `App.tsx` never
+ * registered, so the catch-all silently bounced the visitor to `/runs`).
+ * Model rows are plain monospace (no agents-by-model route in the UI).
  */
 import { Link } from "react-router-dom";
 import { RUN_ANALYTICS_NONE_KEY, type RunGroupBucket } from "@/api/client.ts";
@@ -28,7 +31,7 @@ function renderKey(dimension: "agent" | "model", key: string): React.ReactNode {
 	if (dimension === "agent") {
 		return (
 			<Link
-				to={`/agents/${encodeURIComponent(key)}`}
+				to={`/agents?agent=${encodeURIComponent(key)}`}
 				className="underline-offset-2 hover:underline"
 			>
 				{key}


### PR DESCRIPTION
## Summary

Closes #641 (tracked internally as `warren-14fc`). Two related problems on the
public read-only dashboard, where everything below is visible to anonymous
visitors.

- **Fixes a dead link.** `run-analytics/Tables.tsx` linked agent rows to
  `/agents/:name`, a route `App.tsx` never registers — the catch-all silently
  bounced the visitor to `/runs`.
- **Adds one home for visitor-facing labels.** New `src/ui/src/lib/labels.ts`
  turns wire enums into prose. The raw value always survives in a `title`
  tooltip so an operator can still read what the server recorded, and unknown
  values degrade through `humanizeWireValue` instead of leaking underscores.
- **Chose `/agents` over a new detail route.** There is no agent-detail page;
  the Agents list already renders the full agent envelope in an expandable row,
  so a detail route would be a second surface for the same data and a much
  larger change than this bug warrants. To keep the link meaningful rather than
  dumping every agent on the same undifferentiated list, rows link to
  `/agents?agent=<name>` and `Agents.tsx` pre-expands that row at mount.

| Surface | Before | After |
|---|---|---|
| Run stats, agent row | `/agents/claude-code` → bounced to `/runs` | `/agents?agent=claude-code`, row pre-expanded |
| Plan-run child badge | `pr_open` | `PR open` |
| Run detail header | `finalize_failed` | `Finalize failed` |
| Failure-reason pie (legend, slice labels, tooltip) | `oom_killed`, `evicted` | `Out of memory`, `Evicted` |
| Plan-run detail header | `pr_closed_without_merge` | `PR closed without merge` |
| Plan-run child table | `child_seed_not_found:warren-a` | `Child seed not found (warren-a)` |
| Plan runs, "Children" column | `1p / 2i / 2m / 1f` | `1 pending · 2 in flight · 1 merged · 1 skipped · 1 failed` |

Two judgement calls worth flagging — happy to change either:

- `burrow_run_lost` / `burrow_unreachable` read **"Sandbox run lost"** /
  **"Sandbox unreachable"**. Burrow is the LocalProvider's substrate — an
  implementation detail a visitor has no name for, and one that does not exist
  at all under `WARREN_RUNTIME=k8s`. Raw value still in the tooltip.
- The child rollup gives `skipped` its **own bucket** instead of folding it into
  `merged` the way the letter form did. Once the counts are words, calling a
  child that was never dispatched "merged" is simply wrong.

## Changes

**New**

- `src/ui/src/lib/labels.ts` — `humanizeWireValue`, `formatRunFailureReason`,
  `formatPlanRunFailureReason`, `formatChildStateCounts`. Status-*pill* labels
  are deliberately **not** duplicated here: `components/StatusIndicator.tsx` is
  already the single registry for `{label, variant, icon, pulse}`.
  Plan-run failure text is *not* an enum — the coordinator writes free-form
  `reason` or `reason:detail` — so there is no closed set to map exhaustively;
  that formatter humanizes the discriminator half and keeps the detail verbatim
  in parentheses.
- `src/ui/src/lib/labels.test.ts` — 14 cases. The exhaustiveness case walks the
  canonical `RUN_FAILURE_REASONS` tuple from `src/core/wire.ts` (not a local
  copy) and asserts every reason has a prose label containing no underscore, so
  a reason added to the kernel without a label fails the suite. The map is also
  `satisfies Record<RunFailureReason, string>`, so the same gap fails
  `typecheck`.

**Modified**

- `pages/run-analytics/Tables.tsx` — the link fix.
- `pages/Agents.tsx` — reads `?agent=<name>` to pre-expand a row.
- `components/StatusIndicator.tsx` — `pr_open` → `"PR open"`; the unknown-status
  fallback humanizes; new `<RunFailureBadge>`.
- `pages/RunDetail.tsx`, `pages/run-analytics/Charts.tsx`,
  `pages/PlanRunDetail.tsx`, `pages/plan-run-detail/child-table.tsx`,
  `pages/PlanRuns.tsx` — consume the formatters.
- `scripts/file-size-budgets.json` — `RunDetail.tsx` was at its frozen ceiling,
  so the failure badge moved into `StatusIndicator.tsx` next to the other
  wire-value badges rather than growing the page. Ratchets **down**, 1103 → 1101.
- `scripts/bundle-size-budgets.json` — re-baselined via
  `bun run check:bundle-size --update` on a clean `--frozen-lockfile` build:
  +607 B gzip js / +1211 B raw js, well inside `AUTO_RAISE_CAP`; css ratchets
  down. Rationale recorded in a `$comment`, per the file's convention.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun test` — 3572 pass / 21 skip / 4 fail. The 4 are
      `scripts/cloud-armor.test.ts` and fail **identically on a clean `main`** in
      my environment: the test pins `PATH` to `/usr/bin:/bin` and this is a NixOS
      box with no `bash` there. `bash deploy/gcp/cloud-armor.sh --dry-run` emits
      its 8 `+ gcloud` lines normally, so this is environmental and CI's ubuntu
      runner is unaffected. Nothing in this diff touches that area.
- [x] `bun run check:all` — 11/12 gates pass; `check:coverage` reports coverage
      above both floors (functions 89.71% vs 89.30, lines 92.17% vs 91.85) and
      exits non-zero only on the same 4 tests above.
- [x] Manual verification — every surface in the table above was driven in a
      real browser against a local warren with a seeded database, both as an
      operator and anonymously. The agent link was verified by clicking it:
      it lands on `#/agents?agent=claude-code` with that row expanded.

---

**Separate pre-existing bug, found while verifying this one (not fixed here).**
The Run stats page **crashes for anonymous visitors** on `main`, including on
<https://app.warren.run>. The public projection drops `costUsd` / `priced` from
each `RunGroupBucket` and `cost` from `totals` (`REDACTED_RUN_GROUP_FIELDS` /
`REDACTED_RUN_TOTALS_FIELDS`), but `src/ui/src/api/client.ts` types all three as
required, so `KpiCards` throws `Cannot read properties of undefined (reading
'total')` and `Tables.tsx` throws `… (reading 'toFixed')`. The whole page falls
through to the error boundary. Verified against the live instance:
`curl https://app.warren.run/analytics/runs?days=7 | jq .byAgent[0]` has no
`costUsd`. It is a wire-type drift rather than a labelling problem, so I left it
out of this PR — say the word and I'll open an issue or a follow-up PR.
