### PR TITLE
fix: bound the per-request idle timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,17 +161,19 @@ GITHUB_TOKEN=
 # Instance-wide concurrent event streams.
 # WARREN_MAX_EVENT_STREAMS=200
 #
-# Concurrent event streams per client. The client is the left-most
-# `X-Forwarded-For` hop when warren sits behind Caddy / an Ingress (the
-# canonical deploy), else the socket peer address.
+# Concurrent event streams per client. The client is read from
+# `X-Forwarded-For` counting from the RIGHT, skipping
+# WARREN_EVENT_STREAM_TRUSTED_PROXY_HOPS infrastructure entries, else the
+# socket peer address. The left-most hop is client-controlled, so keying on
+# it let one source rotate the header and drain the global budget.
 # WARREN_MAX_EVENT_STREAMS_PER_CLIENT=5
 #
-# Wall-clock budget for one connection, as a duration ("4h", "90m"). OFF by
-# default: expiry ends the stream cleanly and the UI treats a clean close as
-# "ended" rather than reconnecting, so enabling this stops live updates
-# mid-run for browser clients. Worth setting on a public instance, where a
-# wedged client holding a slot forever is the bigger risk.
-# WARREN_EVENT_STREAM_MAX_LIFETIME=0
+# Wall-clock budget for one connection, as a duration ("4h", "90m").
+# Defaults to 4h. Expiry ends the stream cleanly and the UI treats a clean
+# close as "ended" rather than reconnecting, so a client watching a run for
+# longer than this stops getting live updates until it reconnects. Set 0 to
+# disable the cap, at the cost of a wedged client holding a slot forever.
+# WARREN_EVENT_STREAM_MAX_LIFETIME=4h
 
 # ---------- optional: storage ----------
 

--- a/deploy/k8s/overlays/gke/backendconfig.yaml
+++ b/deploy/k8s/overlays/gke/backendconfig.yaml
@@ -25,8 +25,8 @@ spec:
   securityPolicy:
     name: warren-armor
   # The GCE backend-service default is 30s, which would cut every long-lived
-  # NDJSON event stream (GET /runs/:id/events, unbounded by default —
-  # WARREN_EVENT_STREAM_MAX_LIFETIME=0). This is a stream *response* timeout,
+  # NDJSON event stream (GET /runs/:id/events, capped at 4h by default via
+  # WARREN_EVENT_STREAM_MAX_LIFETIME). This is a stream *response* timeout,
   # not an idle timeout, so it must exceed the longest run a client watches.
   timeoutSec: 3600
   # LB request logging is where Cloud Armor decisions surface (the

--- a/src/server/preview-server.ts
+++ b/src/server/preview-server.ts
@@ -21,6 +21,7 @@ import { previewError } from "../preview/proxy/responses.ts";
 import { errorLogFields, renderError } from "./errors.ts";
 import { bindRequestIdLogger, extractOrGenerateRequestId, stampRequestId } from "./request-id.ts";
 import { jsonResponse, withSecurityHeaders } from "./response.ts";
