### PR TITLE
feat(claude-code): warn agents that staging is not committing

### DIFF
--- a/src/registry/builtins/claude-code.ts
+++ b/src/registry/builtins/claude-code.ts
@@ -28,7 +28,7 @@ ${BASE_WORKSPACE_BULLETS}
 Operating contract:
 - Edit files in place. Run tests when relevant.
 - Quality gates are terminal, not advisory. You are NOT done until the gate exits zero. Resolve the command in this order: ${QUALITY_GATE_CHAIN}. Run it before committing and again before reporting completion. Do not declare the task complete, hand off, or end the session with a red gate — fix failures (including lint warnings, which CI treats as errors) until it is green. If the gate is genuinely unfixable in this run, say so explicitly and leave the work open rather than claiming success.
-- Use git as you normally would. Commit your changes; warren reaps the branch and pushes upstream.
+- Use git as you normally would. Commit your changes; warren reaps the branch and pushes upstream. Committing is mandatory, and staging is not committing. \`git add\` on its own leaves the work uncommitted, and reap classifies a run that ends with uncommitted changes as a FAILURE (\`dropped_commit\`) even when the agent otherwise succeeded — the workspace is then destroyed and the work is lost. Before you report completion, run \`git status\` and \`git log\` and confirm your edits are in a commit. The only exception is a run that genuinely changed no files.
 - Do not run \`git push\` yourself — warren handles the push host-side after the run terminates.
 `;
 


### PR DESCRIPTION
## What

One-line change to the `claude-code` builtin's operating contract.

The contract said only "Commit your changes; warren reaps the branch and pushes
upstream." In practice agents were ending runs with `git add` done and
`git commit` never run.

## Why it matters

reap classifies that shape as `dropped_commit`: an otherwise successful run
flips to `failed`, the workspace is destroyed, and the work is gone. The agent
believes it succeeded. Nothing in the prompt told it that staging is not
committing.

This spells out the distinction, names the failure mode and its consequence, and
asks the agent to verify with `git status` / `git log` before reporting
completion — mirroring the warning the `pi` builtin already carries, so the two
harnesses give agents the same instruction.

## Scope

Prompt text only. No behaviour change, no code paths touched. The
`${QUALITY_GATE_CHAIN}` refactor in this block is left exactly as it is upstream.

Note `src/registry/builtins/` is an Article IX protected path, so
`.github/workflows/auto-merge.yml` will refuse auto-merge on this PR by design —
it needs a human review.

## Testing

`bun test src/registry/builtins/` green (41 pass); full suite green.
`lint` and `typecheck` clean.

## Note on tracker ids

The commit references `warren-91eb`, an id in my fork's seeds tracker — it will
not resolve against yours. Happy to renumber or drop it.

Observed running warren against its own repo.