### PR TITLE
fix(judge): defer runs past the daily budget instead of writing them off (warren-5fcf)

### DIFF
--- a/deploy/k8s/extensions/judge/deployment.yaml
+++ b/deploy/k8s/extensions/judge/deployment.yaml
@@ -78,8 +78,8 @@ spec:
                   name: judge-secrets
                   key: openrouter-api-key
                   optional: true
-            # --- budget gates (§12.5). Past the daily budget, runs get a
-            # visible `unjudged` marker and are retried next UTC day. ---
+            # --- budget gates (§12.5). Past the daily budget, further runs
+            # are deferred (visibly, in the cycle stats) to the next UTC day. ---
             - name: JUDGE_DAILY_BUDGET_USD
               value: "5"
             # --- export surface: token-gated /verdicts.jsonl + /agreement.

--- a/extensions/judge/README.md
+++ b/extensions/judge/README.md
@@ -85,10 +85,15 @@ Step 6 (warren-33da) adds the collector daemon:
   ledger: every judgment's accrued USD cost, summed per UTC day to enforce
   `JUDGE_DAILY_BUDGET_USD`. Spend is ledgered for verdicts AND unjudged
   markers alike — the provider billed the attempts either way.
-- Budget gates (§12.5): past the daily budget the judgment is SKIPPED and a
-  visible `unjudged` marker with reason `budget_exceeded` is recorded —
-  never a silent drop. The per-judgment cap is clamped to the remaining
-  daily budget so one judgment cannot push the fleet past the day gate.
+- Budget gates (§12.5): past the daily budget the run is DEFERRED — no
+  marker, no checkpoint — so it re-enters the candidate set once budget
+  frees (the next UTC day). The hole stays visible in the cycle stats and
+  a once-per-cycle deferral log line, never as a permanent write-off: a
+  `budget_exceeded` marker would occupy the store's dedupe key and block
+  the eventual real verdict (warren-5fcf). The per-judgment cap is clamped
+  to the remaining daily budget so one judgment cannot push the fleet past
+  the day gate; a judgment that hits its cap MID-ATTEMPT does resolve with
+  a `budget_exceeded` marker, because the attempts were billed.
 - SIGTERM/SIGINT abort the loop between cycles; the in-flight judgment
   always finishes and checkpoints before exit.
 - [`src/calibration.ts`](src/calibration.ts) — the calibration re-judge
@@ -111,9 +116,9 @@ Step 8 (warren-265d) adds the export surface and the end-to-end smoke:
 - [`src/smoke.test.ts`](src/smoke.test.ts) — the end-to-end smoke against
   the fake-warren double with a stubbed judge (no provider calls):
   terminal run → judged → validated verdict exported over
-  `/verdicts.jsonl`; the budget-skip path exports a visible `unjudged`
-  marker; the re-judge append path keeps both verdicts readable keyed by
-  rubric version, with the stored calibration metric served by
+  `/verdicts.jsonl`; the fleet-budget path defers the run and judges it
+  once budget frees; the re-judge append path keeps both verdicts readable
+  keyed by rubric version, with the stored calibration metric served by
   `/agreement`.
 
 ## Export surface
@@ -178,7 +183,7 @@ extension's own store, never a core table.
 | `JUDGE_DB_PATH`   | no       | SQLite store path (default `./data/judge.db`) |
 | `JUDGE_POLL_INTERVAL_MS` | no | Delay between terminal-run discovery polls (default `30000`) |
 | `JUDGE_MAX_COST_USD` | no | Per-judgment USD cost cap (default `0.25`) — the §12.5 analog of `maxCostUsd`. The legacy `JUDGE_MAX_COST_USD_PER_JUDGMENT` spelling still resolves as a fallback alias |
-| `JUDGE_DAILY_BUDGET_USD` | no | Fleet-level daily judge budget (default `5`); past it, runs are marked `unjudged` rather than degraded silently |
+| `JUDGE_DAILY_BUDGET_USD` | no | Fleet-level daily judge budget (default `5`); past it, further runs are deferred to the next UTC day, visibly in the cycle stats |
 | `JUDGE_MAX_RETRIES` | no | Malformed/missing-verdict retries per judgment (default `2`) |
 | `JUDGE_MAX_PAGES` | no | Hard cap on events pages per judgment (default `40`); past it the tail degrades to a lower-confidence verdict, never unbounded spend |
 | `JUDGE_EVENTS_PAGE_SIZE` | no | Default events page size when the model omits `limit` (default `200`) |

