### PR TITLE
fix(reap): measure pre-push commitsAhead correctly on ref-dispatch runs

### DIFF
--- a/src/runs/reap/no-changes.test.ts
+++ b/src/runs/reap/no-changes.test.ts
@@ -161,6 +161,29 @@ describe("reapRun ref-dispatch zero-commit (warren-ba08)", () => {
 		});
 	});
 
+	test("ref-dispatch with commits made reaps as succeeded", async () => {
+		const { repos, runId } = await setupSeeded(null, {
+			ref: "fix/pr-head",
+			targetBranch: "fix/pr-head",
+		});
+		const f = fakeFs({ "/data/projects/x/y/.seeds/issues.jsonl": ISSUES });
+		const e = fakeExec({ revListCount: "2", gitStatus: "" });
+
+		const result = await reapRun({
+			runId,
+			outcome: "succeeded",
+			repos,
+			...reapDeps(fakeBurrowClient(makeBurrow()), { fs: f.fs, exec: e.exec }),
+			fs: f.fs,
+			exec: e.exec,
+		});
+
+		expect(result.state).toBe("succeeded");
+		expect(result.failureReason).toBeNull();
+		expect(result.branchPushed).toBe(true);
+		expect(result.commitsAhead).toBe(2);
+	});
+
 	test("targetBranch-only dispatch with bookkeeping-only dirt fails as no_changes", async () => {
 		const { repos, runId } = await setupSeeded(null, { targetBranch: "fix/pr-head" });
 		const f = fakeFs({ "/data/projects/x/y/.seeds/issues.jsonl": ISSUES });

--- a/src/runs/reap/outcome-facts.ts
+++ b/src/runs/reap/outcome-facts.ts
@@ -104,7 +104,14 @@ async function measureDiffStats(input: RecordOutcomeFactsInput): Promise<DiffSta
 	if (input.baseBranch === null) return null;
 	// LocalProvider: read straight off the still-live host worktree.
 	if (input.workspacePath !== null) {
-		return numstat(input.exec, input.workspacePath, input.baseBranch, "HEAD");
+		const baseRef =
+			input.branch !== null && input.branch === input.baseBranch
+				? `origin/${input.baseBranch}`
+				: input.baseBranch;
+		return (
+			(await numstat(input.exec, input.workspacePath, baseRef, "HEAD")) ??
+			(await numstat(input.exec, input.workspacePath, input.baseBranch, "HEAD"))
+		);
 	}
 	// K8s: no host worktree — fetch the pushed branch into the project clone
 	// and read the range there (warren-ab66 posture). Requires the push to
@@ -135,7 +142,11 @@ async function numstatFromClone(
 		return null;
 	}
 	try {
-		return await numstat(exec, project.localPath, baseBranch, tempRef);
+		const baseRef = branch === baseBranch ? `origin/${baseBranch}` : baseBranch;
+		return (
+			(await numstat(exec, project.localPath, baseRef, tempRef)) ??
+			(await numstat(exec, project.localPath, baseBranch, tempRef))
+		);
 	} finally {
 		try {
 			await exec.run("git", ["update-ref", "-d", tempRef], {
@@ -168,7 +179,7 @@ async function numstat(
 }
 
 /**
- * Parse `git diff --numstat` output: one `<added>\t<deleted>\t<path>` row
+ * Parse `git diff --numstat` output: one `<added>	<deleted>	<path>` row
  * per file, with `-` for binary files (counted as a changed file with zero
  * line deltas, matching `git diff --stat`'s "Bin 0 -> N bytes" row).
  */
@@ -179,7 +190,7 @@ export function parseNumstat(stdout: string): DiffStats {
 	for (const raw of stdout.split("\n")) {
 		const line = raw.trimEnd();
 		if (line === "") continue;
-		const [added, removed] = line.split("\t");
+		const [added, removed] = line.split("	");
 		if (added === undefined || removed === undefined) continue;
 		filesChanged++;
 		if (added !== "-") insertions += Number.parseInt(added, 10) || 0;

--- a/src/runtime/k8s/finalize-collect.ts
+++ b/src/runtime/k8s/finalize-collect.ts
@@ -220,6 +220,10 @@ async function runPush(
 		trail.skipped("commits_ahead");
 		return NO_PUSH;
 	}
+	const commitsAhead = await countCommitsAhead(intent, workspacePath, git, trail);
+	const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(workspacePath, git) : [];
+	const dirty = dirtyPaths.length > 0;
+
 	const refspec = intent.branch === "" ? "HEAD" : `HEAD:${intent.branch}`;
 	const restore = await authenticateOrigin(intent.gitToken, workspacePath, git);
 	try {
@@ -228,7 +232,6 @@ async function runPush(
 			const err = new Error(push.stderr.trim() || push.stdout.trim() || "git push failed");
 			trail.failed("branch_push", err);
 			collector.fail("branch_push", err, workspacePath);
-			trail.skipped("commits_ahead");
 			// warren-b68d: a policy refusal carries its own remediation onward.
 			// Both streams are read because git splits the remote's echo across
 			// them by version.
@@ -239,16 +242,11 @@ async function runPush(
 			return NO_PUSH;
 		}
 		trail.ok("branch_push");
-		const commitsAhead = await countCommitsAhead(intent, workspacePath, git, trail);
-		// warren-89b0: capture dirty PATHS on a zero-commit push so warren can
-		// classify a bookkeeping-only no-op vs a dropped commit (parity with
-		// ../local/finalize.ts).
-		const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(workspacePath, git) : [];
 		return {
 			pushed: true,
 			commitsAhead,
 			emptyPush: commitsAhead === 0,
-			dirty: dirtyPaths.length > 0,
+			dirty,
 			dirtyPaths,
 		};
 	} finally {
@@ -293,10 +291,20 @@ async function countCommitsAhead(
 		trail.skipped("commits_ahead");
 		return null;
 	}
-	const res = await git(["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
+	const baseRef =
+		intent.branch !== "" && intent.branch === intent.baseBranch
+			? `origin/${intent.baseBranch}`
+			: intent.baseBranch;
+	let res = await git(["rev-list", "--count", `${baseRef}..HEAD`], {
 		cwd: workspacePath,
 		timeoutMs: 10_000,
 	});
+	if (res.exitCode !== 0 && baseRef !== intent.baseBranch) {
+		res = await git(["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
+			cwd: workspacePath,
+			timeoutMs: 10_000,
+		});
+	}
 	if (res.exitCode !== 0) {
 		trail.failed("commits_ahead", new Error(res.stderr.trim() || "git rev-list failed"));
 		return null;

--- a/src/runtime/local/finalize.ts
+++ b/src/runtime/local/finalize.ts
@@ -366,6 +366,10 @@ async function finalizePush(
 		trail.skipped("commits_ahead");
 		return { pushed: false, commitsAhead: null, emptyPush: false, dirty: false, dirtyPaths: [] };
 	}
+	const commitsAhead = await countCommitsAhead(intent, workspacePath, exec, trail);
+	const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(exec, workspacePath) : [];
+	const dirty = dirtyPaths.length > 0;
+
 	const refspec = intent.branch === "" ? "HEAD" : `HEAD:${intent.branch}`;
 	try {
 		// warren-4e1c: the push authenticates with the per-spawn credential the
@@ -377,10 +381,10 @@ async function finalizePush(
 			env: githubCredentialGitEnv(intent.gitToken),
 		});
 		trail.ok("branch_push");
+		return { pushed: true, commitsAhead, emptyPush: commitsAhead === 0, dirty, dirtyPaths };
 	} catch (err) {
 		trail.failed("branch_push", err);
 		await collector.fail("branch_push", err, workspacePath);
-		trail.skipped("commits_ahead");
 		// warren-b68d: `ReapExec.run` rejects with an Error whose message carries
 		// stderr, so the remote's own refusal text is what gets parsed here.
 		const rejection = parsePushRejection(err instanceof Error ? err.message : String(err));
@@ -389,11 +393,6 @@ async function finalizePush(
 		}
 		return { pushed: false, commitsAhead: null, emptyPush: false, dirty: false, dirtyPaths: [] };
 	}
-	const commitsAhead = await countCommitsAhead(intent, workspacePath, exec, trail);
-	// warren-72b9/89b0: capture dirty PATHS on a zero-commit push (dropped commit vs no-op).
-	const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(exec, workspacePath) : [];
-	const dirty = dirtyPaths.length > 0;
-	return { pushed: true, commitsAhead, emptyPush: commitsAhead === 0, dirty, dirtyPaths };
 }
 
 async function countCommitsAhead(
@@ -407,10 +406,22 @@ async function countCommitsAhead(
 		return null;
 	}
 	try {
-		const out = await exec.run("git", ["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
-			cwd: workspacePath,
-			timeoutMs: 10_000,
-		});
+		const baseRef =
+			intent.branch !== "" && intent.branch === intent.baseBranch
+				? `origin/${intent.baseBranch}`
+				: intent.baseBranch;
+		let out = await exec
+			.run("git", ["rev-list", "--count", `${baseRef}..HEAD`], {
+				cwd: workspacePath,
+				timeoutMs: 10_000,
+			})
+			.catch(() => null);
+		if (out === null) {
+			out = await exec.run("git", ["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
+				cwd: workspacePath,
+				timeoutMs: 10_000,
+			});
+		}
 		const parsed = Number.parseInt(out.stdout.trim(), 10);
 		trail.ok("commits_ahead");
 		return Number.isFinite(parsed) ? parsed : null;


### PR DESCRIPTION
Fixes an issue where ref-dispatch repair runs (`branch === baseBranch`) evaluated `commits_ahead` as structurally 0 because `git rev-list` was executed after `git push` against the local branch name (`baseBranch..HEAD`), which evaluates to 0 when `HEAD` is attached to `baseBranch`. `countCommitsAhead` now runs before `git push` and evaluates against `origin/<baseBranch>` when `branch === baseBranch`, ensuring productive repair runs reap as succeeded with their true `commitsAhead` count while zero-commit repair runs fail as `no_changes`.

Addresses #979

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
