### PR TITLE
fix(judge): real extension runtime in the hermetic loader + k8s deploy manifests (warren-5fcf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage/
 
 # live GKE deployment values (real project ids / identity) — template: overlays/gke
 deploy/k8s/overlays/gke-live/
+deploy/k8s/overlays/gke-live-judge/
 
 # local design-sync working dirs + MCP config (may contain secrets)
 .design-sync/

--- a/deploy/k8s/extensions/judge/deployment.yaml
+++ b/deploy/k8s/extensions/judge/deployment.yaml
@@ -1,0 +1,135 @@
+# Judge extension Deployment (extensions/judge, warren-5fcf).
+#
+# One replica, serial by design: the collector judges one run at a time so
+# the daily budget gate is race-free, and the cursor/verdict store is an
+# RWO SQLite volume — Recreate avoids two pods racing it during a rollout.
+# The collector walks GET /runs oldest-first, so pointing a fresh deploy at
+# a warren with history drains the backlog automatically (retroactive
+# episode labeling, docs/design/corpus-flywheel.md §1).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: judge
+  namespace: warren
+  labels:
+    app.kubernetes.io/name: warren
+    app.kubernetes.io/component: judge
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: warren
+      app.kubernetes.io/component: judge
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: warren
+        app.kubernetes.io/component: judge
+    spec:
+      # Read-only observer: no kube API access, no SA token.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        # The oven/bun image's non-root `bun` user.
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: judge
+          image: LOCATION-docker.pkg.dev/PROJECT/warren/warren-ext-judge:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            # In-cluster Service DNS — the judge sits beside warren, so the
+            # transcript reads never leave the cluster.
+            - name: WARREN_BASE_URL
+              value: "http://warren.warren.svc.cluster.local:8080"
+            # V1 warren auth is single-token, so the judge reads with the
+            # operator credential from the control-plane Secret.
+            - name: WARREN_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: warren-secrets
+                  key: warren-api-token
+            # --- judge model pair (provider-agnostic; README env contract).
+            # Overlays override these two for a different provider/model. ---
+            - name: JUDGE_PROVIDER
+              value: "anthropic"
+            - name: JUDGE_MODEL
+              value: "claude-haiku-4-5"
+            # Model credentials: the pi SDK reads one env var per provider;
+            # only the configured provider's key is required, so both are
+            # optional here and the wrong-provider one may be absent.
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: warren-secrets
+                  key: anthropic-api-key
+                  optional: true
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: judge-secrets
+                  key: openrouter-api-key
+                  optional: true
+            # --- budget gates (§12.5). Past the daily budget, runs get a
+            # visible `unjudged` marker and are retried next UTC day. ---
+            - name: JUDGE_DAILY_BUDGET_USD
+              value: "5"
+            # --- export surface: token-gated /verdicts.jsonl + /agreement.
+            # optional:true — an absent key disables the surface, it never
+            # blocks the collector. ---
+            - name: JUDGE_EXPORT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: judge-secrets
+                  key: judge-export-token
+                  optional: true
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          # /healthz is the one unauthenticated route (liveness only, no data).
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: "250m"
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            # The judge writes only under /app/data (the PVC); bun needs no
+            # other writable paths.
+            readOnlyRootFilesystem: false
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: judge-data

--- a/deploy/k8s/extensions/judge/kustomization.yaml
+++ b/deploy/k8s/extensions/judge/kustomization.yaml
@@ -1,0 +1,15 @@
+# Judge extension (extensions/judge, plan pl-17ca / warren-5fcf) — the
+# bounded, read-only LLM judge collector deployed BESIDE warren in the
+# `warren` namespace. Deliberately NOT part of ../../base: extensions are
+# opt-in observers, never required infrastructure (docs/design/extensions.md).
+#
+# Deploy with an overlay that pins the real image (see
+# ../../overlays/gke-live-judge, gitignored) after creating the judge
+# Secret imperatively (secrets.yaml documents the keys).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secrets.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/deploy/k8s/extensions/judge/pvc.yaml
+++ b/deploy/k8s/extensions/judge/pvc.yaml
@@ -1,0 +1,19 @@
+# The judge's verdict store, judgment cursors, and spend ledger — one
+# SQLite file at /app/data/judge.db (JUDGE_DB_PATH). Must survive pod
+# replacement: the cursor store is what makes a restart resume instead of
+# re-judging (and re-billing) the whole backlog, and verdicts are
+# append-only history. storageClassName intentionally omitted so each
+# cluster's default class binds (standard-rwo on GKE).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: judge-data
+  namespace: warren
+  labels:
+    app.kubernetes.io/name: warren
+    app.kubernetes.io/component: judge
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/k8s/extensions/judge/secrets.yaml
+++ b/deploy/k8s/extensions/judge/secrets.yaml
@@ -1,0 +1,32 @@
+# SECRET TEMPLATE — PLACEHOLDER VALUES ONLY. Never commit real secrets here.
+#
+# For a real deploy, do NOT `kubectl apply` this file. Create the secret
+# imperatively (values never touch git):
+#
+#   kubectl -n warren create secret generic judge-secrets \
+#     --from-literal=judge-export-token=$(openssl rand -hex 32) \
+#     --from-literal=openrouter-api-key=sk-or-...   # only if JUDGE_PROVIDER=openrouter
+#
+# The judge's WARREN_API_TOKEN comes from the existing `warren-secrets`
+# Secret (warren-api-token key) — warren's V1 auth is single-token
+# (src/server/auth.ts), so a judge-scoped credential does not exist yet;
+# extensions/judge/FRICTION-adjacent gap, tracked in the extension docs.
+# The model credential key here matches the pi SDK's per-provider env
+# convention (OPENROUTER_API_KEY / ANTHROPIC_API_KEY / ...); add the key
+# for whichever provider JUDGE_PROVIDER names.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: judge-secrets
+  namespace: warren
+  labels:
+    app.kubernetes.io/name: warren
+    app.kubernetes.io/component: judge
+type: Opaque
+stringData:
+  # Static bearer credential gating GET /verdicts.jsonl + GET /agreement.
+  # Unset/absent disables the export surface entirely (no public projection).
+  judge-export-token: "REPLACE_ME"
+  # Model credential for JUDGE_PROVIDER=openrouter deployments. Optional in
+  # the pod spec: anthropic deployments use warren-secrets/anthropic-api-key.
+  openrouter-api-key: "REPLACE_ME"

--- a/deploy/k8s/extensions/judge/service.yaml
+++ b/deploy/k8s/extensions/judge/service.yaml
@@ -1,0 +1,25 @@
+# ClusterIP for the judge's token-gated export surface
+# (GET /verdicts.jsonl, GET /agreement, unauthenticated /healthz).
+# In-cluster consumers dial http://judge.warren.svc.cluster.local:8080;
+# operators use `kubectl port-forward svc/judge -n warren 8080:8080`.
+# Deliberately NOT exposed via the Ingress: the surface is operator-facing
+# and bearer-gated, and verdicts must never be readable by agents
+# (the Goodhart guard, docs/design/agent-analytics.md §12.5).
+apiVersion: v1
+kind: Service
+metadata:
+  name: judge
+  namespace: warren
+  labels:
+    app.kubernetes.io/name: warren
+    app.kubernetes.io/component: judge
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: warren
+    app.kubernetes.io/component: judge
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/extensions/judge/src/index.ts
+++ b/extensions/judge/src/index.ts
@@ -198,6 +198,17 @@ async function main(): Promise<void> {
 		onCycleError: (err) => console.error(`${EXTENSION_NAME}: cycle failed:`, err),
 		onRunError: (runId, err) =>
 			console.error(`${EXTENSION_NAME}: judgment for run ${runId} failed:`, err),
+			// An unjudged marker's detail exists only here — the store row
+			// carries the reason alone, so an unlogged detail is
+			// undiagnosable from the pod (warren-5fcf: 334 judge_error
+			// markers with no error text anywhere).
+			onJudgment: (runId, outcome) => {
+				if (outcome.kind === "unjudged") {
+					console.error(
+						`${EXTENSION_NAME}: run ${runId} unjudged (${outcome.reason}): ${outcome.detail}`,
+					);
+				}
+			},
 			onBudgetSkip: (runId, detail) =>
 				console.error(`${EXTENSION_NAME}: run ${runId} unjudged (budget_exceeded): ${detail}`),
 		}),

