### PR TITLE
fix(judge): add detail column to verdict store for unjudged markers

### DIFF
--- a/extensions/judge/src/calibration.ts
+++ b/extensions/judge/src/calibration.ts
@@ -1,5 +1,5 @@
 /**
- * The calibration re-judge (plan pl-17ca step 7, agent-analytics §12.5).
+ * The calibration re-judge (plan pl-17ca step 7, agent-analytics 12.5).
  *
  * Full coverage by a cheap model inverts the sampling question: a periodic
  * strong-model pass re-judges a small RANDOM sample of already-judged runs
@@ -50,7 +50,7 @@ export interface ClassAgreement {
 }
 
 /**
- * The persisted calibration metric (§12.5): per-class and overall
+ * The persisted calibration metric (12.5): per-class and overall
  * band-agreement between the cheap and strong judge over the paired sample,
  * for one rubric version. Trend lines must never mix rubric versions, so
  * the rubric version is part of the metric's identity.
@@ -262,7 +262,7 @@ export interface CalibrationDeps {
 	readonly random?: () => number;
 	readonly onRunError?: (runId: string, err: unknown) => void;
 	readonly onJudgment?: (runId: string, outcome: string) => void;
-	/** Once per pass, on the first budget deferral — loud by design (§12.5). */
+	/** Once per pass, on the first budget deferral — loud by design (12.5). */
 	readonly onBudgetDeferred?: (runId: string, detail: string) => void;
 }
 
@@ -371,6 +371,7 @@ export async function calibrateOnce(deps: CalibrationDeps): Promise<CalibrationC
 					rubricVersion: deps.rubricVersion,
 					judgeModelId: strongId,
 					reason: outcome.reason,
+					detail: outcome.detail,
 				});
 			}
 			// Spend is ledgered for every outcome — an unjudged marker is not a

--- a/extensions/judge/src/collector.ts
+++ b/extensions/judge/src/collector.ts
@@ -10,7 +10,7 @@
  * no-op. A crash BEFORE the accept re-judges from scratch — no run is
  * ever skipped.
  *
