### PR TITLE
feat: default the warren project to openrouter/moonshotai/kimi-k3 (pi harness)

### DIFF
--- a/.claude/skills/warren-dogfood-pipeline/SKILL.md
+++ b/.claude/skills/warren-dogfood-pipeline/SKILL.md
@@ -16,10 +16,15 @@ locally — including for repairs. The pipeline was proven 2026-07-28
 
 - **Focus theme + priority band** — e.g. "P0/P1 deletion-focused",
   "security leaks", "docs drift". This drives the audit lens.
-- **Agent + model** — default `pi` with an explicit `modelOverride`
-  (the pi builtin defaults to the sonnet tier; pass the opus-tier model
-  for hard refactors). Confirm the model id against
-  `src/registry/builtins/model-tiers.ts`.
+- **Agent + model/provider** — ALWAYS stop and ask the operator
+  (AskUserQuestion) which model + provider to use for all tasks in the
+  session, even when every other input was given. Recommended default:
+  provider `openrouter`, model `moonshotai/kimi-k3`, on the `pi`
+  harness (the only harness that can reach OpenRouter; it is also the
+  project `defaultRole`). Offer the anthropic tiers
+  (`src/registry/builtins/model-tiers.ts`) as alternatives — e.g. the
+  opus-tier model for hard refactors. Dispatch with explicit
+  `providerOverride` + `modelOverride` matching the answer.
 - **Dispatch mode** — sequential one-at-a-time (default, what the
   operator chose last time) vs parallel. Sequential means: next issue
   run dispatches only after the previous run is TERMINAL; repair runs

--- a/.warren/config.yaml
+++ b/.warren/config.yaml
@@ -12,8 +12,10 @@
 
 defaultRole: pi
 defaultBranch: main
-defaultProvider: anthropic
-defaultModel: claude-opus-4-8
+# kimi-k3 is reachable only through the pi harness (defaultRole above);
+# agent pods need OPENROUTER_API_KEY (warren-openrouter-key Secret on k8s).
+defaultProvider: openrouter
+defaultModel: moonshotai/kimi-k3
 
 # ── Optional knobs (uncomment to set) ───────────────────────────────────
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN bun install -g \
     @os-eco/mulch-cli@0.10.7 \
     @os-eco/sapling-cli@0.3.2 \
     @anthropic-ai/claude-code@2.1.150 \
-    @earendil-works/pi-coding-agent@0.77.0 \
+    @earendil-works/pi-coding-agent@0.83.0 \
     pnpm@11.1.2
 
 # bun install -g skips lifecycle scripts by default, so claude-code's

--- a/deploy/docker/Dockerfile.agent
+++ b/deploy/docker/Dockerfile.agent
@@ -53,7 +53,7 @@ RUN bun install -g \
     @os-eco/sapling-cli@0.3.2 \
     @os-eco/plot-cli@0.4.0 \
     @anthropic-ai/claude-code@2.1.150 \
-    @earendil-works/pi-coding-agent@0.77.0
+    @earendil-works/pi-coding-agent@0.83.0
 
 # claude-code's postinstall (download the platform-native `claude` binary) is
 # skipped by `bun install -g`; run it explicitly so /usr/local/bin/claude exists

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -104,6 +104,11 @@ kubectl -n warren create secret generic warren-secrets \
 # Same value as github-token. Optional — public repos clone without it.
 kubectl -n warren-runs create secret generic warren-git-token \
   --from-literal=token=<gh PAT>