--- a/extensions/judge/src/pi-session.ts
+++ b/extensions/judge/src/pi-session.ts
@@ -18,6 +18,7 @@
 
 import {
 	createAgentSession,
+	createExtensionRuntime,
 	ModelRuntime,
 	type ResourceLoader,
 	SessionManager,
@@ -75,7 +76,14 @@ class JudgeResourceLoader implements ResourceLoader {
 		this.#systemPrompt = systemPrompt;
 	}
 	public getExtensions() {
-		return { extensions: [], runtime: undefined, errors: [] } as never;
+		// No extensions load, but the runtime object must be REAL:
+		// AgentSession hands it to ExtensionRunner, whose bindCore assigns
+		// action methods onto it unconditionally — `runtime: undefined`
+		// throws `undefined is not an object (evaluating
+		// 'this.runtime.sendMessage')` on the first prompt (warren-5fcf,
+		// hit live: every judgment errored). Fresh per call so no state
+		// leaks between judge sessions.
+		return { extensions: [], runtime: createExtensionRuntime(), errors: [] } as never;
 	}
 	public getSkills() {
 		return { skills: [], diagnostics: [] };


### PR DESCRIPTION
## Summary

First live deployment of the judge extension (warren-5fcf) surfaced two gaps, both fixed here, plus the k8s manifests the deploy runs on.

- **Session-fatal bug**: the hermetic `JudgeResourceLoader.getExtensions()` returned `runtime: undefined`, but `AgentSession` hands that object straight to `ExtensionRunner`, whose `bindCore` assigns action methods onto it unconditionally. Every judgment errored instantly with `undefined is not an object (evaluating 'this.runtime.sendMessage')`, and the first collector cycle burned the whole 334-run backlog into `judge_error` markers. The loader now returns a fresh `createExtensionRuntime()` per session.
- **Silent failure detail**: an unjudged marker's `detail` string existed only in the in-memory outcome — the store row carries just the reason, and nothing logged it, so the failure above was undiagnosable from the pod. `index.ts` now logs `(reason + detail)` for every unjudged outcome via the existing `onJudgment` hook.
- **Manifests**: `deploy/k8s/extensions/judge/` — committed kustomize template (Deployment + RWO PVC for the verdict store + ClusterIP Service + secret stub) for running the judge beside warren in the `warren` namespace, following the `deploy/k8s` conventions (placeholder image name, imperative secret creation, gitignored live overlay `gke-live-judge`).

## Testing

- Extension suite: 149 pass, typecheck clean (own package gates).
- Verified end-to-end locally: one real `openrouter/google/gemini-3.7-flash` judgment against the live instance returned a validated `clean` verdict (~$0.07, 5 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)