### PR TITLE
feat(runs): classify a policy-refused push as push_rejected_policy (warren-b68d)

### DIFF
--- a/scripts/bundle-size-budgets.json
+++ b/scripts/bundle-size-budgets.json
@@ -9,19 +9,20 @@
 	"$comment_public_labels_2026_07_30": "BOUNDED AUTO-RAISE (warren-14fc / #641): src/ui/src/lib/labels.ts adds the visitor-facing label maps for run / plan-run failure reasons plus the plan-run child rollup, and the call sites that consume them. Net +607 B gzip js / +1211 B raw js — ordinary feature growth, well inside AUTO_RAISE_CAP, re-baselined via `bun run check:bundle-size --update` on a clean --frozen-lockfile build. No new dependency. CSS shrank (no new utilities) and is ratcheted down to its measured floor. The 'ratchet only goes down' rule resumes from here.",
 	"$comment_spectator_dead_ends_2026_08_14": "BOUNDED AUTO-RAISE, RAW JS ONLY (warren-4e7a / #806): Agents.tsx gains the useOperatorHint call and its gated hint node, Login.tsx gains the useCapabilities read and the back-to-/runs link. Net +175 B raw js, measured on a clean --frozen-lockfile build whose numbers match CI byte for byte. Only totals.raw.js was over, so only totals.raw.js takes the script's re-baselined figure; the five budgets the change never exceeded (gzip js, largest gzip js, and all three css) keep their previous, lower ceilings rather than absorb the script's blanket headroom, because css did not move at all and gzip js came in 170 B UNDER its existing floor. The 'ratchet only goes down' rule resumes from here.",
 	"$comment_directory_struggle_2026_08_15": "BOUNDED AUTO-RAISE, RAW ONLY (warren-25b7 / pl-103e step 13): RunAnalytics gains the per-directory struggle table (run-analytics/directory-struggle.tsx) and the denominator/confidence footer on insight callouts. Net +2543 B raw js / +88 B raw css — ordinary feature growth, well inside AUTO_RAISE_CAP, re-baselined via `bun run check:bundle-size --update` on the measured build. Both gzip budgets came in UNDER their existing floors (js 285410 vs 287168, css 7638 vs 7687), so the ratchet took them DOWN; only the two raw budgets moved up. The 'ratchet only goes down' rule resumes from here.",
+	"$comment_push_rejected_policy_2026_08_16": "BOUNDED AUTO-RAISE, JS ONLY (warren-b68d / #809): the UI gains the `push_rejected_policy` entry in the run-failure-reason label map (labels.ts is `satisfies Record<RunFailureReason, string>`, so a new wire reason cannot ship without it) and the `reap.push_rejected` summary case in run-detail-events.tsx, which puts the unblock URL on the event's one-line summary instead of only in the expanded payload. Net +1116 B raw js / +298 B gzip js, well inside AUTO_RAISE_CAP, re-baselined via `bun run check:bundle-size --build --update` on a clean --frozen-lockfile build in oven/bun:1.3.14 so the numbers match CI. No new dependency. Both css budgets and largest.raw.js were never exceeded and keep their existing, lower ceilings. The 'ratchet only goes down' rule resumes from here.",
 	"totals": {
 		"raw": {
-			"js": 950663,
+			"js": 951779,
 			"css": 37394
 		},
 		"gzip": {
-			"js": 287896,
+			"js": 288194,
 			"css": 7699
 		}
 	},
 	"largest": {
 		"gzip": {
-			"js": 161510,
+			"js": 161810,
 			"css": 7699
 		}
 	}

--- a/src/core/wire.ts
+++ b/src/core/wire.ts
@@ -145,6 +145,8 @@ export type CloneKind = (typeof CLONE_KINDS)[number];
  *     recoverable instead of being silently destroyed. Distinct from
  *     `dropped_commit` (push succeeded but landed zero commits over a
  *     still-dirty tree): here the push itself never completed.
+ *   - `push_rejected_policy` (warren-b68d) narrows `finalize_failed` to a push
+ *     the REMOTE refused on policy grounds; see `../runtime/push-rejection.ts`.
  *   - `finalize_unposted` (warren-5ea1) means the K8s in-pod finalize
  *     never POSTed a result at all — the pod reached a terminal phase
  *     (or vanished, or the round-trip timed out) while warren was still
