### PR TITLE
ci: replace AUTO_MERGE_PAT with a GitHub App installation token (warren-2565)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,10 +9,13 @@ name: auto-merge
 # the chosen merge method — keeps main history linear, drops the
 # burrow/run_xxx branch noise from agent-opened PRs.
 #
-# Uses AUTO_MERGE_PAT (not GITHUB_TOKEN) so that the resulting push to
-# main triggers downstream workflows (CI, Release). GITHUB_TOKEN-authored
-# pushes are deliberately suppressed by GitHub to prevent recursive loops.
-# See seed warren-a2dc.
+# Uses a GitHub App installation token (not GITHUB_TOKEN) so that the
+# resulting push to main triggers downstream workflows (CI, Release).
+# GITHUB_TOKEN-authored pushes are deliberately suppressed by GitHub to
+# prevent recursive loops (seed warren-a2dc). The token is minted fresh
+# per run from AUTO_MERGE_APP_ID (repo variable) + AUTO_MERGE_APP_PRIVATE_KEY
+# (secret), so there is no expiring PAT to rotate — the static
+# AUTO_MERGE_PAT that silently died on 2026-08-07 is retired (warren-2565).
 
 on:
   pull_request:
@@ -92,9 +95,17 @@ jobs:
             echo "Article IX: no protected paths in the diff — auto-merge may be enabled."
           fi
 
+      - name: Mint app installation token
+        if: steps.protected.outputs.hit == 'false'
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ vars.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
+
       - name: Enable auto-merge (squash)
         if: steps.protected.outputs.hit == 'false'
         env:
-          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/bundle-size-autoheal.yml
+++ b/.github/workflows/bundle-size-autoheal.yml
@@ -16,8 +16,10 @@ name: bundle-size-autoheal
 # and the job exits without touching anything — so it never masks non-bundle
 # failures and never loops (an unchanged measurement yields an unchanged budget).
 #
-# Uses AUTO_MERGE_PAT (not GITHUB_TOKEN) so the heal commit re-triggers CI;
-# GITHUB_TOKEN-authored pushes are suppressed by GitHub to avoid recursion.
+# Uses a GitHub App installation token (not GITHUB_TOKEN) so the heal commit
+# re-triggers CI; GITHUB_TOKEN-authored pushes are suppressed by GitHub to
+# avoid recursion. Minted per run from AUTO_MERGE_APP_ID +
+# AUTO_MERGE_APP_PRIVATE_KEY — same app as auto-merge.yml, no PAT to rotate.
 # NOTE: workflow_run jobs run from the DEFAULT branch's copy of this file, so
 # this only takes effect once merged to main.
 
@@ -40,9 +42,16 @@ jobs:
     env:
       HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
     steps:
+      - name: Mint app installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ vars.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v7.0.1
         with:
-          token: ${{ secrets.AUTO_MERGE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,9 +230,9 @@ jobs:
       - name: Post release notes to Discord
         env:
           # Discord channel webhook — docs/project-setup.md §6. Unlike
-          # AUTO_MERGE_PAT, its absence breaks nothing in the release
-          # pipeline, so a fork with no Discord server skips instead of
-          # failing. A webhook that is present but REJECTED is fatal.
+          # the auto-merge app credential, its absence breaks nothing in
+          # the release pipeline, so a fork with no Discord server skips
+          # instead of failing. A webhook present but REJECTED is fatal.
           WEBHOOK: ${{ secrets.DISCORD_RELEASES_WEBHOOK }}
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.release.outputs.version }}
@@ -272,60 +272,26 @@ jobs:
             -X POST -d @payload.json "${WEBHOOK}"
           echo "Announced v${VERSION} in Discord."
 