+
+# Agent pods read OPENROUTER_API_KEY from THIS secret, in warren-runs.
+# Optional — needed only for runs whose provider is `openrouter` (pi harness).
+kubectl -n warren-runs create secret generic warren-openrouter-key \
+  --from-literal=api-key=<sk-or-…>
 ```
 
 | Secret / key | Namespace | warren env var | Purpose |
@@ -116,6 +121,7 @@ kubectl -n warren-runs create secret generic warren-git-token \
 | `warren-secrets/warren-auth` | warren | `WARREN_AUTH` | auth posture: `token` (default) or `public` (optional) |
 | `warren-secrets/warren-public-allowlist` | warren | `WARREN_PUBLIC_ALLOWLIST` | owners (`my-org`) and/or repos (`some-owner/some-repo`) a public instance may hold (required iff `warren-auth=public`) |
 | `warren-git-token/token` | warren-runs | `WARREN_GIT_TOKEN` (init pod) | init-container clone |
+| `warren-openrouter-key/api-key` | warren-runs | `OPENROUTER_API_KEY` (agent pod) | OpenRouter auth for `openrouter`-provider runs (optional) |
 
 ### Going public
 
@@ -233,7 +239,9 @@ pushed refs.
 OPTIONAL `secretKeyRef` (`WARREN_K8S_ANTHROPIC_SECRET_NAME` /
 `_KEY`, default Secret `warren-anthropic-key` key `api-key`) so a run whose key
 rides the dispatch env still schedules when the Secret is absent. Provision the
-Secret alongside `warren-git-token` (design §6.3).
+Secret alongside `warren-git-token` (design §6.3). `OPENROUTER_API_KEY` rides
+the same pattern (`WARREN_K8S_OPENROUTER_SECRET_NAME` / `_KEY`, default Secret
+`warren-openrouter-key` key `api-key`) for `openrouter`-provider runs.
 
 ## Host-mode local dev: kubeconfig 401 with client-cert clusters
 

--- a/deploy/k8s/base/secrets.yaml
+++ b/deploy/k8s/base/secrets.yaml
@@ -69,3 +69,23 @@ metadata:
 type: Opaque
 stringData:
   token: "REPLACE_ME"
+---
+# The agent container sources OPENROUTER_API_KEY from THIS Secret via an
+# OPTIONAL secretKeyRef (pod-spec.ts DEFAULT_K8S_OPENROUTER_SECRET_*), needed
+# when a run's provider is `openrouter` (pi harness — e.g. the
+# moonshotai/kimi-k3 project default). MUST live in `warren-runs` like the git
+# token above. Optional: anthropic-only runs schedule without it.
+#
+#   kubectl -n warren-runs create secret generic warren-openrouter-key \
+#     --from-literal=api-key=sk-or-...
+apiVersion: v1
+kind: Secret
+metadata:
+  name: warren-openrouter-key
+  namespace: warren-runs
+  labels:
+    app.kubernetes.io/name: warren
+    app.kubernetes.io/component: runs
+type: Opaque
+stringData:
+  api-key: "REPLACE_ME"

--- a/deploy/k8s/overlays/gke/kustomization.yaml
+++ b/deploy/k8s/overlays/gke/kustomization.yaml
@@ -90,6 +90,16 @@ patches:
       metadata:
         name: warren-git-token
         namespace: warren-runs
+  - target:
+      kind: Secret
+      name: warren-openrouter-key
+    patch: |
+      $patch: delete
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: warren-openrouter-key
+        namespace: warren-runs
   # GCE external Application LB exposure (warren-682a). The host below is a
   # PLACEHOLDER — gke-live patches it (and the ManagedCertificate domain) to
   # the real hostname. The static-IP name refers to a reserved *global*

--- a/src/runtime/k8s/pod-env.ts
+++ b/src/runtime/k8s/pod-env.ts
@@ -33,6 +33,25 @@ export function serviceDnsCallbackUrl(config: K8sPodConfig): string {
 	return `http://${service}.${namespace}.svc.cluster.local:${port}`;
 }
 
