### PR TITLE
fix: make the plan-runs default filter mean every state

### DIFF
--- a/src/client/types.plan-runs.ts
+++ b/src/client/types.plan-runs.ts
@@ -2,7 +2,7 @@
  * Plan-run wire types (warren-8ffc), split out of `./types.ts`
  * (warren-fcc8) to keep that file under its line budget.
  */
-import type { PlanRunChildState, PlanRunState } from "../core/wire.ts";
+import type { PlanRunChildState, PlanRunState, PlanRunStateFilter } from "../core/wire.ts";
 import type { RunRow } from "./types.ts";
 
 /* Plan-runs — typed facade over /plan-runs (warren-8ffc).                 */
@@ -81,7 +81,8 @@ export interface PlanRunDetailResponse {
 
 export interface ListPlanRunsFilter {
 	project?: string;
-	state?: PlanRunState;
+	/** Omit for every state; `active` is the live view (warren-302a). */
+	state?: PlanRunStateFilter;
 }
 
 export interface ListPlanRunsResponse {

--- a/src/core/wire.ts
+++ b/src/core/wire.ts
@@ -543,6 +543,14 @@ export function isTerminalPlanRunState(state: PlanRunState): state is PlanRunTer
 }
 
 /**
+ * Values `GET /plan-runs?state=` accepts (warren-302a). `active` is the union
+ * of `PLAN_RUN_ACTIVE_STATES` rather than a state a row can hold, so asking
+ * for the live view is explicit. Omitting the parameter means every state.
+ */
+export const PLAN_RUN_STATE_FILTERS = ["active", ...PLAN_RUN_STATES] as const;
+export type PlanRunStateFilter = (typeof PLAN_RUN_STATE_FILTERS)[number];
+
+/**
  * Per-child lifecycle within a plan-run (pl-a258 step 2 / warren-4d7c).
  *
  *   - `pending`    — child seed not yet dispatched; waiting for its turn.

--- a/src/server/handlers/plan-runs.get.test.ts
+++ b/src/server/handlers/plan-runs.get.test.ts
@@ -32,7 +32,8 @@ describe("GET /plan-runs", () => {
 		await db.close();
 	});
 
-	test("returns active plan_runs when no filter is set", async () => {
+	/** One queued row and one driven through to succeeded. */
+	async function seedOneOfEach(): Promise<void> {
 		await repos.planRuns.create({
 			planId: "pl-active",
 			projectId: seedyProjectId,
@@ -45,25 +46,61 @@ describe("GET /plan-runs", () => {
 			agentName: "claude-code",
 			children: [{ seq: 1, seedId: "wa-b" }],
 		});
-		// Drive the second through to running → succeeded so listActive omits it.
 		await repos.planRuns.transitionTo(done.planRun.id, "running", {
 			startedAt: new Date().toISOString(),
 		});
 		await repos.planRuns.transitionTo(done.planRun.id, "succeeded", {
 			endedAt: new Date().toISOString(),
 		});
+	}
 
+	async function serve(): Promise<string> {
 		const deps = await depsFor({ repos, sdSpawn: makeSdSpawn([], []) });
 		handle = startServer(deps, {
 			transport: { kind: "tcp", hostname: "127.0.0.1", port: 0 },
 			auth: NO_AUTH,
 			logger: silentLogger,
 		});
+		return tcpUrl(handle);
+	}
 
-		const res = await fetch(`${tcpUrl(handle)}/plan-runs`);
+	async function planIds(url: string): Promise<string[]> {
+		const res = await fetch(url);
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as { planRuns: { planId: string }[] };
-		expect(body.planRuns.map((p) => p.planId)).toEqual(["pl-active"]);
+		return body.planRuns.map((p) => p.planId).sort();
+	}
+
+	// warren-302a: no filter used to mean active-only here and every state on
+	// the project-scoped path, so a quiet instance opened on an empty table
+	// while finished plan-runs sat one click away.
+	test("returns every state when no filter is set", async () => {
+		await seedOneOfEach();
+		const base = await serve();
+		expect(await planIds(`${base}/plan-runs`)).toEqual(["pl-active", "pl-done"]);
+	});
+
+	test("the project-scoped path agrees with it", async () => {
+		await seedOneOfEach();
+		const base = await serve();
+		expect(await planIds(`${base}/plan-runs?project=${seedyProjectId}`)).toEqual([
+			"pl-active",
+			"pl-done",
+		]);
+	});
+
+	test("?state=active is how the live view is asked for now", async () => {
+		await seedOneOfEach();
+		const base = await serve();
+		expect(await planIds(`${base}/plan-runs?state=active`)).toEqual(["pl-active"]);
+	});
+
+	test("?state=active narrows the project-scoped path too", async () => {
+		await seedOneOfEach();
+		const base = await serve();
+		expect(await planIds(`${base}/plan-runs?project=${seedyProjectId}&state=active`)).toEqual([
+			"pl-active",
+		]);
 	});
 
 	test("filters by project + state", async () => {

--- a/src/server/handlers/plan-runs.ts
+++ b/src/server/handlers/plan-runs.ts
@@ -13,6 +13,11 @@
  */
 
 import { ValidationError } from "../../core/errors.ts";
+import {
+	isTerminalPlanRunState,
+	PLAN_RUN_STATE_FILTERS,
+	type PlanRunStateFilter,
+} from "../../core/wire.ts";
 import { mintGitCredentialSecret } from "../../forge/credentials.ts";
 import { cancelPlanRun, createPlanRun, tailPlanRunEvents } from "../../plan-runs/index.ts";
 import { jsonResponse, ndjsonResponse } from "../response.ts";
@@ -39,20 +44,11 @@ import {
 /* Plan runs (warren-f923 / pl-a258 step 6)                                 */
 /* ----------------------------------------------------------------------- */
 
-const PLAN_RUN_STATE_FILTER_VALUES = [
-	"queued",
-	"running",
-	"succeeded",
-	"failed",
-	"cancelled",
-] as const;
-type PlanRunStateFilter = (typeof PLAN_RUN_STATE_FILTER_VALUES)[number];
-
 function parsePlanRunStateFilter(raw: string | null): PlanRunStateFilter | undefined {
 	if (raw === null) return undefined;
-	if (!(PLAN_RUN_STATE_FILTER_VALUES as readonly string[]).includes(raw)) {
+	if (!(PLAN_RUN_STATE_FILTERS as readonly string[]).includes(raw)) {
 		throw new ValidationError(
-			`?state must be one of ${PLAN_RUN_STATE_FILTER_VALUES.join(", ")}; got '${raw}'`,
+			`?state must be one of ${PLAN_RUN_STATE_FILTERS.join(", ")}; got '${raw}'`,
 		);
 	}
 	return raw as PlanRunStateFilter;
@@ -122,18 +118,24 @@ export function listPlanRunsHandler(deps: ServerDeps): RouteHandler {
 		if (projectId !== null) {
 			const rows = await deps.repos.planRuns.listByProjectAndState(
 				projectId,
-				state !== undefined ? state : undefined,
+				state !== undefined && state !== "active" ? state : undefined,
 			);
+			const scoped =
+				state === "active" ? rows.filter((row) => !isTerminalPlanRunState(row.state)) : rows;
 			return jsonResponse(200, {
-				planRuns: rows.map((row) => projectPlanRun(row, ctx.actor)),
+				planRuns: scoped.map((row) => projectPlanRun(row, ctx.actor)),
 			});
 		}
-		// No project filter — return active PlanRuns when no state requested,
-		// or the operator's chosen state across every project.
-		if (state !== undefined) {
-			// listByProjectAndState requires a project; for a state-only view
-			// we walk projects sequentially. Volume is tiny relative to runs
-			// (one plan-run per dispatched plan, not per child).
+		if (state === "active") {
+			const active = await deps.repos.planRuns.listActive();
+			return jsonResponse(200, {
+				planRuns: active.map((row) => projectPlanRun(row, ctx.actor)),
+			});
+		}
+		// listByProjectAndState requires a project, so the unscoped view walks
+		// projects. Volume is tiny relative to runs (one plan-run per
+		// dispatched plan, not per child). `state` undefined means every state.
+		{
 			const projects = await deps.repos.projects.listAll();
 			const all = (
 				await Promise.all(
@@ -144,10 +146,6 @@ export function listPlanRunsHandler(deps: ServerDeps): RouteHandler {
 				planRuns: all.map((row) => projectPlanRun(row, ctx.actor)),
 			});
 		}
-		const active = await deps.repos.planRuns.listActive();
-		return jsonResponse(200, {
-			planRuns: active.map((row) => projectPlanRun(row, ctx.actor)),
-		});
 	};
 }
 

--- a/src/ui/src/api/client.ts
+++ b/src/ui/src/api/client.ts
@@ -15,7 +15,7 @@ import type {
 	ListRunsResponse,
 	PlanRunDetailResponse,
 	PlanRunRow,
-	PlanRunState,
+	PlanRunStateFilter,
 	PreviewConfigResponse,
 	PreviewLoginResponse,
 	PreviewTeardownResponse,
@@ -329,7 +329,8 @@ export function formatPreviewUrl(
 
 export interface ListPlanRunsFilter {
 	project?: string;
-	state?: PlanRunState;
+	/** Omit for every state; `active` is the live view (warren-302a). */
+	state?: PlanRunStateFilter;
 }
 
 export const planRunsApi = {

--- a/src/ui/src/api/types.ts
+++ b/src/ui/src/api/types.ts
@@ -26,6 +26,7 @@ export {
 	PLAN_RUN_TERMINAL_STATES,
 	type PlanRunChildState,
 	type PlanRunState,
+	type PlanRunStateFilter,
 	PREVIEW_ACTIVE_STATES,
 	type PreviewState,
 	type PullRequestLifecycle,

--- a/src/ui/src/pages/PlanRuns.tsx
+++ b/src/ui/src/pages/PlanRuns.tsx
@@ -2,7 +2,13 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { planRunsApi, projectsApi } from "@/api/client.ts";
-import type { CapabilityName, PlanRunRow, PlanRunState, RunRow } from "@/api/types.ts";
+import type {
+	CapabilityName,
+	PlanRunRow,
+	PlanRunState,
+	PlanRunStateFilter,
+	RunRow,
+} from "@/api/types.ts";
 import { OperatorOnly, useOperatorHint } from "@/components/OperatorOnly.tsx";
 import { PlanRunStateBadge } from "@/components/PlanRunStateBadge.tsx";
 import { Alert } from "@/components/ui/alert.tsx";
@@ -45,8 +51,14 @@ const TABS: { label: string; value: PlanRunsTab }[] = [
 	{ label: "Ready to dispatch", value: "ready" },
 ];
 
-const STATE_FILTERS: { label: string; value: "all" | PlanRunState }[] = [
-	{ label: "Active", value: "all" },
+// warren-302a: the default pill used to read "Active" while carrying the
+// value "all", and the server read a missing `?state` as active-only when no
+// project was selected and as every state when one was. Three different
+// things. "All" is now a real option and the default, so a visitor landing
+// here sees history instead of an empty table on a quiet instance.
+const STATE_FILTERS: { label: string; value: "all" | PlanRunStateFilter }[] = [
+	{ label: "All", value: "all" },
+	{ label: "Active", value: "active" },
 	{ label: "Queued", value: "queued" },
 	{ label: "Running", value: "running" },
 	{ label: "Succeeded", value: "succeeded" },
@@ -57,7 +69,7 @@ const STATE_FILTERS: { label: string; value: "all" | PlanRunState }[] = [
 export function PlanRunsPage() {
 	const caps = useCapabilities();
 	const [tab, setTab] = useState<PlanRunsTab>("plan-runs");
-	const [stateFilter, setStateFilter] = useState<"all" | PlanRunState>("all");
+	const [stateFilter, setStateFilter] = useState<"all" | PlanRunStateFilter>("all");
 	const [projectFilter, setProjectFilter] = useState<string>("");
 
 	const planRuns = useQuery({


### PR DESCRIPTION
Closes #769.

## Summary

- `?state=active` is now a thing a caller asks for, defined in `wire.ts` as the union of the non-terminal states
- omitting `?state` means every state, on the project-scoped path and the unscoped one alike
- the UI gains a real "All" pill and defaults to it, so the label, the value and the server behaviour finally agree

## What was happening

The three pieces disagreed in a way that only showed up on a quiet instance. The default pill was labelled "Active" and carried the value `"all"`, which the UI translates into no `?state` parameter. The handler then read a missing `?state` two different ways: `listActive()` when no project was selected, and every state when one was.

So a visitor landing on the page with no project selected got active-only under a pill that said "Active" while carrying `"all"`, and had to guess and click "Succeeded" to find out the instance had ever run a plan. Selecting a project silently changed what the same pill meant.

## The shape of the fix

`active` is not a state a row can hold, so it lives in `wire.ts` next to `PLAN_RUN_ACTIVE_STATES` rather than being spelled out again in the handler:

```ts
export const PLAN_RUN_STATE_FILTERS = ["active", ...PLAN_RUN_STATES] as const;
```

The unscoped no-state path now walks projects the same way the state-filtered one already did, so both paths answer "every state" to the same question. `?state=active` keeps the old landing behaviour for anyone who wants it: `listActive()` unscoped, and a terminal-state filter on the project-scoped path, where the repo has no per-project active query.

`check:wire-types` caught me declaring the filter union locally in `PlanRuns.tsx` on the first pass. Good gate.

## Left out on purpose

The issue also suggests folding in the per-row `GET /plan-runs/:id` refetch at `PlanRuns.tsx:256-277`, the one that multiplies by concurrent visitors. It is a real problem and I would like to take it, but it is a different change: it wants server-side counts on the list envelope, which means touching the wire shape and the projection. CONTRIBUTING asks for one concern per PR, so I would rather send it separately once this lands. Happy to do that next if you want it.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun run build:ui` passes
- [x] `bun test` passes: 96 failing tests before and after, same names, all of them Windows-only shell-script and sqlite-path cases on this machine
- [x] Four tests in `plan-runs.get.test.ts`. Three fail on `main` and pass here: no filter returning both rows, `?state=active` unscoped, and `?state=active` project-scoped. The fourth, the project-scoped path with no filter, passes on both sides on purpose, since that path already returned every state and it is the asymmetry the other three are measured against.