+import { DEFAULT_IDLE_TIMEOUT_SECONDS } from "./server.ts";
 import type { Logger, PreviewProxyHandler, ServeHandle, Transport } from "./types.ts";
 
 export interface PreviewServerOptions {
@@ -29,7 +30,11 @@ export interface PreviewServerOptions {
 	readonly port: number;
 	readonly proxy: PreviewProxyHandler;
 	readonly logger: Logger;
-	/** Matches the main listener's streaming-friendly default (0 = disabled). */
+	/**
+	 * Per-request idle timeout in seconds. Matches the main listener's
+	 * bounded default; 0 disables it. This origin has no streaming route of
+	 * its own, so nothing here opts out (warren-a676).
+	 */
 	readonly idleTimeout?: number;
 }
 
@@ -41,7 +46,7 @@ export interface PreviewServerOptions {
  * mounting it replaced.
  */
 export function startPreviewServer(opts: PreviewServerOptions): ServeHandle {
-	const idleTimeout = opts.idleTimeout ?? 0;
+	const idleTimeout = opts.idleTimeout ?? DEFAULT_IDLE_TIMEOUT_SECONDS;
 	const logger = opts.logger;
 
 	const fetchHandler = async (request: Request): Promise<Response> => {

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -13,7 +13,7 @@ import { checkBurrowPoolReachable } from "../runtime/local/diagnostics/burrow.ts
 import { resolveRuntimeProvider } from "../runtime/registry.ts";
 import { bearerAuth, NO_AUTH } from "./auth.ts";
 import { createBridgeRegistry } from "./bridges.ts";
-import { startServer } from "./server.ts";
+import { DEFAULT_IDLE_TIMEOUT_SECONDS, startServer } from "./server.ts";
 import type { BridgeRegistry, Route, ServeHandle, ServeOptions, ServerDeps } from "./types.ts";
 
 const silentLogger = {
@@ -277,36 +277,18 @@ describe("startServer — lifecycle", () => {
 		expect(res.status).toBe(500);
 	});
 
-	test("default idleTimeout=0 keeps a >10s-quiet streaming response alive (warren-b8fc)", async () => {
-		// Bun.serve's default idleTimeout is 10s; without our override the
-		// per-request timer would close this connection mid-stream and the
-		// second chunk would never arrive. We pause 11s between chunks so
-		// the fix being plumbed (idleTimeout: 0 default) is what makes the
-		// assertion pass.
-		const routes: Route[] = [
-			{
-				method: "GET",
-				pattern: "/slow",
-				policy: "readPublic",
-				handler: () =>
-					new Response(
-						new ReadableStream({
-							async start(controller) {
-								controller.enqueue(new TextEncoder().encode("a\n"));
-								await new Promise((r) => setTimeout(r, 11_000));
-								controller.enqueue(new TextEncoder().encode("b\n"));
-								controller.close();
-							},
-						}),
-						{ headers: { "content-type": "application/x-ndjson" } },
-					),
-			},
-		];
-		handle = startServer(await depsFor(repos), tcpOpts({ routes }));
-		const res = await fetch(`${tcpUrl(handle)}/slow`);
-		const body = await res.text();
-		expect(body).toBe("a\nb\n");
-	}, 15_000);
+	test("the default idle timeout is bounded (warren-a676)", () => {
+		// The regression this issue is about: the default was 0, which
+		// disables the timer for every route on the listener.
+		//
+		// This is asserted on the constant rather than through a request on
+		// purpose. `idleTimeout` fires on socket inactivity while a request
+		// is being read, and that timer does not run under `bun test`: the
+		// same stalled request a listener closes after ~1s under `bun run`
+		// is served in full here. A behavioural assertion would pass
+		// whatever the default is, which is worse than no test.
+		expect(DEFAULT_IDLE_TIMEOUT_SECONDS).toBeGreaterThan(0);
+	});
 });
 
 describe("startServer — routes", () => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -55,14 +55,21 @@ type ServeServer = ReturnType<typeof Bun.serve>;
 const DEFAULT_TRANSPORT: Transport = { kind: "tcp", hostname: "127.0.0.1", port: 0 };
 
 /**
- * Bun.serve's per-request idleTimeout defaults to 10 seconds; that
- * silently kills the long-lived NDJSON stream behind
- * `GET /runs/:id/events?follow=1` whenever the agent has a quiet stretch
- * (warren-b8fc). 0 disables the per-request timeout — every other route
- * here completes in milliseconds, so a server-wide disable is safe and
- * keeps the streaming surface honest.
+ * Per-request idle timeout handed to `Bun.serve`, in seconds.
+ *
+ * This was 0 (warren-b8fc), which disables the timer for the whole server
+ * and left no route with slow-request protection (warren-a676). What the
+ * timer actually watches is socket inactivity while a request is being
+ * read: a client that drips its body a byte at a time is refused once the
+ * gap exceeds this, and with 0 it is served no matter how long it stalls.
+ *
+ * It does NOT watch a handler that takes its time, nor a response body
+ * that stays quiet, so the long-lived NDJSON tails behind
+ * `GET /runs/:id/events?follow=1` are unaffected by a bounded value and
+ * need no per-route exemption. Their own lifetime and concurrency caps
+ * live in `stream-limits.ts`.
  */
-const DEFAULT_IDLE_TIMEOUT_SECONDS = 0;
+export const DEFAULT_IDLE_TIMEOUT_SECONDS = 30;
 
 /**
  * Boot the wire layer for a fully-wired `ServerDeps`. The serving side

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -370,10 +370,11 @@ export interface ServeOptions {
 	routes?: readonly Route[];
 	logger?: Logger;
 	/**
-	 * Per-request idle timeout in seconds passed to `Bun.serve`. Defaults
-	 * to 0 (disabled) so long-lived NDJSON streams aren't killed at the
-	 * Bun runtime default of 10s (warren-b8fc). Tests override to assert
-	 * the wire is plumbed.
+	 * Per-request idle timeout in seconds passed to `Bun.serve`. Defaults to
+	 * `DEFAULT_IDLE_TIMEOUT_SECONDS`. The timer watches socket inactivity
+	 * while a request is being read, so it bounds a stalled client without
+	 * touching a long-lived NDJSON tail (warren-b8fc, warren-a676). 0
+	 * disables it for the whole listener.
 	 */
 	idleTimeout?: number;
 	/**


### PR DESCRIPTION
Closes #807.

## Summary

- `DEFAULT_IDLE_TIMEOUT_SECONDS` goes from 0 to 30, so the listener has slow-request protection again
- `preview-server.ts` shares that constant instead of repeating its own `?? 0`
- the two stale comments the issue flags are corrected
- I did not add the per-route scoping the issue asks for, and the measurements below are why

## What the timer actually watches

I went looking for the smallest change that would give the two stream routes an exemption, and measured first to make sure the exemption was needed. On Bun 1.3.14, `idleTimeout` turned out to watch a narrower thing than I expected, so the fix is smaller than the issue's fix direction.

Three shapes, one listener booted per shape, `idleTimeout: 1` and a 3s stall:

| shape | outcome |
| --- | --- |
| handler awaits 3s before returning a `Response` | served, 3008ms |
| response body is a `ReadableStream` quiet for 3s | served, 3009ms |
| client drips a chunked request body with a 3s gap | socket closed, 998ms |

So the timer fires on socket inactivity while the request is still being read. That is the Slowloris shape, and it is the protection the issue is about. The before and after of the defect, same request both times:

```
idleTimeout=0: served "got 2\n" after 4015ms
idleTimeout=2: closed by the listener
```

Two consequences for the fix:

**No per-route exemption.** A bounded value does not reap the NDJSON tails, because it does not watch response bodies. Exempting them with `server.timeout(request, 0)` would have removed slow-client protection from the two routes most likely to have a connection held open against them, in exchange for nothing.

**30 seconds.** Every route other than the tails completes in milliseconds, as the comment being replaced already noted, so this is far above anything legitimate and still bounded. Happy to move it if you have a number in mind.

## The test, and why it asserts a constant

`idleTimeout` does not fire under `bun test`. The same stalled request that a listener closes after ~1s under `bun run` is served in full inside the test runner. I confirmed it against a bare `Bun.serve` in a test file, so it is the runner rather than anything in `startServer`.

That makes a behavioural assertion here worse than useless: it would pass with the default at 0, which is exactly the regression it would exist to catch. `src/server/server.test.ts:280` replaces the old 15s streaming test with a cheap assertion that the default is greater than zero, and the comment records why. If you would rather have the real thing, it would need to live outside `bun test`, and I am glad to write it as a script gate if you want that.

## One judgement call to flag

`startPreviewServer` now inherits the bounded default. That origin proxies whatever the preview app serves, so a preview app that holds a request open while reading a slow body would now be cut at 30s where it was not before. The issue asks for the same treatment there and I think it is right, but it is the one line in here that changes behaviour for code neither of us controls. Say the word and I will leave preview unbounded.

## Changes

- `src/server/server.ts`: bounded default, exported, comment rewritten around what the timer measures
- `src/server/preview-server.ts`: shares the constant
- `src/server/types.ts`: `ServeOptions.idleTimeout` doc corrected
- `src/server/server.test.ts`: the old test replaced as described
- `.env.example`: `WARREN_EVENT_STREAM_MAX_LIFETIME` documented as 4h rather than "OFF by default", and the per-client key described as counting `X-Forwarded-For` from the right, matching `eventStreamClientKey` since warren-46a7
- `deploy/k8s/overlays/gke/backendconfig.yaml`: same lifetime correction

Out of scope, as the issue says: no request body size limit and no application-level max request duration. Happy to file those separately.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun test` passes: 96 failing tests before and after, same test names, all of them Windows-only shell-script and sqlite-path cases on this machine
- [x] Manual verification: the tables above, measured with standalone scripts under `bun run`