+// --- Secret sources (design §6.3) -------------------------------------------
+// Each is referenced as an OPTIONAL secretKeyRef so a pod still schedules when
+// the Secret is absent; each pair is overridable via the matching
+// `WARREN_K8S_*_SECRET_NAME` / `_KEY` env. Provisioned by the manifests step
+// (see deploy/k8s/base/secrets.yaml); all three live in the RUNS namespace.
+
+/** Init container's `WARREN_GIT_TOKEN` source (public repos clone without it). */
+export const DEFAULT_K8S_GIT_SECRET_NAME = "warren-git-token";
+export const DEFAULT_K8S_GIT_SECRET_KEY = "token";
+/** Agent container's `ANTHROPIC_API_KEY` source — from a Secret, NOT the control
+ * plane's process env; a key riding `spec.env` (OAuth-token flow) wins. */
+export const DEFAULT_K8S_ANTHROPIC_SECRET_NAME = "warren-anthropic-key";
+export const DEFAULT_K8S_ANTHROPIC_SECRET_KEY = "api-key";
+/** Agent container's `OPENROUTER_API_KEY` source — the multi-provider sibling,
+ * needed when a run's provider is `openrouter` (pi harness only; e.g. the
+ * moonshotai/kimi-k3 project default). */
+export const DEFAULT_K8S_OPENROUTER_SECRET_NAME = "warren-openrouter-key";
+export const DEFAULT_K8S_OPENROUTER_SECRET_KEY = "api-key";
+
 // --- Repo-cache PVC (design §4.3, R2 — warren-e908) -------------------------
 
 /**
@@ -180,6 +199,10 @@ export function buildInitVolumeMounts(
  *     sourced from a Secret, not the control plane's env) UNLESS the domain env
  *     already carries it (an OAuth-token flow), which would make a duplicate env
  *     name illegal.
+ *   - `OPENROUTER_API_KEY` rides the same way from its own Secret, so runs
+ *     whose provider is `openrouter` (pi harness) can authenticate. The pod
+ *     entrypoint spawns the agent with the full pod env, so presence here is
+ *     sufficient — pi reads the var directly.
  *
  * The prompt travels as an env var: composed prompts are bounded (system section
  * + user input) and fit comfortably under K8s's per-pod object size. A prompt
@@ -204,6 +227,18 @@ export function buildAgentEnv(spec: RunSpec, config: K8sPodConfig): V1EnvVar[] {
 				secretKeyRef: {
 					name: config.anthropicSecret.name,
 					key: config.anthropicSecret.key,
+					optional: true,
+				},
+			},
+		});
+	}
+	if (spec.env.OPENROUTER_API_KEY === undefined) {
+		vars.push({
+			name: "OPENROUTER_API_KEY",
+			valueFrom: {
+				secretKeyRef: {
+					name: config.openrouterSecret.name,
+					key: config.openrouterSecret.key,
 					optional: true,
 				},
 			},

--- a/src/runtime/k8s/pod-spec.test.ts
+++ b/src/runtime/k8s/pod-spec.test.ts
@@ -404,6 +404,29 @@ describe("buildRunPod", () => {
 		expect(anthropic[0]?.valueFrom).toBeUndefined();
 	});
 
+	test("OPENROUTER_API_KEY rides as an optional secretKeyRef by default", () => {
+		const agent = buildRunPod(baseSpec(), config).spec?.containers?.[0];
+		const openrouter = (agent?.env ?? []).find((e) => e.name === "OPENROUTER_API_KEY");
+		expect(openrouter?.valueFrom?.secretKeyRef).toEqual({
+			name: config.openrouterSecret.name,
+			key: config.openrouterSecret.key,
+			optional: true,
+		});
+	});
+
+	test("a domain-supplied OPENROUTER_API_KEY is not shadowed by the secret ref", () => {
+		const pod = buildRunPod(
+			baseSpec({ env: { WARREN_API_TOKEN: "tok", OPENROUTER_API_KEY: "sk-or-inline" } }),
+			config,
+		);
+		const openrouter = (pod.spec?.containers?.[0]?.env ?? []).filter(
+			(e) => e.name === "OPENROUTER_API_KEY",
+		);
+		expect(openrouter).toHaveLength(1);
+		expect(openrouter[0]?.value).toBe("sk-or-inline");
+		expect(openrouter[0]?.valueFrom).toBeUndefined();
+	});
+
 	test("no ServiceAccount by default → token automount disabled", () => {
 		const pod = buildRunPod(baseSpec(), config);
 		expect(pod.spec?.serviceAccountName).toBeUndefined();

--- a/src/runtime/k8s/pod-spec.ts
+++ b/src/runtime/k8s/pod-spec.ts
@@ -49,6 +49,12 @@ import {
 	buildInitEnv,
 	buildInitVolumeMounts,
 	buildRunPodVolumes,
+	DEFAULT_K8S_ANTHROPIC_SECRET_KEY,
+	DEFAULT_K8S_ANTHROPIC_SECRET_NAME,
+	DEFAULT_K8S_GIT_SECRET_KEY,
+	DEFAULT_K8S_GIT_SECRET_NAME,
+	DEFAULT_K8S_OPENROUTER_SECRET_KEY,
+	DEFAULT_K8S_OPENROUTER_SECRET_NAME,
 	resolveRepoCacheConfig,
 } from "./pod-env.ts";
 import {
@@ -64,6 +70,12 @@ export {
 	buildAgentEnv,
 	buildInitEnv,
 	buildInitVolumeMounts,
+	DEFAULT_K8S_ANTHROPIC_SECRET_KEY,
+	DEFAULT_K8S_ANTHROPIC_SECRET_NAME,
+	DEFAULT_K8S_GIT_SECRET_KEY,
+	DEFAULT_K8S_GIT_SECRET_NAME,
+	DEFAULT_K8S_OPENROUTER_SECRET_KEY,
+	DEFAULT_K8S_OPENROUTER_SECRET_NAME,
 	ENV_AGENT_METADATA,
 	ENV_AGENT_RUNTIME,
 	ENV_PROMPT,
@@ -157,27 +169,6 @@ export const DEFAULT_K8S_CALLBACK_NAMESPACE = "warren";
 export const DEFAULT_K8S_CALLBACK_PORT = "8080";
 
 /**
- * K8s Secret the init container's `WARREN_GIT_TOKEN` is sourced from (design
- * §6.3 `github-token`). Referenced as an OPTIONAL secretKeyRef so public repos
- * still clone when no secret is present. Overridable via
- * `WARREN_K8S_GIT_SECRET_NAME` / `WARREN_K8S_GIT_SECRET_KEY`; the actual Secret
- * is provisioned by the manifests step (warren-74b5).
- */
-export const DEFAULT_K8S_GIT_SECRET_NAME = "warren-git-token";
-export const DEFAULT_K8S_GIT_SECRET_KEY = "token";
-
-/**
- * K8s Secret the agent container's `ANTHROPIC_API_KEY` is sourced from (design
- * §6.3: agent pods receive `ANTHROPIC_API_KEY` from a Secret, NOT the control
- * plane's process env). Referenced as an OPTIONAL secretKeyRef so a run whose
- * key rides `spec.env` (or an OAuth-token flow) still schedules when the Secret
- * is absent. Overridable via `WARREN_K8S_ANTHROPIC_SECRET_NAME` /
- * `WARREN_K8S_ANTHROPIC_SECRET_KEY`; the Secret is provisioned by the manifests.
- */
-export const DEFAULT_K8S_ANTHROPIC_SECRET_NAME = "warren-anthropic-key";
-export const DEFAULT_K8S_ANTHROPIC_SECRET_KEY = "api-key";
-
-/**
  * SIGTERM grace on `cancel()` (pl-829f step 19 / warren-31d4). `cancel` is the
  * seam's GRACEFUL stop: it deletes the pod with this `gracePeriodSeconds`, so
  * the kubelet delivers SIGTERM and waits this long before SIGKILL — giving the
@@ -216,8 +207,9 @@ export interface K8sPodConfig {
 	callback: { service: string; namespace: string; port: string };
 	/** K8s Secret the init container's git token is sourced from (§6.3). */
 	gitTokenSecret: { name: string; key: string };
