### PR TITLE
docs: fix the last dangling forge-contract 4.2 citation

### DIFF
--- a/src/runtime/contract.ts
+++ b/src/runtime/contract.ts
@@ -326,7 +326,7 @@ export interface FinalizeIntent {
 	resetSeededPaths?: ReadonlyArray<{ path: string; contents: string }>;
 	/**
 	 * Per-spawn minted git credential for `branch_push` (warren-4e1c, forge
-	 * contract §4.2 — minted via `mintGitCredentialSecret` immediately before
+	 * contract §4 — minted via `mintGitCredentialSecret` immediately before
 	 * `finalize`, never held on a config object). LocalProvider splices it into
 	 * the push's `GIT_CONFIG_*` env; K8s prefers it over the env-derived token.
 	 * Undefined ⇒ anonymous push. */


### PR DESCRIPTION
Closes #888.

## What changed

The `gitToken` doc comment in `src/runtime/contract.ts` cited `forge-contract.md §4.2` — the doc has §4 and §4.1 and then jumps to §5, so the pointer landed nowhere. It now cites §4, the section that actually states the minted-never-held credential contract.

One note on the count: of the eleven sites the issue catalogued, ten already read `§4` at current HEAD (clone-apply, finalize-intent, salvage, run.ts, local/finalize, plan-runs, the three projects.ts sites, and the test-file comment) — presumably fixed since the issue's snapshot. This PR fixes the one remaining stale citation. The `src/runtime/k8s/` comments citing `§4.2` are untouched: they point at `k8s-migration.md`, whose §4.2 genuinely exists.

## How I verified

`bun run check:all` — 12/12 gates pass (lint, typecheck, coverage, docs/openapi gen, ci-parity). No design-doc edits, no behavior change: one comment line.