@@ -207,6 +209,7 @@ export const RUN_FAILURE_REASONS = [
 	"burrow_unreachable",
 	"dropped_commit",
 	"finalize_failed",
+	"push_rejected_policy",
 	"finalize_unposted",
 	"provider_error",
 	"oom_killed",

--- a/src/runs/reap/pipeline.ts
+++ b/src/runs/reap/pipeline.ts
@@ -23,6 +23,7 @@ import type { EventRow, ProjectRow, RunRow } from "../../db/schema.ts";
 import type { PreviewSidecarResolver } from "../../preview/launch/index.ts";
 import type { FinalizeResult, FinalizeStage, RuntimeProvider } from "../../runtime/contract.ts";
 import { finalizeCommitStage, finalizeMergeStage } from "../../runtime/contract.ts";
+import { PUSH_REJECTED_EVENT } from "../../runtime/push-rejection.ts";
 import type { BoundBridgeLogger } from "../stream/index.ts";
 import { dispatchAutoPlanRuns, hasAutoPlanRunFrontmatter, parsePlanIds } from "./auto-plan-run.ts";
 import { applyK8sCloneDeltas } from "./clone-apply.ts";
@@ -58,6 +59,10 @@ export interface ReapPipelineState {
 	 * `finalize_failed` in reap.
 	 */
 	finalizeUnposted: NonNullable<FinalizeResult["unposted"]> | null;
+	/** warren-b68d: the REMOTE refused the push on policy grounds, narrowing
+	 * `finalizeFailed` to `push_rejected_policy`. False for a non-fast-forward,
+	 * which stays `finalize_failed`; the unblock URL rides the replayed event. */
+	pushRejectedByPolicy: boolean;
 	/** warren-e9e1 (leg 2): K8s finalize's mirror deltas applied to the clone; local=false. */
 	cloneDeltasApplied: boolean;
 	/**
@@ -93,6 +98,7 @@ export function createPipelineState(): ReapPipelineState {
 		noChanges: false,
 		finalizeFailed: false,
 		finalizeUnposted: null,
+		pushRejectedByPolicy: false,
 		cloneDeltasApplied: false,
 		mirrorDurabilityFailed: false,
 		prUrl: null,
@@ -226,6 +232,9 @@ function applyFinalizeToState(state: ReapPipelineState, r: FinalizeResult): void
 	state.finalizeFailed = r.stages.some((s) => s.stage === "branch_push" && s.status === "failed");
 	// warren-5ea1: a warren-synthesized result (pod never posted) carries its cause.
 	state.finalizeUnposted = r.unposted ?? null;
+	// warren-b68d: trust a POLICY refusal only alongside a failed push stage.
+	state.pushRejectedByPolicy =
+		state.finalizeFailed && r.events.some((e) => e.kind === PUSH_REJECTED_EVENT);
 }
 
 /**

--- a/src/runs/reap/run.push-rejected.test.ts
+++ b/src/runs/reap/run.push-rejected.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { PUSH_REJECTED_EVENT } from "../../runtime/push-rejection.ts";
+import { reapRun } from "./index.ts";
+import {
+	type Ctx,
+	fakeBurrowClient,
+	fakeExec,
+	fakeFs,
+	makeBurrow,
+	reapDeps,
+	setup,
+} from "./test-helpers.ts";
+
+/**
+ * End-to-end reapRun coverage for the warren-b68d policy-rejection split. Split
+ * out of `run.test.ts` to keep that file under the 500-line budget; the parser
+ * itself is covered directly in `../../runtime/push-rejection.test.ts`.
+ *
+ * What these two cases pin is the DISTINCTION. Both pushes fail, both leave the
+ * commits unpushed, and before this split both read as `finalize_failed`. Only
+ * one of them is an operator's to resolve.
+ */
+const POLICY_REFUSAL = [
+	"remote: error: GH013: Repository rule violations found for refs/heads/warren/run-x.",
+	"remote: - GITHUB PUSH PROTECTION",
+	"remote:            path: src/redaction/scrub.test.ts:42",
+	"remote:        https://github.com/o/r/security/secret-scanning/unblock-secret/abc/",
+].join("\n");
+
+const NON_FAST_FORWARD = [
+	" ! [rejected]        HEAD -> warren/run-x (non-fast-forward)",
+	"error: failed to push some refs to 'https://github.com/o/r.git'",
+	"hint: Updates were rejected because the tip of your current branch is behind",
+].join("\n");
+
+describe("reapRun policy push rejection (warren-b68d)", () => {
+	let ctx: Ctx;
+
+	beforeEach(async () => {
+		ctx = await setup();
+	});
+
+	afterEach(async () => {
+		await ctx.db.close();
+	});
+
+	const reap = async (failPush: string) => {
+		const f = fakeFs();
+		const e = fakeExec({ failPush });
+		return await reapRun({
+			runId: ctx.runId,
+			outcome: "succeeded",
+			repos: ctx.repos,
+			...reapDeps(fakeBurrowClient(makeBurrow()), { fs: f.fs, exec: e.exec }),
+			fs: f.fs,
+			exec: e.exec,
+		});
+	};
+
+	test("a refusal on policy grounds gets its own failure reason", async () => {
+		const result = await reap(POLICY_REFUSAL);
+
+		expect(result.state).toBe("failed");
+		expect(result.failureReason).toBe("push_rejected_policy");
+		// Same preserve-the-workspace posture as finalize_failed: the commits
+		// never reached origin, so destroying the workspace would lose them.
+		expect(result.workspaceDestroyed).toBe(false);
+	});
+
+	test("the unblock URL and flagged path reach the event stream", async () => {
+		await reap(POLICY_REFUSAL);
+
+		// The remediation stops being something an operator greps a raw stderr
+		// blob for (run_m6br4vntg007 lost $7.23 of finished work to that).
+		const events = await ctx.repos.events.listByRun(ctx.runId);
+		const rejected = events.find((ev) => ev.kind === PUSH_REJECTED_EVENT);
+		expect(rejected?.payloadJson).toMatchObject({
+			unblockUrls: ["https://github.com/o/r/security/secret-scanning/unblock-secret/abc/"],
+			locations: ["src/redaction/scrub.test.ts:42"],
+		});
+	});
+
+	test("a non-fast-forward push stays finalize_failed", async () => {
+		const result = await reap(NON_FAST_FORWARD);
+
+		// This one is warren's to fix by rebasing, not the operator's to unblock,
+		// so it must NOT pick up the new reason or the remediation event.
+		expect(result.state).toBe("failed");
+		expect(result.failureReason).toBe("finalize_failed");
+		const events = await ctx.repos.events.listByRun(ctx.runId);
+		expect(events.some((ev) => ev.kind === PUSH_REJECTED_EVENT)).toBe(false);
+	});
+});

--- a/src/runs/reap/run.ts
+++ b/src/runs/reap/run.ts
@@ -193,7 +193,16 @@ export async function reapRun(input: ReapRunInput): Promise<ReapRunResult> {
 		// reached a terminal phase / vanished / timed out without posting
 		// anything, so the workspace died with it and salvage is the only
 		// recovery path.
-		failureReason = state.finalizeUnposted !== null ? "finalize_unposted" : "finalize_failed";
+		// warren-b68d: a pod-computed result whose push the REMOTE refused on
+		// policy grounds narrows one step further. `finalize_unposted` still wins
+		// the tie: no push was ever attempted, so a rejection cannot be live. The
+		// remediation itself already reached the operator — finalize appended
+		// `reap.push_rejected` and the pipeline replayed it.
+		if (state.finalizeUnposted !== null) {
+			failureReason = "finalize_unposted";
+		} else {
+			failureReason = state.pushRejectedByPolicy ? "push_rejected_policy" : "finalize_failed";
+		}
 	} else if (effectiveOutcome === "failed") {
 		failureReason =
 			input.failureReason ?? (await inferFailureReason(input.repos, run.id, stateOnEntry));

--- a/src/runtime/k8s/finalize-collect.ts
+++ b/src/runtime/k8s/finalize-collect.ts
@@ -24,6 +24,7 @@ import type {
 	FinalizeStageOutcome,
 } from "../contract.ts";
 import { finalizeCommitStage, finalizeMergeStage } from "../contract.ts";
+import { PUSH_REJECTED_EVENT, parsePushRejection } from "../push-rejection.ts";
 import type { InPodFinalizeIntent } from "./finalize-wire.ts";
 
 /** Clone-relative (posix) tracker paths — the delta `path` fields (match `../local/finalize.ts`). */
@@ -228,6 +229,13 @@ async function runPush(
 			trail.failed("branch_push", err);
 			collector.fail("branch_push", err, workspacePath);
 			trail.skipped("commits_ahead");
+			// warren-b68d: a policy refusal carries its own remediation onward.
+			// Both streams are read because git splits the remote's echo across
+			// them by version.
+			const rejection = parsePushRejection(`${push.stderr}\n${push.stdout}`);
+			if (rejection !== null) {
+				collector.events.push({ kind: PUSH_REJECTED_EVENT, payload: rejection });
+			}
 			return NO_PUSH;
 		}
 		trail.ok("branch_push");

--- a/src/runtime/local/finalize.ts
+++ b/src/runtime/local/finalize.ts
@@ -52,6 +52,7 @@ import type {
 } from "../contract.ts";
 import { finalizeCommitStage, finalizeMergeStage } from "../contract.ts";
 import { RuntimeProviderError } from "../errors.ts";
+import { PUSH_REJECTED_EVENT, parsePushRejection } from "../push-rejection.ts";
 import { finalizeSeedReset } from "./finalize-seed-reset.ts";
 
 /** Clone-relative (posix) tracker paths — the delta `path` fields + read-back keys. */
@@ -412,6 +413,12 @@ async function finalizePush(
 		trail.failed("branch_push", err);
 		await collector.fail("branch_push", err, workspacePath);
 		trail.skipped("commits_ahead");
+		// warren-b68d: `ReapExec.run` rejects with an Error whose message carries
+		// stderr, so the remote's own refusal text is what gets parsed here.
+		const rejection = parsePushRejection(err instanceof Error ? err.message : String(err));
+		if (rejection !== null) {
+			collector.events.push({ kind: PUSH_REJECTED_EVENT, payload: rejection });
+		}
 		return { pushed: false, commitsAhead: null, emptyPush: false, dirty: false, dirtyPaths: [] };
 	}
 	const commitsAhead = await countCommitsAhead(intent, workspacePath, exec, trail);

--- a/src/runtime/push-rejection.test.ts
+++ b/src/runtime/push-rejection.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+
+import { parsePushRejection } from "./push-rejection.ts";
+
+/**
+ * The shape GitHub prints when secret-scanning push protection refuses a push,
+ * reproduced from run_m6br4vntg007 (warren-b68d). No fixture here carries a
+ * credential-shaped literal: the secret's TYPE is a label GitHub prints, and
+ * the unblock URL is an opaque id, so this file cannot flag its own push.
+ */
+const PUSH_PROTECTION = [
+	"remote: error: GH013: Repository rule violations found for refs/heads/warren/run-abc.",
+	"remote: ",
+	"remote: - GITHUB PUSH PROTECTION",
+	"remote:   —————————————————————————————————————————",
+	"remote:     Resolve the following violations before pushing again",
+	"remote: ",
+	"remote:     - Push cannot contain secrets",
+	"remote: ",
+	"remote:       —— Linear API Key ——————————————————————",
+	"remote:        locations:",
+	"remote:          - commit: 4f21c0d8b1a54e0f9c3d2b7a6e5f4c3d2b1a0f9e",
+	"remote:            path: src/redaction/scrub.test.ts:42",
+	"remote: ",
+	"remote:        (?) To push, remove secret from commit(s) or follow this URL to allow the secret.",
+	"remote:        https://github.com/jayminwest/warren/security/secret-scanning/unblock-secret/2xYzAbC/",
+	"remote: ",
+	"To https://github.com/jayminwest/warren.git",
+	" ! [remote rejected] HEAD -> warren/run-abc (push declined due to repository rule violations)",
+	"error: failed to push some refs to 'https://github.com/jayminwest/warren.git'",
+].join("\n");
+
+const NON_FAST_FORWARD = [
+	"To https://github.com/jayminwest/warren.git",
+	" ! [rejected]        HEAD -> warren/run-abc (non-fast-forward)",
+	"error: failed to push some refs to 'https://github.com/jayminwest/warren.git'",
+	"hint: Updates were rejected because the tip of your current branch is behind",
+	"hint: its remote counterpart. Integrate the remote changes before pushing again.",
+].join("\n");
+
+const PROTECTED_BRANCH = [
+	"remote: error: GH006: Protected branch update failed for refs/heads/main.",
+	"remote: error: At least 1 approving review is required by reviewers with write access.",
+	"To https://github.com/jayminwest/warren.git",
+	" ! [remote rejected] HEAD -> main (protected branch hook declined)",
+].join("\n");
+
+describe("parsePushRejection", () => {
+	test("reads the unblock URL and the flagged path out of a push-protection refusal", () => {
+		const rejection = parsePushRejection(PUSH_PROTECTION);
+
+		expect(rejection).not.toBeNull();
+		expect(rejection?.unblockUrls).toEqual([
+			"https://github.com/jayminwest/warren/security/secret-scanning/unblock-secret/2xYzAbC/",
+		]);
+		expect(rejection?.locations).toEqual(["src/redaction/scrub.test.ts:42"]);
+	});
+
+	test("a non-fast-forward is NOT a policy rejection", () => {
+		// The distinction the failure reason exists to draw: this one is warren's
+		// to fix by rebasing, and stays `finalize_failed`.
+		expect(parsePushRejection(NON_FAST_FORWARD)).toBeNull();
+	});
+
+	test("a protected-branch refusal is a policy rejection with nothing to unblock", () => {
+		const rejection = parsePushRejection(PROTECTED_BRANCH);
+
+		expect(rejection).not.toBeNull();
+		expect(rejection?.unblockUrls).toEqual([]);
+		expect(rejection?.locations).toEqual([]);
+	});
+
+	test("collects every secret's URL and path when a push trips more than one rule", () => {
+		const twoSecrets = [
+			"remote: error: GH013: Repository rule violations found for refs/heads/warren/run-abc.",
+			"remote: - GITHUB PUSH PROTECTION",
+			"remote:       —— Linear API Key ——",
+			"remote:        locations:",
+			"remote:          - commit: 4f21c0d8",
+			"remote:            path: src/redaction/scrub.test.ts:42",
+			"remote:        https://github.com/o/r/security/secret-scanning/unblock-secret/aaa/",
+			"remote:       —— Stripe API Key ——",
+			"remote:        locations:",
+			"remote:          - commit: 4f21c0d8",
+			"remote:            path: src/redaction/fixtures.ts:7",
+			"remote:        https://github.com/o/r/security/secret-scanning/unblock-secret/bbb/",
+		].join("\n");
+
+		const rejection = parsePushRejection(twoSecrets);
+
+		expect(rejection?.unblockUrls).toEqual([
+			"https://github.com/o/r/security/secret-scanning/unblock-secret/aaa/",
+			"https://github.com/o/r/security/secret-scanning/unblock-secret/bbb/",
+		]);
+		expect(rejection?.locations).toEqual([
+			"src/redaction/scrub.test.ts:42",
+			"src/redaction/fixtures.ts:7",
+		]);
+	});
+
+	test("reports one finding when two rules flag the same file", () => {
+		const repeated = [
+			"remote: error: GH013: Repository rule violations found for refs/heads/warren/run-abc.",
+			"remote: - GITHUB PUSH PROTECTION",
+			"remote:            path: src/redaction/scrub.test.ts:42",
+			"remote:        https://github.com/o/r/security/secret-scanning/unblock-secret/aaa/",
+			"remote:            path: src/redaction/scrub.test.ts:42",
+			"remote:        https://github.com/o/r/security/secret-scanning/unblock-secret/aaa/",
+		].join("\n");
+
+		expect(parsePushRejection(repeated)?.locations).toEqual(["src/redaction/scrub.test.ts:42"]);
+		expect(parsePushRejection(repeated)?.unblockUrls).toEqual([
+			"https://github.com/o/r/security/secret-scanning/unblock-secret/aaa/",
+		]);
+	});
+
+	test("keeps the trailing slash but drops sentence punctuation after the URL", () => {
+		const punctuated = [
+			"remote: error: GH013: Repository rule violations found for refs/heads/warren/run-abc.",
+			"remote: follow this URL to allow the secret:",
+			"remote: https://github.com/o/r/security/secret-scanning/unblock-secret/ccc/.",
+		].join("\n");
+
+		expect(parsePushRejection(punctuated)?.unblockUrls).toEqual([
+			"https://github.com/o/r/security/secret-scanning/unblock-secret/ccc/",
+		]);
+	});
+
+	test("an auth failure and an empty output are not policy rejections", () => {
+		expect(parsePushRejection("remote: Invalid username or password.")).toBeNull();
+		expect(parsePushRejection("fatal: Authentication failed")).toBeNull();
+		expect(parsePushRejection("")).toBeNull();
+		expect(parsePushRejection("   \n  \n")).toBeNull();
+	});
+
+	test("reads the local runner's Error message, which carries stderr verbatim", () => {
+		// `ReapExec.run` rejects with an Error whose message is the stderr, so the
+		// LocalProvider path parses a message rather than a captured stream.
+		const err = new Error(PUSH_PROTECTION);
+
+		expect(parsePushRejection(err.message)?.locations).toEqual(["src/redaction/scrub.test.ts:42"]);
+	});
+});

--- a/src/runtime/push-rejection.ts
+++ b/src/runtime/push-rejection.ts
@@ -1,0 +1,135 @@
+/**
+ * Remote-policy push rejection parser (warren-b68d).
+ *
+ * A branch push that GitHub refuses on POLICY grounds — secret-scanning push
+ * protection, a repository ruleset, a protected-branch rule — fails the same
+ * way a non-fast-forward push does: non-zero exit, stderr, no branch. Reap saw
+ * only that, so both collapsed into `finalize_failed` and the operator was left
+ * grepping the raw event payload for the remediation URL GitHub had already
+ * printed (run_m6br4vntg007, 2026-07-30, $7.23 of agent work discarded).
+ *
+ * The two cases want different operator moves. A non-fast-forward is warren's
+ * problem: rebase and re-push. A policy rejection is the operator's: allow-list
+ * the secret at the unblock URL, or change the content GitHub refused. Only the
+ * second is parsed here, and the discriminator is the marker GitHub prints, not
+ * the exit code.
+ *
+ * Both finalize implementations feed this: `k8s/finalize-collect.ts` from the
+ * push's `stderr`/`stdout`, `local/finalize.ts` from the rejected `Error`'s
+ * message (`ReapExec.run` carries stderr there). Keeping the parse in one pure
+ * function is what stops the two from drifting.
+ */
+
+/**
+ * What GitHub refused, and what an operator needs to act on it.
+ *
+ * Both lists can be empty: GitHub varies its output by rule kind, and a
+ * ruleset violation that is not a secret carries no unblock URL at all. An
+ * empty list means "GitHub printed none", never "the parse failed" — a failed
+ * parse is `null` from {@link parsePushRejection}.
+ */
+export interface PushRejection {
+	/**
+	 * The `security/secret-scanning/unblock-secret/...` URLs GitHub returned,
+	 * one per blocked secret, in the order printed. This is the remediation the
+	 * issue asked to surface: it allow-lists that one secret so the same push
+	 * succeeds on retry.
+	 */
+	readonly unblockUrls: readonly string[];
+	/**
+	 * The `path:line` locations GitHub listed under each blocked secret, in the
+	 * order printed. Duplicates are dropped: the same fixture flagged by two
+	 * rules prints twice and reads as two findings.
+	 */
+	readonly locations: readonly string[];
+}
+
+/**
+ * Event kind a finalize implementation appends to `FinalizeResult.events` when
+ * it parses a policy refusal. Reap replays every finalize event through its
+ * real event surface, so declaring the kind here (rather than adding a field to
+ * the `FinalizeResult` seam) is what carries the remediation to the operator
+ * AND tells the domain which failure reason to record. Payload is a
+ * {@link PushRejection}.
+ */
+export const PUSH_REJECTED_EVENT = "reap.push_rejected";
+
+/**
+ * Markers that mean "the remote applied a policy", each taken from output
+ * GitHub actually prints:
+ *
+ *   - `GH013` heads a repository-rule violation, `GH006` a protected-branch
+ *     update refusal.
+ *   - `GITHUB PUSH PROTECTION` heads the secret-scanning block.
+ *   - The two prose forms appear without their codes when the push is refused
+ *     by a pre-receive hook rather than the ruleset engine.
+ *
+ * A non-fast-forward rejection prints none of these — it prints `[rejected]`
+ * with `(non-fast-forward)` or `(fetch first)` — so it stays `finalize_failed`,
+ * which is the existing and correct classification for it.
+ */
+const POLICY_MARKERS: readonly RegExp[] = [
+	/\bGH006\b/,
+	/\bGH013\b/,
+	/GITHUB PUSH PROTECTION/i,
+	/push declined due to repository rule violations/i,
+	/protected branch (?:update failed|hook declined)/i,
+];
+
+/** GitHub's per-secret allow-list URL. */
+const UNBLOCK_URL = /https?:\/\/\S*?\/security\/secret-scanning\/unblock-secret\/[^\s)\]]+/gi;
+
+/** A `path:` entry under a `locations:` block, once the `remote:` prefix is off. */
+const LOCATION_LINE = /^path:\s*(\S.*?)\s*$/i;
+
+/**
+ * Strip git's `remote: ` echo prefix and surrounding whitespace so the matchers
+ * see the server's own text. Git indents continuation lines under the prefix,
+ * which is why the trim happens after the strip and not before.
+ */
+function normalizeLines(output: string): string[] {
+	return output
+		.split(/\r?\n/)
+		.map((line) => line.replace(/^\s*remote:\s?/i, "").trim())
+		.filter((line) => line !== "");
+}
+
+/**
+ * Trailing punctuation GitHub wraps a URL in when it ends a sentence. The URL
+ * itself ends in a slash, which must survive.
+ */
+function trimUrl(url: string): string {
+	return url.replace(/[.,;]+$/, "");
+}
+
+/** Keep first occurrence, drop repeats, preserve order. */
+function unique(values: readonly string[]): string[] {
+	return [...new Set(values)];
+}
+
+/**
+ * Parse a failed push's output. Returns `null` when the remote refused for any
+ * reason OTHER than policy, which includes the ordinary non-fast-forward and
+ * every auth failure — the caller keeps its existing behavior for those.
+ *
+ * @param output - The push's combined stderr/stdout, or the rejected `Error`'s
+ *   message. Empty input is not a rejection.
+ */
+export function parsePushRejection(output: string): PushRejection | null {
+	if (output === "") return null;
+	const lines = normalizeLines(output);
+	if (lines.length === 0) return null;
+
+	const body = lines.join("\n");
+	if (!POLICY_MARKERS.some((marker) => marker.test(body))) return null;
+
+	const unblockUrls = unique((body.match(UNBLOCK_URL) ?? []).map(trimUrl));
+	const locations = unique(
+		lines.flatMap((line) => {
+			const match = LOCATION_LINE.exec(line);
+			return match?.[1] === undefined ? [] : [match[1]];
+		}),
+	);
+
+	return { unblockUrls, locations };
+}

--- a/src/ui/src/lib/labels.ts
+++ b/src/ui/src/lib/labels.ts
@@ -61,6 +61,7 @@ const RUN_FAILURE_REASON_LABELS: Readonly<Record<string, string>> = {
 	burrow_unreachable: "Sandbox unreachable",
 	dropped_commit: "Dropped commit",
 	finalize_failed: "Finalize failed",
+	push_rejected_policy: "Push blocked by repository policy",
 	finalize_unposted: "Finalize not posted",
 	provider_error: "Provider error",
 	oom_killed: "Out of memory",

--- a/src/ui/src/pages/run-detail-events.tsx
+++ b/src/ui/src/pages/run-detail-events.tsx
@@ -259,6 +259,16 @@ function summarizeReap(kind: string, payload: Record<string, unknown>): string {
 	if (kind === "reap.empty_push") {
 		return readString(payload.message) ?? "empty push";
 	}
+	// warren-b68d: the remediation is the point of this event, so the unblock
+	// URL goes in the one-line summary rather than only in the expanded payload.
+	if (kind === "reap.push_rejected") {
+		const urls = Array.isArray(payload.unblockUrls) ? payload.unblockUrls : [];
+		const locations = Array.isArray(payload.locations) ? payload.locations : [];
+		const parts = ["push blocked by repository policy"];
+		if (locations.length > 0) parts.push(`${locations.length} location(s)`);
+		if (typeof urls[0] === "string") parts.push(`unblock: ${urls[0]}`);
+		return parts.join(" · ");
+	}
 	if (kind === "reap.orphaned") {
 		return readString(payload.message) ?? "orphaned";
 	}


### PR DESCRIPTION
Closes #809 (warren-b68d).

## Summary

- Splits the case where the REMOTE refuses a branch push on policy grounds out of `finalize_failed` into its own `push_rejected_policy` reason.
- Carries GitHub's unblock URL and the flagged paths to the operator as a structured `reap.push_rejected` event instead of leaving them in a raw stderr blob.
- Keeps a non-fast-forward exactly where it was, on `finalize_failed`.

The reason the split is worth having is that the two failures need different people. A non-fast-forward is warren's to fix by rebasing and re-pushing. A policy rejection needs a human to allow-list the secret at the URL GitHub returned, or to change what the remote refused. Before this, both read the same on the run.

## The detection

`src/runtime/push-rejection.ts` is a pure parser over the push output. It keys on the markers GitHub prints, `GH013`, `GH006` and `GITHUB PUSH PROTECTION`, and never on the exit code, which a non-fast-forward shares. Both finalize implementations feed it: the k8s path from the push's `stderr`/`stdout`, the local path from the rejected `Error`'s message, since `ReapExec.run` carries stderr there. One parser rather than two is what stops the paths from drifting.

The parser also covers a protected-branch refusal (`GH006`), which carries no unblock URL. Empty lists mean GitHub printed none, never that the parse failed; a failed parse is `null`.

## One design note worth flagging

The rejection travels as a `FinalizeEvent` rather than as a new field on `FinalizeResult`.

Reap already replays every finalize event through its real event surface, and `applyFinalizeToState` already reads one back this way (`state.seedsCommitted`). So a single event both delivers the remediation to the operator and tells the domain which reason to record, where a new seam field would have needed a separate emit to do the second half.

It also happens to respect the ratchet. `src/runtime/contract.ts` sits at exactly its frozen 510-line budget, so a field plus its doc could not have landed there without a refactor of the seam file, which does not belong in this PR.

For the same reason the `wire.ts` entry is two lines against neighbours that run fifteen: `src/core/wire.ts` had three lines of headroom under its frozen budget. The full explanation lives in the module doc of `push-rejection.ts`. Happy to reshape either if you would rather spend the budget differently.

## What is not here

Want (2) in the issue asks for the locations and unblock URL "on the run object and in the UI". The UI half is done: the run's events pane summarises the event as `push blocked by repository policy · N location(s) · unblock: <url>`, and the failure badge now reads "Push blocked by repository policy" instead of "Finalize failed".

The **run object** half is not. Putting the URL on the runs row means a column in both dialects, two migrations, the drift test and the client/UI types, which is a bigger and riskier diff than the classification it would decorate. The information is not lost without it, since the event carries it, so I left it out rather than bundle it in. Glad to send it separately if you want the column.

Want (3), the docs convention about building secret-shaped fixtures from concatenated parts, is marked optional in the issue and is not here either.

## Bundle budget

`scripts/bundle-size-budgets.json` moves, and I want to be explicit about why since the ratchet normally forbids it.

`labels.ts` is `satisfies Record<RunFailureReason, string>`, so a new wire reason cannot compile without a label, which means any new failure reason costs UI bytes by construction. Net growth is +1116 B raw js and +298 B gzip js, well inside `AUTO_RAISE_CAP`. The numbers came from `bun run scripts/check-bundle-size.ts --build --update` on a clean `--frozen-lockfile` build in `oven/bun:1.3.14`, not hand-edited and not read off Vite's log. Both css budgets and `largest.raw.js` were never exceeded and keep their existing lower ceilings. There is a `$comment_` entry recording all of that.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun test` passes
- [x] `bun run check:all`

Windows cannot run the gate to completion here, so everything below was measured in a clean Linux clone at `oven/bun:1.3.14` on `da378614`, and every number is paired with a control run of the same command on unpatched `main` in an identical container.

`check:all` with this change: 10 of 12 gates pass. On unpatched `main` in the same container: the same 10 of 12. The two that fail are the same two in both, and neither is attributable to this change:

- `check:deps` dies loading `src/ui/vite.config.ts`, a knip known-issue it reports identically on clean `main`.
- `check:coverage` cannot resolve `@sinclair/typebox` from `extensions/judge`, an artifact of installing only the root workspace in my container, again identical on clean `main`.

`check:bundle-size` failed before the re-baseline and passes after it.

Full suite: 4796 pass / 3 fail / 22 skip with the change, against 4785 pass / 3 fail / 22 skip on clean `main`. Same failures, same skips; the 11 extra passes are the new tests.

New coverage is 8 parser cases and 3 end-to-end reap cases. The ones that carry the argument are the pair that pins the distinction: a `GH013` push protection refusal produces `push_rejected_policy` plus the event, and a `(non-fast-forward)` rejection still produces `finalize_failed` and no event. The existing `warren-495d` test, which fails a push with a message carrying no policy marker, keeps asserting `finalize_failed` untouched.
