### PR TITLE
fix(judge): calibration budget breach defers instead of writing a permanent marker

### DIFF
--- a/extensions/judge/README.md
+++ b/extensions/judge/README.md
@@ -108,9 +108,13 @@ Step 6 (warren-33da) adds the collector daemon:
   band-agreement between the cheap and strong verdicts is computed from
   the store's calibration join and persisted per rubric version in the
   `calibration_metrics` table — the disagreement rate is itself the
-  tracked signal. Budget gates apply to calibration judgments too: a
-  budget breach writes a visible `unjudged` marker under the strong
-  model id, never a silent skip. Disabled unless
+  tracked signal. Budget gates apply to calibration judgments too: past
+  the daily budget the sampled run is DEFERRED — no marker, no store
+  write, same PR #969 semantics as the collector — so it re-enters the
+  candidate pool next pass instead of a `budget_exceeded` marker
+  permanently excluding it. The deferral stays visible in the cycle
+  stats and a once-per-pass log line. Per-judgment failures from billed
+  attempts still write markers. Disabled unless
   `JUDGE_CALIBRATION_MODEL` is set.
 
 Step 8 (warren-265d) adds the export surface and the end-to-end smoke:

--- a/extensions/judge/src/calibration.test.ts
+++ b/extensions/judge/src/calibration.test.ts
@@ -206,23 +206,30 @@ describe("calibrateOnce", () => {
 		deps.verdicts.close();
 	});
 