--- a/extensions/judge/src/collector.test.ts
+++ b/extensions/judge/src/collector.test.ts
@@ -97,7 +97,7 @@ function makeHarness(opts?: {
 		dailyBudgetUsd: opts?.dailyBudgetUsd ?? 5,
 		now: opts?.now ?? (() => NOW),
 		onRunError: (runId, err) => errors.push({ runId, err }),
-		onBudgetSkip: (runId, detail) => skips.push({ runId, detail }),
+		onBudgetDeferred: (runId, detail) => skips.push({ runId, detail }),
 	};
 	return { fake, verdicts, cursors, spend, judgeCalls, errors, skips, deps };
 }
@@ -196,26 +196,37 @@ describe("collectOnce", () => {
 		}
 	});
 
-	test("skips with a visible budget_exceeded marker once the daily budget is exhausted", async () => {
+	test("defers without a marker or checkpoint once the daily budget is exhausted", async () => {
 		// Each stubbed judgment spends 0.01, so the first run lands exactly
-		// on the budget and the second sees it exhausted.
+		// on the budget and the rest see it exhausted.
 		const h = makeHarness({ dailyBudgetUsd: 0.01 });
 		h.fake.addRun({ id: "run-1", state: "succeeded", startedAt: "2026-08-15T10:00:00.000Z" });
 		h.fake.addRun({ id: "run-2", state: "succeeded", startedAt: "2026-08-15T11:00:00.000Z" });
+		h.fake.addRun({ id: "run-3", state: "succeeded", startedAt: "2026-08-15T12:00:00.000Z" });
 		try {
 			const out = await collectOnce(h.deps);
 			expect(out.judged).toBe(1);
-			expect(out.budgetSkipped).toBe(1);
-			// Oldest first: run-1 was judged, run-2 hit the exhausted budget.
+			expect(out.budgetDeferred).toBe(2);
+			// Oldest first: run-1 was judged, the rest hit the exhausted budget.
 			expect(h.judgeCalls.map((c) => c.runId)).toEqual(["run-1"]);
+			// The deferral announces ONCE per cycle, not once per run.
 			expect(h.skips).toHaveLength(1);
 			expect(h.skips[0]?.runId).toBe("run-2");
 			expect(h.skips[0]?.detail).toContain("daily budget");
-			const rows = h.verdicts.rowsForRun("run-2");
-			expect(rows[0]?.kind).toBe("unjudged");
-			expect(rows[0]?.reason).toBe("budget_exceeded");
-			// The skip is the run's resolution — checkpointed, not retried.
-			expect(h.cursors.needsJudgment("run-2", RUBRIC_V1, MODEL)).toBe(false);
+			// No marker, no checkpoint: a budget_exceeded row would close the
+			// run under this pair AND occupy the store's dedupe key, blocking
+			// the eventual real verdict (warren-5fcf).
+			expect(h.verdicts.rowsForRun("run-2")).toHaveLength(0);
+			expect(h.cursors.needsJudgment("run-2", RUBRIC_V1, MODEL)).toBe(true);
+			// Budget freed (next UTC day) — the oldest deferred run is
+			// judged; the day's budget then gates the next one again.
+			const nextDay = await collectOnce({
+				...h.deps,
+				now: () => new Date("2026-08-16T10:00:00.000Z"),
+			});
+			expect(nextDay.judged).toBe(1);
+			expect(nextDay.budgetDeferred).toBe(1);
+			expect(h.verdicts.rowsForRun("run-2")[0]?.kind).toBe("verdict");
 		} finally {
 			teardown(h);
 		}
@@ -242,7 +253,7 @@ describe("collectOnce", () => {
 		try {
 			const out = await collectOnce(h.deps);
 			expect(out.judged).toBe(1);
-			expect(out.budgetSkipped).toBe(0);
+			expect(out.budgetDeferred).toBe(0);
 		} finally {
 			teardown(h);
 		}

--- a/extensions/judge/src/collector.ts
+++ b/extensions/judge/src/collector.ts
@@ -12,12 +12,21 @@
  *
  * Budget gates (agent-analytics §12.5), checked per run before judging:
  *   - `JUDGE_DAILY_BUDGET_USD` fleet-wide: when the day's ledgered spend
- *     reaches the budget the judgment is SKIPPED and a visible unjudged
- *     marker with reason `budget_exceeded` is recorded — never a silent
- *     drop. The marker is the run's resolution under this rubric version.
+ *     reaches the budget the run is DEFERRED — no marker, no checkpoint,
+ *     so it re-enters the candidate set once budget frees (the next UTC
+ *     day). The hole stays visible in the cycle stats and the deferral
+ *     log line, never as a permanent write-off: a `budget_exceeded`
+ *     marker would checkpoint the run closed under this
+ *     (rubricVersion, judgeModelId) pair AND occupy the store's dedupe
+ *     key, blocking the eventual real verdict (warren-5fcf — a backlog
+ *     larger than one day's budget would have been burned unjudged on
+ *     day one).
  *   - `JUDGE_MAX_COST_USD` per judgment: passed to the judge loop as its
  *     cost cap, clamped to the remaining daily budget so one judgment
- *     cannot push the fleet past the day gate.
+ *     cannot push the fleet past the day gate. A judgment that hits its
+ *     cap mid-attempt DOES resolve with a `budget_exceeded` marker — the
+ *     attempts were billed, and retrying an over-cap run burns the same
+ *     budget again.
  *
  * Sequencing is serial: one judgment at a time, so the daily gate's
  * read-then-judge is race-free and a graceful shutdown has at most one
@@ -59,8 +68,12 @@ export interface JudgeCollectorDeps {
 	readonly onRunError?: (runId: string, err: unknown) => void;
 	/** After every accepted judgment — the operator's visibility feed. */
 	readonly onJudgment?: (runId: string, outcome: JudgeOutcome) => void;
-	/** After every budget skip — loud by design (§12.5). */
-	readonly onBudgetSkip?: (runId: string, detail: string) => void;
+	/**
+	 * Once per cycle when the fleet gate first trips — loud by design
+	 * (§12.5), but once, not once per deferred run (a big backlog would
+	 * repeat the line hundreds of times every cycle).
+	 */
+	readonly onBudgetDeferred?: (runId: string, detail: string) => void;
 }
 
 export interface JudgeCycleStats {
@@ -68,7 +81,8 @@ export interface JudgeCycleStats {
 	readonly terminalRuns: number;
 	readonly judged: number;
 	readonly alreadyJudged: number;
-	readonly budgetSkipped: number;
+	/** Runs deferred (not judged, not marked) because the daily budget is spent. */
+	readonly budgetDeferred: number;
 }
 
 const DEFAULT_RUNS_PAGE_SIZE = 500;
@@ -90,52 +104,19 @@ async function discoverRuns(client: WarrenClient, pageSize: number): Promise<Run
 	}
 }
 
-/** Record a budget-skip marker and checkpoint — the skip is the resolution. */
-function recordBudgetSkip(
-	runId: string,
-	detail: string,
-	deps: JudgeCollectorDeps,
-	now: () => Date,
-): void {
-	deps.verdicts.recordUnjudged({
-		runId,
-		rubricVersion: deps.rubricVersion,
-		judgeModelId: deps.judgeModelId,
-		reason: "budget_exceeded",
-	});
-	deps.cursors.checkpoint(runId, {
-		rubricVersion: deps.rubricVersion,
-		judgeModelId: deps.judgeModelId,
-		outcome: "unjudged",
-		updatedAt: now().toISOString(),
-	});
-	deps.onBudgetSkip?.(runId, detail);
-}
-
 /**
- * Judge one terminal run: budget gate, judge, store, ledger, checkpoint —
- * in that order, and the checkpoint is always last.
+ * Judge one terminal run: judge, store, ledger, checkpoint — in that
+ * order, and the checkpoint is always last. The fleet budget gate lives
+ * in the cycle loop (a gated run is deferred, never resolved); this
+ * function only clamps the per-judgment cap to the remaining budget.
  */
 async function judgeOneRun(
 	runId: string,
+	remainingBudgetUsd: number,
 	deps: JudgeCollectorDeps,
 	now: () => Date,
-): Promise<"judged" | "budget_skipped"> {
-	const today = dayKey(now());
-	const spentToday = deps.spend.spendForDay(today);
-	const remaining = deps.dailyBudgetUsd - spentToday;
-	if (remaining <= 0) {
-		recordBudgetSkip(
-			runId,
-			`fleet daily budget $${deps.dailyBudgetUsd.toFixed(4)} exhausted ` +
-				`($${spentToday.toFixed(4)} spent on ${today})`,
-			deps,
-			now,
-		);
-		return "budget_skipped";
-	}
-
-	const maxCostUsd = Math.min(deps.maxCostUsdPerJudgment, remaining);
+): Promise<"judged"> {
+	const maxCostUsd = Math.min(deps.maxCostUsdPerJudgment, remainingBudgetUsd);
 	const outcome = await deps.judge(runId, { maxCostUsd });
 
 	if (outcome.kind === "verdict") {
@@ -174,16 +155,34 @@ export async function collectOnce(deps: JudgeCollectorDeps): Promise<JudgeCycleS
 
 	let judged = 0;
 	let alreadyJudged = 0;
-	let budgetSkipped = 0;
+	let budgetDeferred = 0;
+	let deferralAnnounced = false;
 	for (const run of terminal) {
 		if (!deps.cursors.needsJudgment(run.id, deps.rubricVersion, deps.judgeModelId)) {
 			alreadyJudged += 1;
 			continue;
 		}
+		// Fleet gate: past the daily budget the run is DEFERRED — no
+		// marker, no checkpoint — so it re-enters the candidate set once
+		// budget frees. Re-read per run: each judgment moves the ledger.
+		const today = dayKey(now());
+		const spentToday = deps.spend.spendForDay(today);
+		const remaining = deps.dailyBudgetUsd - spentToday;
+		if (remaining <= 0) {
+			budgetDeferred += 1;
+			if (!deferralAnnounced) {
+				deferralAnnounced = true;
+				deps.onBudgetDeferred?.(
+					run.id,
+					`fleet daily budget $${deps.dailyBudgetUsd.toFixed(4)} exhausted ` +
+						`($${spentToday.toFixed(4)} spent on ${today}); deferring until budget frees`,
+				);
+			}
+			continue;
+		}
 		try {
-			const result = await judgeOneRun(run.id, deps, now);
-			if (result === "judged") judged += 1;
-			else budgetSkipped += 1;
+			await judgeOneRun(run.id, remaining, deps, now);
+			judged += 1;
 		} catch (err) {
 			// Per-run isolation: one failing judgment (warren unreachable,
 			// wire drift, store error) must not starve the others. The
@@ -196,7 +195,7 @@ export async function collectOnce(deps: JudgeCollectorDeps): Promise<JudgeCycleS
 		terminalRuns: terminal.length,
 		judged,
 		alreadyJudged,
-		budgetSkipped,
+		budgetDeferred,
 	};
 }
 

--- a/extensions/judge/src/index.ts
+++ b/extensions/judge/src/index.ts
@@ -193,7 +193,7 @@ async function main(): Promise<void> {
 			console.error(
 				`${EXTENSION_NAME}: cycle — ${stats.terminalRuns} terminal, ` +
 					`${stats.judged} judged, ${stats.alreadyJudged} current, ` +
-					`${stats.budgetSkipped} budget-skipped`,
+					`${stats.budgetDeferred} budget-deferred`,
 			),
 		onCycleError: (err) => console.error(`${EXTENSION_NAME}: cycle failed:`, err),
 		onRunError: (runId, err) =>
@@ -209,8 +209,8 @@ async function main(): Promise<void> {
 					);
 				}
 			},
-			onBudgetSkip: (runId, detail) =>
-				console.error(`${EXTENSION_NAME}: run ${runId} unjudged (budget_exceeded): ${detail}`),
+			onBudgetDeferred: (runId, detail) =>
+				console.error(`${EXTENSION_NAME}: deferring from run ${runId}: ${detail}`),
 		}),
 	]);
 	verdicts.close();

--- a/extensions/judge/src/smoke.test.ts
+++ b/extensions/judge/src/smoke.test.ts
@@ -137,8 +137,8 @@ describe("judge export smoke", () => {
 		});
 	}
 
-	async function cycle(judge: JudgeFn, dailyBudgetUsd = 5): Promise<void> {
-		await collectOnce({
+	async function cycle(judge: JudgeFn, dailyBudgetUsd = 5) {
+		return await collectOnce({
 			client,
 			verdicts,
 			cursors,
@@ -179,7 +179,7 @@ describe("judge export smoke", () => {
 			dailyBudgetUsd: 5,
 			now: () => NOW,
 		});
-		expect(stats).toMatchObject({ terminalRuns: 1, judged: 1, budgetSkipped: 0 });
+		expect(stats).toMatchObject({ terminalRuns: 1, judged: 1, budgetDeferred: 0 });
 
 		// The gate: no token, no rows — there is no public projection.
 		expect(handler(authed("/verdicts.jsonl", null)).status).toBe(401);
@@ -193,21 +193,35 @@ describe("judge export smoke", () => {
 		expect(validateVerdict(row.verdict).provenance.rubricVersion).toBe(RUBRIC);
 	});
 
-	test("budget skip writes a visible unjudged marker that exports", async () => {
+	test("an exhausted daily budget defers the run — no marker, judged once budget frees", async () => {
 		addTerminalRun("r-smoke-budget");
-		const judge: JudgeFn = async () => {
+		const gated: JudgeFn = async () => {
 			throw new Error("judge must not run past the budget gate");
 		};
-		await cycle(judge, 0);
+		const stats = await cycle(gated, 0);
+		expect(stats).toMatchObject({ judged: 0, budgetDeferred: 1 });
 
+		// No marker exported: a budget_exceeded row would occupy the store's
+		// dedupe key and block the eventual real verdict (warren-5fcf).
+		expect(await exportRows(handler)).toHaveLength(0);
+
+		// Budget available again — the deferred run is judged for real.
+		const judge: JudgeFn = async (runId) =>
+			({
+				kind: "verdict",
+				verdict: verdictFor(runId, CHEAP_MODEL, "high"),
+				stats: {
+					attempts: 1,
+					tokens: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 },
+					costUsd: 0.01,
+					pagesRead: 1,
+					pageCapHit: false,
+				},
+			}) satisfies JudgeOutcome;
+		await cycle(judge, 5);
 		const rows = await exportRows(handler);
 		expect(rows).toHaveLength(1);
-		expect(rows[0]).toMatchObject({
-			kind: "unjudged",
-			runId: "r-smoke-budget",
-			reason: "budget_exceeded",
-			verdict: null,
-		});
+		expect(rows[0]).toMatchObject({ kind: "verdict", runId: "r-smoke-budget" });
 	});
 
 	test("re-judge appends: both verdicts stay readable keyed by rubric version, and /agreement serves the metric", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #968, found while sizing the live backlog drain. The fleet budget gate recorded a `budget_exceeded` marker AND checkpointed the cursor for every run past the daily budget. Two compounding problems, both fatal for draining a backlog larger than one day's budget:

- **Permanent write-off**: `JudgmentCursorStore.needsJudgment` never re-opens under the same `(rubricVersion, judgeModelId)` pair, so the first budget-exhausted cycle would permanently close the entire remaining backlog (~190 of 334 runs on the live drain, a few hours from now).
- **Dedupe-key collision**: the verdict store's dedupe key is `(runId|rubricVersion|judgeModelId)` across BOTH row kinds, so the `unjudged` marker would also block the eventual real verdict even if the cursor were cleared.

## Change

The fleet gate now **defers**: no marker, no checkpoint — the run re-enters the candidate set once budget frees (the next UTC day). Visibility is preserved per §12.5 through the cycle stats (`budgetSkipped` → `budgetDeferred`) and a once-per-cycle deferral log line (`onBudgetSkip` → `onBudgetDeferred`; once per cycle, not once per deferred run, so a big backlog doesn't repeat the line hundreds of times every 30s).

A judgment that hits the **per-judgment** cap mid-attempt still resolves with a `budget_exceeded` marker — those attempts were billed, and retrying an over-cap run burns the same budget again. Calibration's own budget path is untouched (its markers land under the strong model id and can't collide with cheap verdicts).

README + deploy manifest comments updated to the new semantics.

## Testing

- Collector test now pins: deferral writes no row and leaves the cursor open, announces once per cycle, and the deferred run is judged for real once budget frees.
- Smoke test drives the defer → budget-freed → real-verdict-exported path end to end.
- 149 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)