-  # AUTO_MERGE_PAT is a silent single point of failure (warren-8b5f). GitHub
-  # suppresses workflow runs for GITHUB_TOKEN-authored pushes, so auto-merge.yml
-  # must merge with a PAT; when that PAT expires, PRs simply stop merging, main
-  # stops moving, and releases stop happening — with no failed run anywhere to
-  # notice. This job is the heartbeat: it runs on every release-workflow tick
-  # and turns a dead PAT into a red X.
+  # The auto-merge app credential is a silent single point of failure
+  # (warren-8b5f). GitHub suppresses workflow runs for GITHUB_TOKEN-authored
+  # pushes, so auto-merge.yml must merge with a GitHub App installation token;
+  # if that credential dies (key revoked, app uninstalled, secret or variable
+  # deleted), PRs simply stop merging, main stops moving, and releases stop
+  # happening — with no failed run anywhere to notice. This job is the
+  # heartbeat: it mints a token on every release-workflow tick and turns a
+  # dead credential into a red X. App private keys carry no expiry, so the
+  # old AUTO_MERGE_PAT expiry countdown (retired with warren-2565) has no
+  # successor — a successful mint is the whole proof.
   #
-  # It deliberately does NOT gate the release: an expired PAT breaks the merge
-  # queue, not this release (which is cut with github.token). So it is a
+  # It deliberately does NOT gate the release: a dead credential breaks the
+  # merge queue, not this release (which is cut with github.token). So it is a
   # sibling job with no `needs` edge — visible when it fails, never blocking.
-  pat-heartbeat:
+  app-heartbeat:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - name: Check AUTO_MERGE_PAT validity and expiry
-        env:
-          PAT: ${{ secrets.AUTO_MERGE_PAT }}
-          # Lead time to rotate before the merge queue stops (days).
-          WARN_DAYS: "14"
-        run: |
-          set -uo pipefail
-          if [ -z "${PAT}" ]; then
-            echo "::error::AUTO_MERGE_PAT is not configured. auto-merge.yml needs it to merge PRs in a way that re-triggers CI and Release (docs/project-setup.md §2)."
-            exit 1
-          fi
-          HEADERS=$(curl -sS -D - -o /dev/null --max-time 20 \
-            -H "Authorization: Bearer ${PAT}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/user | tr -d '\r' | tr 'A-Z' 'a-z')
-          STATUS=$(printf '%s\n' "${HEADERS}" | awk 'NR==1{print $2}')
-          if [ "${STATUS:-}" != "200" ]; then
-            echo "::error::AUTO_MERGE_PAT was rejected by api.github.com (HTTP ${STATUS:-none}) — it has expired or been revoked. Rotate it (docs/project-setup.md §2)."
-            exit 1
-          fi
-          EXPIRY=$(printf '%s\n' "${HEADERS}" | sed -n 's/^github-authentication-token-expiration:[[:space:]]*//p')
-          if [ -z "${EXPIRY}" ]; then
-            echo "AUTO_MERGE_PAT is valid and carries no expiration date."
-            exit 0
-          fi
-          # Compare on the YYYY-MM-DD prefix only; GitHub's timezone suffix
-          # varies and neither GNU nor BSD date parses every spelling.
-          DAY=$(printf '%s\n' "${EXPIRY}" | sed -n 's/^\([0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\).*/\1/p')
-          EXPIRY_EPOCH=$(date -u -d "${DAY}" +%s 2>/dev/null || date -u -j -f "%Y-%m-%d" "${DAY}" +%s 2>/dev/null || echo "")
-          if [ -z "${EXPIRY_EPOCH}" ]; then
-            echo "::warning::AUTO_MERGE_PAT expires ${EXPIRY} (unparseable date — check it by hand)."
-            exit 0
-          fi
-          DAYS=$(( (EXPIRY_EPOCH - $(date -u +%s)) / 86400 ))
-          if [ "${DAYS}" -le 0 ]; then
-            echo "::error::AUTO_MERGE_PAT expired on ${EXPIRY}. Rotate it now (docs/project-setup.md §2) or merges — and therefore releases — stop silently."
-            exit 1
-          fi
-          if [ "${DAYS}" -le "${WARN_DAYS}" ]; then
-            echo "::warning::AUTO_MERGE_PAT expires in ${DAYS} day(s) (${EXPIRY}). Rotate it (docs/project-setup.md §2)."
-          else
-            echo "AUTO_MERGE_PAT is valid for ${DAYS} more day(s) (${EXPIRY})."
-          fi
+      - name: Mint an auto-merge app token (proof the credential is alive)
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ vars.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}

--- a/docs/project-setup.md
+++ b/docs/project-setup.md
@@ -4,7 +4,8 @@ Checklist for configuring a GitHub repository so warren can open PRs that auto-m
 
 ## Prerequisites
 