-	test("a budget breach records a visible unjudged marker under the strong model id", async () => {
+	test("an exhausted daily budget defers the sampled run — no marker, announced once", async () => {
 		const { deps, verdicts, judged } = makeDeps({ dailyBudgetUsd: 0 });
-		seedCheapVerdicts(verdicts, ["run-1"]);
-		const skips: string[] = [];
+		seedCheapVerdicts(verdicts, ["run-1", "run-2"]);
+		const deferrals: string[] = [];
 
-		const result = await calibrateOnce({ ...deps, onBudgetSkip: (runId) => skips.push(runId) });
-		expect(result.budgetSkipped).toBe(1);
+		const result = await calibrateOnce({
+			...deps,
+			onBudgetDeferred: (runId) => deferrals.push(runId),
+		});
+		expect(result.budgetDeferred).toBe(2);
 		expect(result.rejudged).toBe(0);
 		expect(judged).toHaveLength(0);
-		expect(skips).toEqual(["run-1"]);
+		// Announced once per pass, not once per deferred run.
+		expect(deferrals).toHaveLength(1);
 
-		const rows = verdicts.rowsForRun("run-1");
-		expect(rows[1]).toMatchObject({
-			kind: "unjudged",
-			judgeModelId: STRONG_ID,
-			reason: "budget_exceeded",
-		});
+		// No marker: a budget_exceeded row under the strong id would occupy
+		// the dedupe key and permanently exclude the run from every future
+		// sample (PR #969 semantics). Both runs stay candidates.
+		for (const runId of ["run-1", "run-2"]) {
+			expect(verdicts.rowsForRun(runId)).toHaveLength(1);
+		}
+		const rerun = await calibrateOnce({ ...deps, dailyBudgetUsd: 5 });
+		expect(rerun.candidates).toBe(2);
+		expect(rerun.rejudged).toBe(2);
 		verdicts.close();
 	});
 

--- a/extensions/judge/src/calibration.ts
+++ b/extensions/judge/src/calibration.ts
@@ -13,9 +13,15 @@
  * of the same sample is an exact no-op.
  *
  * Budget gates apply to calibration judgments exactly as to first-pass
- * ones: the fleet daily budget and the per-judgment cap are shared, and a
- * budget breach records a VISIBLE unjudged marker under the strong model
- * id — never a silent skip (§12.5).
+ * ones: the fleet daily budget and the per-judgment cap are shared. Past
+ * the daily budget the sampled run is DEFERRED — no marker, no store
+ * write — mirroring the collector's semantics (PR #969): a
+ * `budget_exceeded` marker under the strong model id would occupy the
+ * dedupe key and permanently exclude the run from every future sample.
+ * The deferral stays visible in the cycle stats and the once-per-pass
+ * deferral log line. Per-judgment failures (judge_error,
+ * malformed_verdict, a mid-attempt cap breach) still record markers,
+ * because the attempts were billed.
  *
  * The agreement rate is computed from the store's calibration join and
  * persisted per rubric version in the `calibration_metrics` table, so the
@@ -256,15 +262,16 @@ export interface CalibrationDeps {
 	readonly random?: () => number;
 	readonly onRunError?: (runId: string, err: unknown) => void;
 	readonly onJudgment?: (runId: string, outcome: string) => void;
-	/** After every budget skip — loud by design (§12.5). */
-	readonly onBudgetSkip?: (runId: string, detail: string) => void;
+	/** Once per pass, on the first budget deferral — loud by design (§12.5). */
+	readonly onBudgetDeferred?: (runId: string, detail: string) => void;
 }
 
 export interface CalibrationCycleStats {
 	readonly candidates: number;
 	readonly sampled: number;
 	readonly rejudged: number;
-	readonly budgetSkipped: number;
+	/** Sampled runs deferred by the exhausted daily budget — no row written. */
+	readonly budgetDeferred: number;
 	readonly report: AgreementReport;
 }
 
@@ -276,7 +283,8 @@ export function strongJudgeModelId(provider: string, model: string): string {
 /**
  * Runs eligible for the calibration sample: judged by the cheap model under
  * this rubric version, with no row yet from the strong model (a verdict OR
- * an unjudged marker — a budget-skip marker is that run's resolution).
+ * an unjudged marker from a billed attempt). A budget deferral writes no
+ * row, so a deferred run re-enters the candidate pool next pass.
  */
 function calibrationCandidates(deps: CalibrationDeps, strongId: string): string[] {
 	const cheapJudged = new Set<string>();
@@ -319,25 +327,27 @@ export async function calibrateOnce(deps: CalibrationDeps): Promise<CalibrationC
 	const sample = sampleRuns(candidates, deps.sampleSize, random);
 
 	let rejudged = 0;
-	let budgetSkipped = 0;
+	let budgetDeferred = 0;
+	let deferralAnnounced = false;
 	for (const runId of sample) {
 		try {
 			const today = dayKey(now());
 			const spentToday = deps.spend.spendForDay(today);
 			const remaining = deps.dailyBudgetUsd - spentToday;
 			if (remaining <= 0) {
-				deps.verdicts.recordUnjudged({
-					runId,
-					rubricVersion: deps.rubricVersion,
-					judgeModelId: strongId,
-					reason: "budget_exceeded",
-				});
-				deps.onBudgetSkip?.(
-					runId,
-					`fleet daily budget $${deps.dailyBudgetUsd.toFixed(4)} exhausted ` +
-						`($${spentToday.toFixed(4)} spent on ${today})`,
-				);
-				budgetSkipped += 1;
+				// DEFER, never mark (PR #969 semantics): a budget_exceeded
+				// marker under the strong id would occupy the dedupe key and
+				// permanently exclude this run from every future sample. No
+				// write means the next pass can re-draw it.
+				budgetDeferred += 1;
+				if (!deferralAnnounced) {
+					deferralAnnounced = true;
+					deps.onBudgetDeferred?.(
+						runId,
+						`fleet daily budget $${deps.dailyBudgetUsd.toFixed(4)} exhausted ` +
+							`($${spentToday.toFixed(4)} spent on ${today})`,
+					);
+				}
 				continue;
 			}
 			const maxCostUsd = Math.min(deps.maxCostUsdPerJudgment, remaining);
@@ -387,7 +397,7 @@ export async function calibrateOnce(deps: CalibrationDeps): Promise<CalibrationC
 		candidates: candidates.length,
 		sampled: sample.length,
 		rejudged,
-		budgetSkipped,
+		budgetDeferred,
 		report,
 	};
 }

--- a/extensions/judge/src/index.ts
+++ b/extensions/judge/src/index.ts
@@ -129,7 +129,7 @@ async function main(): Promise<void> {
 					onCycle: (stats) =>
 						console.error(
 							`${EXTENSION_NAME}: calibration — ${stats.sampled} sampled, ` +
-								`${stats.rejudged} re-judged, ${stats.budgetSkipped} budget-skipped, ` +
+								`${stats.rejudged} re-judged, ${stats.budgetDeferred} budget-deferred, ` +
 								`agreement ${String(stats.report.overallRate)} over ` +
 								`${stats.report.sampledPairs} pairs`,
 						),
@@ -137,10 +137,8 @@ async function main(): Promise<void> {
 						console.error(`${EXTENSION_NAME}: calibration pass failed:`, err),
 					onRunError: (runId, err) =>
 						console.error(`${EXTENSION_NAME}: calibration re-judge for run ${runId} failed:`, err),
-					onBudgetSkip: (runId, detail) =>
-						console.error(
-							`${EXTENSION_NAME}: run ${runId} calibration-unjudged (budget_exceeded): ${detail}`,
-						),
+					onBudgetDeferred: (runId, detail) =>
+						console.error(`${EXTENSION_NAME}: calibration deferring from run ${runId}: ${detail}`),
 				});
 	exportServer =
 		config.exportToken === null


### PR DESCRIPTION
## Summary

Prep for enabling calibration (warren-941e): the calibration arm still had the pre-#969 budget semantics — an exhausted daily budget wrote a `budget_exceeded` marker under the strong model id, permanently occupying the dedupe key `(runId|rubricVersion|strongModelId)` and excluding that run from every future sample. With the shared $20/day budget actively consumed by the rubric-fork re-drain (#970), enabling calibration as-is would burn sample slots into dead markers.

This ports the collector's deferral semantics (#969): past the daily budget the sampled run is skipped with **no store write**, announced once per pass, and counted in cycle stats (`budgetSkipped` → `budgetDeferred`, `onBudgetSkip` → `onBudgetDeferred`). Markers from billed attempts (judge_error, malformed_verdict, mid-attempt cap breach) are unchanged.

## Testing

- Rewritten budget test pins: no row written, announced once per pass (not per run), both deferred runs re-enter the candidate pool and are judged for real once budget frees.
- `bun test` in `extensions/judge`: 154 pass; `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)