### PR TITLE
fix/js yaml v5 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Releases **0.9.10 and earlier** live in
 
 ## [Unreleased]
 
+### Changed
+
+- **js-yaml 4 → 5** — config parsing migrates to js-yaml v5
+  (named `load`/`dump` imports, bundled types replace `@types/js-yaml`;
+  warren-381c, #637). Empty or comment-only `.warren/*` YAML files still
+  parse as "absent". v5's `load` uses the YAML 1.2 `CORE_SCHEMA` (no
+  `!!merge` by default, `yes`/`no`/`on`/`off` are strings) and `dump`
+  quotes per YAML 1.1, so `warren init` / `warren config migrate` output
+  may differ cosmetically — semantics are unchanged.
+
 ## [0.13.0] — 2026-07-30
 
 ### Security

--- a/SPEC.md
+++ b/SPEC.md
@@ -790,7 +790,7 @@ allowed (JSON's biggest weakness) and arrays-of-objects stay readable as
 new blocks accumulate. The pre-reorg JSON choice (`mx-2cefdd`) is
 superseded by the warren-5840 decision; both formats keep working until
 projects migrate via `warren config migrate`. YAML parser is `js-yaml
-^4.1.1` to match mulch + overstory (`mx-8b6896`).
+^5.x` (was `^4.1.1`; warren-381c) to match mulch + overstory (`mx-8b6896`).
 
 **Schema.** `triggers.yaml` is `Array<Trigger>` with a `kind:` discriminator
 (only `'cron'` is implemented today; `kind:` exists so future webhook

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "commander": "^15.0.0",
         "croner": "^10.0.1",
         "drizzle-orm": "^0.45.2",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^5.2.1",
         "pg": "^8.13.1",
         "pino": "^10.3.1",
         "zod": "^4.4.3",
@@ -19,7 +19,6 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
         "@types/bun": "latest",
-        "@types/js-yaml": "^4.0.9",
         "@types/pg": "^8.11.10",
         "drizzle-kit": "^0.31.10",
         "jscpd": "^5.0.12",
@@ -424,7 +423,7 @@
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "js-yaml": ["js-yaml@5.2.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.mjs" } }, "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw=="],
 
     "jscpd": ["jscpd@5.0.14", "", { "optionalDependencies": { "jscpd-darwin-arm64": "5.0.14", "jscpd-darwin-x64": "5.0.14", "jscpd-linux-arm64-gnu": "5.0.14", "jscpd-linux-x64-gnu": "5.0.14", "jscpd-linux-x64-musl": "5.0.14", "jscpd-windows-x64-msvc": "5.0.14" }, "bin": { "jscpd": "run-jscpd.js" } }, "sha512-zge+FPZZAymt2Do5Z0+QHyIn4/XcUhrO/W7of9HcHZfx2AK8++dYhLA1uWtwXj47ml3Of8PbcUW4wUWvYMCc3w=="],
 
@@ -599,6 +598,8 @@
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@kubernetes/client-node/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
+    "@kubernetes/client-node/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "get-intrinsic/hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.10",
 		"@types/bun": "latest",
-		"@types/js-yaml": "^4.0.9",
 		"@types/pg": "^8.11.10",
 		"drizzle-kit": "^0.31.10",
 		"jscpd": "^5.0.12",
@@ -93,7 +92,7 @@
 		"commander": "^15.0.0",
 		"croner": "^10.0.1",
 		"drizzle-orm": "^0.45.2",
-		"js-yaml": "^4.1.1",
+		"js-yaml": "^5.2.1",
 		"pg": "^8.13.1",
 		"pino": "^10.3.1",
 		"zod": "^4.4.3"

--- a/src/cli/commands/config-migrate.test.ts
+++ b/src/cli/commands/config-migrate.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import yaml from "js-yaml";
+import { load } from "js-yaml";
 import { openDatabase, type WarrenDb } from "../../db/client.ts";
 import { DrizzleAdapter } from "../../db/repos/drizzle-adapter.ts";
 import { ProjectsRepo } from "../../db/repos/projects.ts";
@@ -64,7 +64,7 @@ describe("runConfigMigrate (--cwd mode)", () => {
 		expect(existsSync(join(warrenDir, "defaults.json"))).toBe(false);
 		const configBody = await readFile(join(warrenDir, "config.yaml"), "utf8");
 		expect(configBody.startsWith("# .warren/config.yaml")).toBe(true);
-		expect(yaml.load(configBody)).toEqual({
+		expect(load(configBody)).toEqual({
 			defaultRole: "claude-code",
 			defaultBranch: "main",
 		});
@@ -97,10 +97,10 @@ describe("runConfigMigrate (--cwd mode)", () => {
 		expect(stdout.migrated.written).toEqual([".warren/config.yaml", ".warren/preview.yaml"]);
 
 		const configBody = await readFile(join(warrenDir, "config.yaml"), "utf8");
-		expect(yaml.load(configBody)).toEqual({ defaultRole: "claude-code" });
+		expect(load(configBody)).toEqual({ defaultRole: "claude-code" });
 
 		const previewBody = await readFile(join(warrenDir, "preview.yaml"), "utf8");
-		expect(yaml.load(previewBody)).toEqual({
+		expect(load(previewBody)).toEqual({
 			type: "server",
 			command: "bun run dev",
 			port: 3000,
@@ -120,7 +120,7 @@ describe("runConfigMigrate (--cwd mode)", () => {
 		expect(stdout.migrated.previewHoisted).toBe(false);
 
 		const configBody = await readFile(join(warrenDir, "config.yaml"), "utf8");
-		expect(yaml.load(configBody)).toEqual({});
+		expect(load(configBody)).toEqual({});
 	});
 
 	test("refuses to overwrite an existing config.yaml", async () => {

--- a/src/cli/commands/config-migrate.ts
+++ b/src/cli/commands/config-migrate.ts
@@ -25,7 +25,7 @@
 import { existsSync } from "node:fs";
 import { readFile, rm, writeFile } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
-import yaml from "js-yaml";
+import { dump } from "js-yaml";
 import { NotFoundError, ValidationError } from "../../core/errors.ts";
 import type { ProjectsRepo } from "../../db/repos/projects.ts";
 import {
@@ -205,9 +205,9 @@ function renderConfig(config: DefaultsConfig): string {
 	if (Object.keys(config).length === 0) {
 		return `${CONFIG_HEADER}{}\n`;
 	}
-	return `${CONFIG_HEADER}${yaml.dump(config, { lineWidth: 100, noRefs: true })}`;
+	return `${CONFIG_HEADER}${dump(config, { lineWidth: 100, noRefs: true })}`;
 }
 
 function renderPreview(preview: PreviewConfig): string {
-	return `${PREVIEW_HEADER}${yaml.dump(preview, { lineWidth: 100, noRefs: true })}`;
+	return `${PREVIEW_HEADER}${dump(preview, { lineWidth: 100, noRefs: true })}`;
 }

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import yaml from "js-yaml";
+import { load } from "js-yaml";
 import { openDatabase, type WarrenDb } from "../../db/client.ts";
 import { AgentsRepo } from "../../db/repos/agents.ts";
 import { DrizzleAdapter } from "../../db/repos/drizzle-adapter.ts";
@@ -60,12 +60,12 @@ describe("runInit (--cwd mode)", () => {
 		expect(stdout.scaffolded.files).toEqual([".warren/triggers.yaml", ".warren/config.yaml"]);
 
 		const triggersRaw = await readFile(join(tmp, ".warren/triggers.yaml"), "utf8");
-		const triggersParsed = parseTriggersConfig(yaml.load(triggersRaw));
+		const triggersParsed = parseTriggersConfig(load(triggersRaw));
 		expect(triggersParsed.ok).toBe(true);
 		if (triggersParsed.ok) expect(triggersParsed.value).toEqual([]);
 
 		const configRaw = await readFile(join(tmp, ".warren/config.yaml"), "utf8");
-		const configParsed = parseConfigFile(yaml.load(configRaw));
+		const configParsed = parseConfigFile(load(configRaw));
 		expect(configParsed.ok).toBe(true);
 		if (configParsed.ok) expect(configParsed.value).toEqual({ defaultRole: "claude-code" });
 	});
@@ -79,7 +79,7 @@ describe("runInit (--cwd mode)", () => {
 		const configRaw = await readFile(join(tmp, ".warren/config.yaml"), "utf8");
 		// Empty config renders as a YAML flow-style empty mapping `{}` so the
 		// file round-trips back through the schema to an empty DefaultsConfig.
-		expect(yaml.load(configRaw)).toEqual({});
+		expect(load(configRaw)).toEqual({});
 		expect(JSON.parse(out.join("")).scaffolded.defaultRole).toBeNull();
 	});
 
@@ -92,7 +92,7 @@ describe("runInit (--cwd mode)", () => {
 			{ mode: "cwd", cwd: tmp, defaultRole: "sapling" },
 		);
 		expect(result.exitCode).toBe(0);
-		const config = yaml.load(await readFile(join(tmp, ".warren/config.yaml"), "utf8")) as {
+		const config = load(await readFile(join(tmp, ".warren/config.yaml"), "utf8")) as {
 			defaultRole?: string;
 		};
 		expect(config.defaultRole).toBe("sapling");

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -37,7 +37,7 @@
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
-import yaml from "js-yaml";
+import { dump } from "js-yaml";
 import { NotFoundError, ValidationError } from "../../core/errors.ts";
 import type { AgentsRepo } from "../../db/repos/agents.ts";
 import type { ProjectsRepo } from "../../db/repos/projects.ts";
@@ -216,11 +216,11 @@ async function resolveDefaults(deps: InitDeps, args: InitArgs): Promise<Defaults
 /**
  * Render `DefaultsConfig` into the scaffolded YAML body. Empty objects
  * render as `{}` rather than the empty string so the file always
- * round-trips through `yaml.load` to the same schema-valid value.
+ * round-trips through `load` to the same schema-valid value.
  */
 function renderConfigYaml(defaults: DefaultsConfig): string {
 	if (Object.keys(defaults).length === 0) {
 		return "{}\n";
 	}
-	return yaml.dump(defaults, { lineWidth: 100, noRefs: true });
+	return dump(defaults, { lineWidth: 100, noRefs: true });
 }

--- a/src/warren-config/load.test.ts
+++ b/src/warren-config/load.test.ts
@@ -215,7 +215,7 @@ defaultPrompt: Read the issue, plan, execute.
 		expect(result.errors).toHaveLength(2);
 	});
 
-	test("empty triggers file (yaml.load returns undefined) → empty array, no error", async () => {
+	test("empty triggers file → empty array, no error", async () => {
 		const result = await loadWarrenConfig({
 			projectPath: PROJECT,
 			...fs({ [TRIGGERS_PATH]: "" }),
@@ -232,6 +232,41 @@ defaultPrompt: Read the issue, plan, execute.
 		expect(result.defaults).toEqual({});
 		expect(result.errors).toEqual([]);
 		expect(result.warnings).toEqual([]);
+	});
+
+	// warren-381c: comment-only files are the documented "keep the file around
+	// as documentation" shape (schema.ts) and must not become parse errors —
+	// js-yaml v5 load() throws on input with no document.
+	test("comment-only triggers file → empty array, no error", async () => {
+		const result = await loadWarrenConfig({
+			projectPath: PROJECT,
+			...fs({ [TRIGGERS_PATH]: "# just a comment\n# and another\n" }),
+		});
+		expect(result.triggers).toEqual([]);
+		expect(result.errors).toEqual([]);
+	});
+
+	test("comment-only config.yaml → empty defaults object, no error", async () => {
+		const result = await loadWarrenConfig({
+			projectPath: PROJECT,
+			...fs({ [CONFIG_PATH]: "# just a comment\n" }),
+		});
+		expect(result.defaults).toEqual({});
+		expect(result.errors).toEqual([]);
+		expect(result.warnings).toEqual([]);
+	});
+
+	test("comment-only preview.yaml → no error, defaults preserved", async () => {
+		const result = await loadWarrenConfig({
+			projectPath: PROJECT,
+			...fs({
+				[CONFIG_PATH]: "defaultRole: claude-code\n",
+				[PREVIEW_PATH]: "# just a comment\n",
+			}),
+		});
+		expect(result.errors).toEqual([]);
+		expect(result.defaults?.defaultRole).toBe("claude-code");
+		expect(result.defaults?.preview).toBeUndefined();
 	});
 
 	// warren-7be9 / SPEC §11.L: malformed preview block surfaces in the per-file

--- a/src/warren-config/load.ts
+++ b/src/warren-config/load.ts
@@ -35,7 +35,7 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import yaml from "js-yaml";
+import { load } from "js-yaml";
 import { formatError } from "../core/errors.ts";
 import { type PrTemplateOverrides, parsePrTemplate } from "../runs/pr-template.ts";
 import { WARREN_CONFIG_DIR, WARREN_CONFIG_FILES, warrenConfigRelativePath } from "./config.ts";
@@ -153,6 +153,35 @@ interface LoadDefaultsInput extends LoadOneInput {
 	readonly warnings: WarrenConfigFileError[];
 }
 
+/**
+ * Parse the YAML document for one `.warren/` file, treating empty or
+ * comment-only content as "absent" (`undefined`) rather than an error.
+ * js-yaml v5 `load()` throws when the input contains no document — a bare
+ * `# comment` file included — so the emptiness check strips comment lines
+ * before trimming to preserve the v4 behaviour where such files parsed to
+ * `undefined` (warren-381c).
+ */
+function loadYamlDocument(
+	raw: string,
+	relPath: string,
+	errors: WarrenConfigFileError[],
+): { readonly ok: true; readonly document: unknown } | { readonly ok: false } {
+	const trimmed = raw.replace(/^\s*#.*$/gm, "").trim();
+	if (trimmed === "") {
+		return { ok: true, document: undefined };
+	}
+	try {
+		return { ok: true, document: load(raw, { filename: relPath }) };
+	} catch (err) {
+		errors.push({
+			file: relPath,
+			code: WARREN_CONFIG_FILE_ERROR_CODES.parseError,
+			message: `YAML parse error: ${formatError(err)}`,
+		});
+		return { ok: false };
+	}
+}
+
 async function loadTriggers(input: LoadOneInput): Promise<TriggersConfig | null> {
 	const relPath = warrenConfigRelativePath("triggers");
 	const absPath = join(input.projectPath, WARREN_CONFIG_DIR, WARREN_CONFIG_FILES.triggers);
@@ -173,19 +202,12 @@ async function loadTriggers(input: LoadOneInput): Promise<TriggersConfig | null>
 		return null;
 	}
 
-	let document: unknown;
-	try {
-		document = yaml.load(raw, { filename: relPath });
-	} catch (err) {
-		input.errors.push({
-			file: relPath,
-			code: WARREN_CONFIG_FILE_ERROR_CODES.parseError,
-			message: `YAML parse error: ${formatError(err)}`,
-		});
+	const parsed = loadYamlDocument(raw, relPath, input.errors);
+	if (!parsed.ok) {
 		return null;
 	}
 
-	const result = parseTriggersConfig(document);
+	const result = parseTriggersConfig(parsed.document);
 	if (!result.ok) {
 		input.errors.push({
 			file: relPath,
@@ -274,24 +296,12 @@ async function loadConfigYaml(
 		return null;
 	}
 
-	const trimmed = raw.trim();
-	let document: unknown;
-	if (trimmed === "") {
-		document = undefined;
-	} else {
-		try {
-			document = yaml.load(raw, { filename: relPath });
-		} catch (err) {
-			input.errors.push({
-				file: relPath,
-				code: WARREN_CONFIG_FILE_ERROR_CODES.parseError,
-				message: `YAML parse error: ${formatError(err)}`,
-			});
-			return null;
-		}
+	const parsed = loadYamlDocument(raw, relPath, input.errors);
+	if (!parsed.ok) {
+		return null;
 	}
 
-	const result = parseConfigFile(document);
+	const result = parseConfigFile(parsed.document);
 	if (!result.ok) {
 		input.errors.push({
 			file: relPath,
@@ -377,24 +387,12 @@ async function loadPreviewFile(input: LoadOneInput): Promise<DefaultsConfig["pre
 		return null;
 	}
 
-	const trimmed = raw.trim();
-	let document: unknown;
-	if (trimmed === "") {
-		document = undefined;
-	} else {
-		try {
-			document = yaml.load(raw, { filename: relPath });
-		} catch (err) {
-			input.errors.push({
-				file: relPath,
-				code: WARREN_CONFIG_FILE_ERROR_CODES.parseError,
-				message: `YAML parse error: ${formatError(err)}`,
-			});
-			return null;
-		}
+	const parsed = loadYamlDocument(raw, relPath, input.errors);
+	if (!parsed.ok) {
+		return null;
 	}
 
-	const result = parsePreviewFile(document);
+	const result = parsePreviewFile(parsed.document);
 	if (!result.ok) {
 		input.errors.push({
 			file: relPath,

--- a/src/warren-config/schema.ts
+++ b/src/warren-config/schema.ts
@@ -374,7 +374,7 @@ export type ParseResult<T> =
 	| { readonly ok: false; readonly message: string };
 
 export function parseTriggersConfig(raw: unknown): ParseResult<TriggersConfig> {
-	// Empty file (yaml.load returns undefined) is the same as "no triggers"
+	// Empty / comment-only file (parses to undefined) is the same as "no triggers"
 	// — operators should be able to scaffold the file without forcing an
 	// explicit empty list literal.
 	if (raw === undefined || raw === null) {


### PR DESCRIPTION
## Summary

- **Migrate js-yaml 4 → 5** (`^4.1.1` → `^5.2.1`), the dependabot bump #587 that was previously closed as a breaking change.
- **Switch default imports to named imports** — v5 drops the ESM default export; the five `src/` call sites now use `import { load }` / `import { dump }`.
- **Drop `@types/js-yaml`** — v5 ships its own types, so the separate devDependency was dead weight failing `check:deps` (knip).
- **Fix a hidden v5 regression**: `load()` now throws on empty input (including comment-only files). The `.warren/` loader treats empty/comment-only config, triggers, and preview files as "absent" so operators can keep a file around as documentation without tripping `warren_config` health checks.

## Changes

- `src/warren-config/load.ts` — named `load` import; new `loadYamlDocument` helper strips comment lines and maps empty/comment-only content to `undefined` at all three load sites (`loadTriggers`, `loadConfigYaml`, `loadPreviewFile`).
- `src/cli/commands/init.ts` / `config-migrate.ts` — `import { dump }`; `lineWidth`/`noRefs` options verified unchanged in v5.
- `src/cli/commands/init.test.ts` / `config-migrate.test.ts` — `import { load }`.
- `src/warren-config/load.test.ts` — comment-only regression tests for triggers/config.yaml/preview.yaml; renamed stale test description.
- `src/warren-config/schema.ts` — stale `yaml.load` comment updated.
- `package.json` / `bun.lock` — js-yaml `^5.2.1` (resolves 5.2.2), `@types/js-yaml` removed; k8s client-node keeps its nested js-yaml@4.
- `CHANGELOG.md` — `[Unreleased]` entry.
- `SPEC.md` — YAML parser version note updated.

## Test plan

- [x] `biome check .` passes (`bun run lint` incl. layers/version-sync/wire-types/prose)
- [x] `tsc --noEmit` passes (`bun run typecheck`)
- [x] `bun test` passes (load/init/config-migrate suites: 46 pass; comment-only regression tests green on js-yaml 5)
- [x] `bun run check:deps` passes (knip clean after `@types/js-yaml` removal)
- [x] `check:agents`, `check:dups`, `check:size`, `check:debt`, `gen:docs:check`, `gen:openapi:check`, `check:ci-parity` pass
- [x] Full `bun run check:all` — **12/12 gates passed** (60.8s): lint, typecheck, check:agents, check:dups, check:deps, check:size, check:debt, check:bundle-size, gen:docs:check, gen:openapi:check, check:coverage, check:ci-parity
- [x] Manual verification — `bun run scripts/acceptance/run.ts --only 14,17,39 --stop-on-failure` → **3 passed, 0 failed**: scenario 14 (`.warren/` absent→valid→malformed via readyz + endpoint), scenario 17 (init scaffold round-trips through `load`/`dump`), scenario 39 (the import-time `Missing default export` failure from the ticket)