-- A GitHub PAT with `contents:write` and `pull-requests:write` scopes
+- A GitHub App on your account with `contents:write` and `pull-requests:write`
+  repository permissions (created in §2 — no PAT, nothing expires)
 - The repo has a CI workflow (e.g. `.github/workflows/ci.yml`) that runs on pull requests
 - `gh` CLI authenticated
 
@@ -30,29 +31,48 @@ jobs:
       !github.event.pull_request.draft &&
       github.event.pull_request.user.login == github.repository_owner
     steps:
+      - name: Mint app installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ vars.AUTO_MERGE_APP_ID }}
+          private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
+
       - name: Enable auto-merge (squash)
         env:
-          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --squash "$PR_URL"
 ```
 
 This enables GitHub's auto-merge on every non-draft PR authored by the repo owner. Other authors' PRs still run CI but require manual merge. Squash keeps main history linear.
 
-The workflow uses `AUTO_MERGE_PAT` instead of `GITHUB_TOKEN` so the merge commit triggers downstream workflows (CI, Publish, Release). GitHub deliberately suppresses `GITHUB_TOKEN`-authored pushes to prevent recursive loops.
+The workflow authenticates with a GitHub App installation token instead of `GITHUB_TOKEN` so the merge commit triggers downstream workflows (CI, Publish, Release). GitHub deliberately suppresses `GITHUB_TOKEN`-authored pushes to prevent recursive loops. An App beats a PAT here. The workflow mints a fresh token on each run from a private key that never expires. A static PAT expires silently, and then merges and releases stop with no failed run to notice (warren-2565).
 
-## 2. Add the `AUTO_MERGE_PAT` secret
+## 2. Create the auto-merge GitHub App and wire its credentials
 
-**Settings → Secrets and variables → Actions → New repository secret**
+One-time, in the browser: **Settings → Developer settings → GitHub Apps → New GitHub App** (<https://github.com/settings/apps/new>)
 
-- Name: `AUTO_MERGE_PAT`
-- Value: your GitHub PAT
+- **GitHub App name:** anything unique, for example `<owner>-warren-automerge`
+- **Homepage URL:** the repo URL (a required field, not otherwise used)
+- **Webhook:** uncheck **Active**
+- **Repository permissions:** Contents — Read and write. Pull requests — Read and write
+- **Where can this GitHub App be installed:** Only on this account
 
-Or via CLI:
+After you create the app, on its settings page:
+
+1. Note the **App ID**.
+2. **Generate a private key** — downloads a `.pem` file.
+3. **Install App** → your account → **Only select repositories** → pick the repo.
+
+Give the credentials to Actions (App ID is not a secret, so it goes in a variable):
 
 ```bash
-gh secret set AUTO_MERGE_PAT --repo owner/repo
+gh variable set AUTO_MERGE_APP_ID --repo owner/repo --body '<app id>'
+gh secret set AUTO_MERGE_APP_PRIVATE_KEY --repo owner/repo < path/to/downloaded-key.pem
 ```
+
+There is no rotation cadence. The workflow mints a new installation token on each run, and the token expires after one hour on its own. The `app-heartbeat` job in `release.yml` mints a token on every release tick as proof that the credential is alive. A revoked key or an uninstalled app turns that job red before the merge queue can stall silently.
 
 ## 3. Enable auto-merge on the repo
 
@@ -117,7 +137,8 @@ gh api --method PATCH "repos/$REPO" \
 
 gh api --method DELETE "repos/$REPO/branches/main/protection/required_pull_request_reviews" 2>/dev/null
 
-gh secret set AUTO_MERGE_PAT --repo "$REPO"
+gh variable set AUTO_MERGE_APP_ID --repo "$REPO" --body '<app id>'
+gh secret set AUTO_MERGE_APP_PRIVATE_KEY --repo "$REPO" < path/to/downloaded-key.pem
 ```
 
 Then commit the workflow file and push.

--- a/scripts/release-hardening.test.ts
+++ b/scripts/release-hardening.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { load } from "js-yaml";
 
 // Guards for warren-8b5f: the release job must be at least as strict as CI,
 // must refuse to publish a release with no curated CHANGELOG section, and must