-	/** K8s Secret the agent container's `ANTHROPIC_API_KEY` is sourced from (§6.3). */
+	/** Agent-container API-key Secrets: `ANTHROPIC_API_KEY` / `OPENROUTER_API_KEY` (§6.3). */
 	anthropicSecret: { name: string; key: string };
+	openrouterSecret: { name: string; key: string };
 	/** Optional PVC-backed git-mirror cache on the init container (§4.3, pod-env.ts). */
 	repoCache?: { claimName: string; mountPath: string };
 	/** SIGTERM grace (seconds) `cancel()` deletes the pod with (step 19). */
@@ -297,6 +289,14 @@ export function resolveK8sPodConfig(
 		anthropicSecret: {
 			name: pickString(env, "WARREN_K8S_ANTHROPIC_SECRET_NAME", DEFAULT_K8S_ANTHROPIC_SECRET_NAME),
 			key: pickString(env, "WARREN_K8S_ANTHROPIC_SECRET_KEY", DEFAULT_K8S_ANTHROPIC_SECRET_KEY),
+		},
+		openrouterSecret: {
+			name: pickString(
+				env,
+				"WARREN_K8S_OPENROUTER_SECRET_NAME",
+				DEFAULT_K8S_OPENROUTER_SECRET_NAME,
+			),
+			key: pickString(env, "WARREN_K8S_OPENROUTER_SECRET_KEY", DEFAULT_K8S_OPENROUTER_SECRET_KEY),
 		},
 		cancelGracePeriodSeconds: pickNonNegativeInt(
 			env,


### PR DESCRIPTION
Switches the warren project's default model to **moonshotai/kimi-k3 via OpenRouter**, reachable only through the pi harness (already the `defaultRole`).

## What's in here

- **pi 0.83.0** in both image pins (`Dockerfile`, `deploy/docker/Dockerfile.agent`) — 0.77.0 predated the kimi-k3 / Claude 5 model catalog.
- **`.warren/config.yaml`**: `defaultProvider: openrouter`, `defaultModel: moonshotai/kimi-k3`. Takes effect for dispatches against this project once merged (the control plane reads the origin/main clone).
- **K8s runtime**: agent pods source `OPENROUTER_API_KEY` from a new optional `warren-openrouter-key` Secret (`warren-runs` ns), mirroring the `ANTHROPIC_API_KEY` secretKeyRef pattern. Secret-ref constants moved to `pod-env.ts` to hold the `pod-spec.ts` size ratchet; tests added.
- **gke overlay**: delete-patch for the new stub Secret so `kubectl apply -k` can't clobber the imperatively-created value (same guard the other secrets already had — verified live, the first apply without it did clobber and was repaired).
- **dogfood skill**: now always asks the operator which model/provider to use for the session, recommending `openrouter` / `moonshotai/kimi-k3` on pi.

## Already deployed

Images `1e5d8835-pi083` are live on the GKE cluster with this exact functional content; the `warren-openrouter-key` Secret is provisioned; smoke run `run_k79rfmkdhpgd` dispatched with explicit overrides to verify end-to-end.

Local/burrow-path parity (`PI_PROVIDER_ENV_KEYS` lacks `openrouter`) is tracked as **burrow-8318**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)