- * Budget gates (agent-analytics §12.5), checked per run before judging:
+ * Budget gates (agent-analytics 12.5), checked per run before judging:
  *   - `JUDGE_DAILY_BUDGET_USD` fleet-wide: when the day's ledgered spend
  *     reaches the budget the run is DEFERRED — no marker, no checkpoint,
  *     so it re-enters the candidate set once budget frees (the next UTC
@@ -70,7 +70,7 @@ export interface JudgeCollectorDeps {
 	readonly onJudgment?: (runId: string, outcome: JudgeOutcome) => void;
 	/**
 	 * Once per cycle when the fleet gate first trips — loud by design
-	 * (§12.5), but once, not once per deferred run (a big backlog would
+	 * (12.5), but once, not once per deferred run (a big backlog would
 	 * repeat the line hundreds of times every cycle).
 	 */
 	readonly onBudgetDeferred?: (runId: string, detail: string) => void;
@@ -88,7 +88,7 @@ export interface JudgeCycleStats {
 const DEFAULT_RUNS_PAGE_SIZE = 500;
 
 /**
- * Discover every run by paging the full list from offset 0. FRICTION §1:
+ * Discover every run by paging the full list from offset 0. FRICTION 1:
  * no "changed since" parameter exists, so this is a full re-list every
  * cycle. Re-seeing a row is harmless — the cursor gate and the store's
  * dedupe key both absorb it.
@@ -127,6 +127,7 @@ async function judgeOneRun(
 			rubricVersion: deps.rubricVersion,
 			judgeModelId: deps.judgeModelId,
 			reason: outcome.reason,
+			detail: outcome.detail,
 		});
 	}
 	// Spend is ledgered for every outcome — an unjudged marker is not a

--- a/extensions/judge/src/index.ts
+++ b/extensions/judge/src/index.ts
@@ -196,10 +196,8 @@ async function main(): Promise<void> {
 		onCycleError: (err) => console.error(`${EXTENSION_NAME}: cycle failed:`, err),
 		onRunError: (runId, err) =>
 			console.error(`${EXTENSION_NAME}: judgment for run ${runId} failed:`, err),
-			// An unjudged marker's detail exists only here — the store row
-			// carries the reason alone, so an unlogged detail is
-			// undiagnosable from the pod (warren-5fcf: 334 judge_error
-			// markers with no error text anywhere).
+			// Log unjudged details for real-time visibility in pod logs;
+			// details are also stored in verdict_rows (warren-a106).
 			onJudgment: (runId, outcome) => {
 				if (outcome.kind === "unjudged") {
 					console.error(

--- a/extensions/judge/src/verdict-store.test.ts
+++ b/extensions/judge/src/verdict-store.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { VerdictStore } from "./verdict-store.ts";
 import type { JudgeVerdict } from "./wire.ts";
@@ -90,20 +94,74 @@ describe("VerdictStore.recordVerdict", () => {
 });
 
 describe("VerdictStore.recordUnjudged", () => {
-	test("appends an unjudged marker with a reason", () => {
+	test("appends an unjudged marker with a reason and detail", () => {
 		const store = makeStore();
 		const id = store.recordUnjudged({
 			runId: "run-1",
 			rubricVersion: "rubric-v1-abc",
 			judgeModelId: "cheap-model",
 			reason: "budget_exceeded",
+			detail: "accrued cost $0.2500 reached per-judgment cap",
 		});
 		expect(id).toBe(1);
 		const row = store.rowsForRun("run-1")[0];
 		expect(row?.kind).toBe("unjudged");
 		expect(row?.reason).toBe("budget_exceeded");
+		expect(row?.detail).toBe("accrued cost $0.2500 reached per-judgment cap");
 		expect(row?.verdict).toBeNull();
 		store.close();
+	});
+
+	test("defaults detail to null when omitted", () => {
+		const store = makeStore();
+		store.recordUnjudged({
+			runId: "run-1",
+			rubricVersion: "rubric-v1-abc",
+			judgeModelId: "cheap-model",
+			reason: "judge_error",
+		});
+		const row = store.rowsForRun("run-1")[0];
+		expect(row?.kind).toBe("unjudged");
+		expect(row?.detail).toBeNull();
+		store.close();
+	});
+
+	test("migrates existing database schema missing the detail column", () => {
+		const tmpDir = mkdtempSync(join(tmpdir(), "verdict-store-test-"));
+		const dbPath = join(tmpDir, "legacy.db");
+		try {
+			const db = new Database(dbPath);
+			db.run(`
+				CREATE TABLE verdict_rows (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					kind TEXT NOT NULL CHECK (kind IN ('verdict', 'unjudged')),
+					run_id TEXT NOT NULL,
+					rubric_version TEXT NOT NULL,
+					judge_model_id TEXT NOT NULL,
+					verdict TEXT,
+					reason TEXT,
+					recorded_at TEXT NOT NULL,
+					dedupe_key TEXT NOT NULL UNIQUE
+				);
+			`);
+			db.close();
+
+			const store = new VerdictStore(dbPath);
+			const id = store.recordUnjudged({
+				runId: "run-legacy",
+				rubricVersion: "rubric-v1-abc",
+				judgeModelId: "cheap-model",
+				reason: "judge_error",
+				detail: "legacy db detail test",
+			});
+			expect(id).toBe(1);
+			const row = store.rowsForRun("run-legacy")[0];
+			expect(row?.kind).toBe("unjudged");
+			expect(row?.detail).toBe("legacy db detail test");
+			store.close();
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
 	});
 
 	test("replay of the same unjudged marker is a no-op", () => {
@@ -167,6 +225,7 @@ describe("VerdictStore paging and per-rubric reads", () => {
 		expect(row?.kind).toBe("verdict");
 		expect(row?.verdict).toEqual(verdict);
 		expect(row?.judgeModelId).toBe("cheap-model");
+		expect(row?.detail).toBeNull();
 		store.close();
 	});
 });

--- a/extensions/judge/src/verdict-store.ts
+++ b/extensions/judge/src/verdict-store.ts
@@ -15,10 +15,10 @@
  *
  * Write-path discipline: `recordVerdict` accepts only wire.ts-validated
  * verdicts. It re-runs `validateVerdict` before touching the DB, so nothing
- * outside the §12.3 contract can land even from an in-memory caller that
+ * outside the 12.3 contract can land even from an in-memory caller that
  * skipped the parse boundary. `recordUnjudged` stores a marker with a
  * machine-readable reason; a judgment resolves to a validated verdict or an
- * unjudged marker, nothing else (agent-analytics §12.5).
+ * unjudged marker, nothing else (agent-analytics 12.5).
  */
 
 import { Database } from "bun:sqlite";
@@ -44,6 +44,7 @@ export interface VerdictRow {
 	readonly judgeModelId: string;
 	readonly verdict: JudgeVerdict;
 	readonly reason: null;
+	readonly detail: null;
 }
 
 /** One stored row — an unjudged marker. */
@@ -55,12 +56,13 @@ export interface UnjudgedRow {
 	readonly judgeModelId: string;
 	readonly verdict: null;
 	readonly reason: UnjudgedReason;
+	readonly detail: string | null;
 }
 
 export type StoreRow = VerdictRow | UnjudgedRow;
 
 /**
- * One leg of the calibration join (§12.5): the cheap judge's verdict and the
+ * One leg of the calibration join (12.5): the cheap judge's verdict and the
  * strong judge's verdict for the same runId + rubricVersion, paired so the
  * agreement-rate computation can compare band assignments class by class.
  */
@@ -82,6 +84,7 @@ CREATE TABLE IF NOT EXISTS verdict_rows (
 	judge_model_id TEXT NOT NULL,
 	verdict TEXT,
 	reason TEXT,
+	detail TEXT,
 	recorded_at TEXT NOT NULL,
 	dedupe_key TEXT NOT NULL UNIQUE
 );
@@ -97,6 +100,7 @@ interface RawRow {
 	judge_model_id: string;
 	verdict: string | null;
 	reason: string | null;
+	detail: string | null;
 }
 
 function toStoreRow(row: RawRow): StoreRow {
@@ -115,12 +119,19 @@ function toStoreRow(row: RawRow): StoreRow {
 			kind: "verdict",
 			verdict: validateVerdict(JSON.parse(row.verdict)),
 			reason: null,
+			detail: null,
 		};
 	}
 	if (row.reason === null || !(UNJUDGED_REASONS as readonly string[]).includes(row.reason)) {
 		throw new Error(`unjudged row ${row.id} has unknown reason — store invariant broken`);
 	}
-	return { ...base, kind: "unjudged", verdict: null, reason: row.reason as UnjudgedReason };
+	return {
+		...base,
+		kind: "unjudged",
+		verdict: null,
+		reason: row.reason as UnjudgedReason,
+		detail: row.detail ?? null,
+	};
 }
 
 export class VerdictStore {
@@ -132,7 +143,17 @@ export class VerdictStore {
 		this.#db = new Database(path);
 		this.#db.run("PRAGMA journal_mode = WAL;");
 		this.#db.run(SCHEMA);
+		this.#ensureDetailColumn();
 		this.#now = opts?.now ?? (() => new Date());
+	}
+
+	#ensureDetailColumn(): void {
+		const columns = this.#db
+			.query("PRAGMA table_info(verdict_rows)")
+			.all() as Array<{ name: string }>;
+		if (!columns.some((col) => col.name === "detail")) {
+			this.#db.run("ALTER TABLE verdict_rows ADD COLUMN detail TEXT;");
+		}
 	}
 
 	/**
@@ -150,6 +171,7 @@ export class VerdictStore {
 			judgeModelId: verdict.provenance.model,
 			verdictJson: JSON.stringify(verdict),
 			reason: null,
+			detail: null,
 		});
 	}
 
@@ -163,6 +185,7 @@ export class VerdictStore {
 		rubricVersion: string;
 		judgeModelId: string;
 		reason: UnjudgedReason;
+		detail?: string | null;
 	}): number | null {
 		if (!(UNJUDGED_REASONS as readonly string[]).includes(opts.reason)) {
 			throw new Error(`unjudged reason must be one of ${UNJUDGED_REASONS.join("/")}`);
@@ -174,6 +197,7 @@ export class VerdictStore {
 			judgeModelId: opts.judgeModelId,
 			verdictJson: null,
 			reason: opts.reason,
+			detail: opts.detail ?? null,
 		});
 	}
 
@@ -184,12 +208,13 @@ export class VerdictStore {
 		judgeModelId: string;
 		verdictJson: string | null;
 		reason: string | null;
+		detail: string | null;
 	}): number | null {
 		const dedupeKey = `${row.runId}|${row.rubricVersion}|${row.judgeModelId}`;
 		const result = this.#db.run(
 			`INSERT INTO verdict_rows
-				(kind, run_id, rubric_version, judge_model_id, verdict, reason, recorded_at, dedupe_key)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				(kind, run_id, rubric_version, judge_model_id, verdict, reason, detail, recorded_at, dedupe_key)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(dedupe_key) DO NOTHING`,
 			[
 				row.kind,
@@ -198,6 +223,7 @@ export class VerdictStore {
 				row.judgeModelId,
 				row.verdictJson,
 				row.reason,
+				row.detail,
 				this.#now().toISOString(),
 				dedupeKey,
 			],
@@ -231,7 +257,7 @@ export class VerdictStore {
 
 	/**
 	 * Per-rubric-version read: every row judged under `rubricVersion`, in
-	 * append order. Trend lines must never mix rubric versions (§12.3), so
+	 * append order. Trend lines must never mix rubric versions (12.3), so
 	 * this is the analytics surface's primary query.
 	 */
 	rowsForRubricVersion(rubricVersion: string): StoreRow[] {
@@ -242,7 +268,7 @@ export class VerdictStore {
 	}
 
 	/**
-	 * The calibration join (§12.5): for one rubric version, pair every run
+	 * The calibration join (12.5): for one rubric version, pair every run
 	 * that has a verdict from BOTH `cheapModelId` and `strongModelId`. The
 	 * disagreement rate between the two legs is the tracked signal that
 	 * drives any future taxonomy narrowing. Unjudged markers never join.


### PR DESCRIPTION
Resolves #973 (warren-a106).

### Summary

When a run goes unjudged (due to provider errors, malformed verdicts, or per-judgment budget caps), `judgeRun` produces a `detail` string explaining the outcome. Previously, `VerdictStore.recordUnjudged` discarded this string.

This change:
1. Adds a nullable `detail TEXT` column to `verdict_rows` table in `VerdictStore`.
2. Includes a startup migration check (`PRAGMA table_info(verdict_rows)`) executing `ALTER TABLE verdict_rows ADD COLUMN detail TEXT` when absent on existing DB files.
3. Updates row interfaces (`VerdictRow`, `UnjudgedRow`, `StoreRow`, `RawRow`) and `toStoreRow` / `#insert` mappings.
4. Threads `outcome.detail` at write sites in `collector.ts` and `calibration.ts`.
5. Updates unit tests in `verdict-store.test.ts` covering `detail` persistence and schema migration on legacy databases.

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