-// keep a heartbeat on AUTO_MERGE_PAT — the secret whose silent expiry stops
-// merges to main and therefore stops releases, with no failed run to notice.
+// keep a heartbeat on the auto-merge app credential — the credential whose
+// silent death stops merges to main and therefore stops releases, with no
+// failed run to notice.
 //
 // Workflows can't run locally, so these assert on the parsed YAML plus direct
 // execution of the shell the workflow embeds.
@@ -20,6 +21,8 @@ type Step = {
 	run?: string;
 	if?: string;
 	env?: Record<string, string>;
+	uses?: string;
+	with?: Record<string, string>;
 };
 
 type Job = { needs?: unknown; steps?: Step[] };
@@ -148,90 +151,43 @@ describe("a missing CHANGELOG section is fatal", () => {
 	});
 });
 
-/**
- * Execute the AUTO_MERGE_PAT heartbeat shell against a stubbed `curl` that
- * replays a canned response-header block.
- */
-function runHeartbeat(opts: { pat: string; headers: string }): {
-	exitCode: number;
-	output: string;
-} {
-	const script = stepScript("pat-heartbeat", "Check AUTO_MERGE_PAT");
-	const dir = mkdtempSync(join(tmpdir(), "warren-pat-heartbeat-"));
-	try {
-		const stub = join(dir, "curl");
-		writeFileSync(stub, `#!/bin/sh\ncat <<'EOF'\n${opts.headers}\nEOF\n`);
-		chmodSync(stub, 0o755);
-		const result = Bun.spawnSync({
-			cmd: ["bash", "-c", script],
-			env: {
-				PATH: `${dir}:${process.env.PATH ?? ""}`,
-				PAT: opts.pat,
-				WARN_DAYS: "14",
-			},
-			stdout: "pipe",
-			stderr: "pipe",
-		});
-		return {
-			exitCode: result.exitCode,
-			output: `${result.stdout.toString()}${result.stderr.toString()}`,
-		};
-	} finally {
-		rmSync(dir, { recursive: true, force: true });
-	}
-}
-
-/** A response-header block whose token expires `days` from now. */
-function headersExpiringIn(days: number): string {
-	const at = new Date(Date.now() + days * 86_400_000).toISOString().slice(0, 10);
-	return `HTTP/2 200\ncontent-type: application/json\ngithub-authentication-token-expiration: ${at} 07:00:00 UTC`;
-}
-
-describe("AUTO_MERGE_PAT heartbeat", () => {
-	test("runs as a sibling job so a dead PAT is visible but never blocks a release", () => {
-		const job = loadRelease().jobs?.["pat-heartbeat"];
+// The merge queue authenticates with a GitHub App installation token minted
+// per run (warren-2565 retired the static AUTO_MERGE_PAT after it expired
+// silently). App private keys carry no expiry, so the heartbeat is a mint
+// attempt: if the credential is dead, the mint step fails and the sibling
+// job goes red without blocking the release.
+describe("auto-merge app credential heartbeat", () => {
+	test("runs as a sibling job so a dead credential is visible but never blocks a release", () => {
+		const job = loadRelease().jobs?.["app-heartbeat"];
 		expect(job).toBeDefined();
 		// No `needs` edge in either direction: the release itself is cut with
-		// github.token and is unaffected by the PAT.
+		// github.token and is unaffected by the app credential.
 		expect(job?.needs).toBeUndefined();
 		expect(loadRelease().jobs?.deploy?.needs).toBe("release");
 	});
 
-	test("an unset secret fails", () => {
-		const r = runHeartbeat({ pat: "", headers: "HTTP/2 200" });
-		expect(r.exitCode).toBe(1);
-		expect(r.output).toContain("AUTO_MERGE_PAT is not configured");
+	test("the heartbeat mints a token from the app id and private key", () => {
+		const steps = releaseSteps("app-heartbeat");
+		const mint = steps.find((s) => s.uses?.startsWith("actions/create-github-app-token@"));
+		expect(mint).toBeDefined();
+		expect(mint?.with?.["app-id"]).toMatch(/^\$\{\{ vars\.AUTO_MERGE_APP_ID \}\}$/);
+		expect(mint?.with?.["private-key"]).toMatch(
+			/^\$\{\{ secrets\.AUTO_MERGE_APP_PRIVATE_KEY \}\}$/,
+		);
 	});
 
-	test("a revoked or expired token is rejected by the API and fails", () => {
-		const r = runHeartbeat({ pat: "ghp_x", headers: "HTTP/2 401\ncontent-type: application/json" });
-		expect(r.exitCode).toBe(1);
-		expect(r.output).toContain("HTTP 401");
+	test("no workflow still authenticates with the retired AUTO_MERGE_PAT", () => {
+		for (const file of ["auto-merge.yml", "bundle-size-autoheal.yml", "release.yml"]) {
+			const raw = readFileSync(resolve(REPO_ROOT, ".github/workflows", file), "utf8");
+			expect(raw).not.toContain("secrets.AUTO_MERGE_PAT");
+		}
 	});
 
-	test("a token past its expiry date fails", () => {
-		const r = runHeartbeat({ pat: "ghp_x", headers: headersExpiringIn(-1) });
-		expect(r.exitCode).toBe(1);
-		expect(r.output).toContain("::error::");
-		expect(r.output).toContain("expired on");
-	});
-
-	test("a token inside the rotation window warns but passes", () => {
-		const r = runHeartbeat({ pat: "ghp_x", headers: headersExpiringIn(3) });
-		expect(r.exitCode).toBe(0);
-		expect(r.output).toContain("::warning::");
-	});
-
-	test("a healthy token passes quietly", () => {
-		const r = runHeartbeat({ pat: "ghp_x", headers: headersExpiringIn(120) });
-		expect(r.exitCode).toBe(0);
-		expect(r.output).not.toContain("::warning::");
-		expect(r.output).toContain("is valid for");
-	});
-
-	test("a non-expiring token passes", () => {
-		const r = runHeartbeat({ pat: "ghp_x", headers: "HTTP/2 200\ncontent-type: application/json" });
-		expect(r.exitCode).toBe(0);
-		expect(r.output).toContain("no expiration date");
+	test("every consumer of the app credential names the same variable and secret", () => {
+		for (const file of ["auto-merge.yml", "bundle-size-autoheal.yml", "release.yml"]) {
+			const raw = readFileSync(resolve(REPO_ROOT, ".github/workflows", file), "utf8");
+			expect(raw).toContain("vars.AUTO_MERGE_APP_ID");
+			expect(raw).toContain("secrets.AUTO_MERGE_APP_PRIVATE_KEY");
+		}
 	});
 });


### PR DESCRIPTION
## Summary

The static `AUTO_MERGE_PAT` expired silently on 2026-08-07 (set 2026-05-15) and every PR since needed a manual merge. This retires the PAT from all three workflow consumers in favor of a GitHub App installation token minted fresh per run via `actions/create-github-app-token@v3.2.0`, from `AUTO_MERGE_APP_ID` (repo variable) + `AUTO_MERGE_APP_PRIVATE_KEY` (secret). App-authored pushes still trigger downstream workflows (CI, Release), which is the whole reason `GITHUB_TOKEN` couldn't be used.

- **auto-merge.yml** — arms the squash merge with the minted token
- **bundle-size-autoheal.yml** — checks out and pushes heal commits with it
- **release.yml** — `pat-heartbeat` becomes `app-heartbeat`: app keys carry no expiry, so a successful mint per release tick is the whole proof; the expiry-countdown shell is deleted
- **docs/project-setup.md §2** — documents the one-time app registration in place of PAT rotation
- **scripts/release-hardening.test.ts** — the heartbeat shell tests become YAML-shape assertions, plus a retirement guard: no workflow may reference `secrets.AUTO_MERGE_PAT` again

## Before merging (operator setup, one time)

1. Create the app: https://github.com/settings/apps/new — webhook off, permissions Contents R/W + Pull requests R/W, install on `jayminwest/warren`
2. `gh variable set AUTO_MERGE_APP_ID --body '<app id>'`
3. `gh secret set AUTO_MERGE_APP_PRIVATE_KEY < <downloaded>.pem`

After the first post-merge PR proves the flow: delete the `AUTO_MERGE_PAT` secret.

This PR touches `auto-merge.yml`, an Article IX protected path — it requires a human merge by design (closes warren-2565, moots warren-beb3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)