### PR TITLE
fix(reap): measure commits_ahead against the pre-push origin tip on ref-dispatch repair runs (warren-ba08, #979)

### DIFF
--- a/docs/design/runtime-provider-contract.md
+++ b/docs/design/runtime-provider-contract.md
@@ -221,7 +221,9 @@ interface FinalizeIntent {
 }
 interface FinalizeResult {
   pushed: boolean;
-  commitsAhead: number;
+  commitsAhead: number | null;      // null = not measured (warren-f3bb)
+  commitsAheadBase?: string;        // ref the count ran against; a repair run pins the
+                                    // pre-push origin/<base> SHA (warren-ba08)
   emptyPush: boolean;               // dropped-commit detection
   mirror: {                         // artifact diffs the domain applies to the project clone
     mulch?: MulchDelta; seeds?: SeedsDelta; plans?: PlansDelta; plot?: PlotDelta;

--- a/src/runs/reap/no-changes.test.ts
+++ b/src/runs/reap/no-changes.test.ts
@@ -3,6 +3,7 @@ import type { SeedsCliDeps } from "../../seeds-cli/index.ts";
 import { reapRun } from "./run.ts";
 import {
 	createRepos,
+	FAKE_REV_PARSE_SHA,
 	fakeBurrowClient,
 	fakeExec,
 	fakeFs,
@@ -161,7 +162,8 @@ describe("reapRun ref-dispatch zero-commit (warren-ba08)", () => {
 		});
 	});
 
-	test("ref-dispatch with commits made reaps as succeeded", async () => {
+	test("ref-dispatch with commits made reaps as succeeded, counted from the pre-push origin tip", async () => {
+		// Repair topology: the workspace branch IS the ref (branch === baseBranch).
 		const { repos, runId } = await setupSeeded(null, {
 			ref: "fix/pr-head",
 			targetBranch: "fix/pr-head",
@@ -173,7 +175,10 @@ describe("reapRun ref-dispatch zero-commit (warren-ba08)", () => {
 			runId,
 			outcome: "succeeded",
 			repos,
-			...reapDeps(fakeBurrowClient(makeBurrow()), { fs: f.fs, exec: e.exec }),
+			...reapDeps(fakeBurrowClient(makeBurrow({ branch: "fix/pr-head" })), {
+				fs: f.fs,
+				exec: e.exec,
+			}),
 			fs: f.fs,
 			exec: e.exec,
 		});
@@ -182,6 +187,24 @@ describe("reapRun ref-dispatch zero-commit (warren-ba08)", () => {
 		expect(result.failureReason).toBeNull();
 		expect(result.branchPushed).toBe(true);
 		expect(result.commitsAhead).toBe(2);
+		// The count and the outcome-facts diff both run against the PRE-PUSH
+		// origin tip, never the structurally-empty `fix/pr-head..HEAD` range.
+		const measured = e.calls
+			.filter((c) => c.cmd === "git")
+			.map((c) => c.args)
+			.filter(
+				(a) => ["rev-parse", "push", "rev-list"].includes(a[0] ?? "") || a.includes("--numstat"),
+			);
+		expect(measured).toEqual([
+			["rev-parse", "--verify", "origin/fix/pr-head"],
+			["push", "origin", "HEAD:fix/pr-head"],
+			["rev-list", "--count", `${FAKE_REV_PARSE_SHA}..HEAD`],
+			["diff", "--numstat", `${FAKE_REV_PARSE_SHA}..HEAD`],
+		]);
+		const row = await repos.runs.require(runId);
+		expect(row.commitsAhead).toBe(2);
+		const events = await repos.events.listByRun(runId);
+		expect(events.find((ev) => ev.kind === "reap.empty_push")).toBeUndefined();
 	});
 
 	test("targetBranch-only dispatch with bookkeeping-only dirt fails as no_changes", async () => {

--- a/src/runs/reap/no-changes.test.ts
+++ b/src/runs/reap/no-changes.test.ts
@@ -161,6 +161,29 @@ describe("reapRun ref-dispatch zero-commit (warren-ba08)", () => {
 		});
 	});
 
+	test("ref-dispatch with commits made reaps as succeeded", async () => {
+		const { repos, runId } = await setupSeeded(null, {
+			ref: "fix/pr-head",
+			targetBranch: "fix/pr-head",
+		});
+		const f = fakeFs({ "/data/projects/x/y/.seeds/issues.jsonl": ISSUES });
+		const e = fakeExec({ revListCount: "2", gitStatus: "" });
+
+		const result = await reapRun({
+			runId,
+			outcome: "succeeded",
+			repos,
+			...reapDeps(fakeBurrowClient(makeBurrow()), { fs: f.fs, exec: e.exec }),
+			fs: f.fs,
+			exec: e.exec,
+		});
+
+		expect(result.state).toBe("succeeded");
+		expect(result.failureReason).toBeNull();
+		expect(result.branchPushed).toBe(true);
+		expect(result.commitsAhead).toBe(2);
+	});
+
 	test("targetBranch-only dispatch with bookkeeping-only dirt fails as no_changes", async () => {
 		const { repos, runId } = await setupSeeded(null, { targetBranch: "fix/pr-head" });
 		const f = fakeFs({ "/data/projects/x/y/.seeds/issues.jsonl": ISSUES });

--- a/src/runs/reap/outcome-facts.ts
+++ b/src/runs/reap/outcome-facts.ts
@@ -35,7 +35,12 @@ export interface RecordOutcomeFactsInput {
 	readonly workspacePath: string | null;
 	/** The run's pushed branch (K8s clone-fetch source); null = none. */
 	readonly branch: string | null;
-	/** Project default branch; null = unmeasurable (matches finalize). */
+	/**
+	 * The base ref for the `base..head` diff — finalize's reported
+	 * `commitsAheadBase` (the ref it counted `commits_ahead` against; a SHA on
+	 * a ref-dispatch repair run, warren-ba08) else the run's base branch;
+	 * null = unmeasurable (matches finalize).
+	 */
 	readonly baseBranch: string | null;
 	readonly project: { readonly gitUrl: string; readonly localPath: string };
 	/** finalize's measured count; the fact persisted verbatim. */
@@ -104,14 +109,7 @@ async function measureDiffStats(input: RecordOutcomeFactsInput): Promise<DiffSta
 	if (input.baseBranch === null) return null;
 	// LocalProvider: read straight off the still-live host worktree.
 	if (input.workspacePath !== null) {
-		const baseRef =
-			input.branch !== null && input.branch === input.baseBranch
-				? `origin/${input.baseBranch}`
-				: input.baseBranch;
-		return (
-			(await numstat(input.exec, input.workspacePath, baseRef, "HEAD")) ??
-			(await numstat(input.exec, input.workspacePath, input.baseBranch, "HEAD"))
-		);
+		return numstat(input.exec, input.workspacePath, input.baseBranch, "HEAD");
 	}
 	// K8s: no host worktree — fetch the pushed branch into the project clone
 	// and read the range there (warren-ab66 posture). Requires the push to
@@ -142,11 +140,7 @@ async function numstatFromClone(
 		return null;
 	}
 	try {
-		const baseRef = branch === baseBranch ? `origin/${baseBranch}` : baseBranch;
-		return (
-			(await numstat(exec, project.localPath, baseRef, tempRef)) ??
-			(await numstat(exec, project.localPath, baseBranch, tempRef))
-		);
+		return await numstat(exec, project.localPath, baseBranch, tempRef);
 	} finally {
 		try {
 			await exec.run("git", ["update-ref", "-d", tempRef], {
@@ -179,7 +173,7 @@ async function numstat(
 }
 
 /**
- * Parse `git diff --numstat` output: one `<added>	<deleted>	<path>` row
+ * Parse `git diff --numstat` output: one `<added>\t<deleted>\t<path>` row
  * per file, with `-` for binary files (counted as a changed file with zero
  * line deltas, matching `git diff --stat`'s "Bin 0 -> N bytes" row).
  */
@@ -190,7 +184,7 @@ export function parseNumstat(stdout: string): DiffStats {
 	for (const raw of stdout.split("\n")) {
 		const line = raw.trimEnd();
 		if (line === "") continue;
-		const [added, removed] = line.split("	");
+		const [added, removed] = line.split("\t");
 		if (added === undefined || removed === undefined) continue;
 		filesChanged++;
 		if (added !== "-") insertions += Number.parseInt(added, 10) || 0;

--- a/src/runs/reap/outcome-facts.ts
+++ b/src/runs/reap/outcome-facts.ts
@@ -104,7 +104,14 @@ async function measureDiffStats(input: RecordOutcomeFactsInput): Promise<DiffSta
 	if (input.baseBranch === null) return null;
 	// LocalProvider: read straight off the still-live host worktree.
 	if (input.workspacePath !== null) {
-		return numstat(input.exec, input.workspacePath, input.baseBranch, "HEAD");
+		const baseRef =
+			input.branch !== null && input.branch === input.baseBranch
+				? `origin/${input.baseBranch}`
+				: input.baseBranch;
+		return (
+			(await numstat(input.exec, input.workspacePath, baseRef, "HEAD")) ??
+			(await numstat(input.exec, input.workspacePath, input.baseBranch, "HEAD"))
+		);
 	}
 	// K8s: no host worktree — fetch the pushed branch into the project clone
 	// and read the range there (warren-ab66 posture). Requires the push to
@@ -135,7 +142,11 @@ async function numstatFromClone(
 		return null;
 	}
 	try {
-		return await numstat(exec, project.localPath, baseBranch, tempRef);
+		const baseRef = branch === baseBranch ? `origin/${baseBranch}` : baseBranch;
+		return (
+			(await numstat(exec, project.localPath, baseRef, tempRef)) ??
+			(await numstat(exec, project.localPath, baseBranch, tempRef))
+		);
 	} finally {
 		try {
 			await exec.run("git", ["update-ref", "-d", tempRef], {
@@ -168,7 +179,7 @@ async function numstat(
 }
 
 /**
- * Parse `git diff --numstat` output: one `<added>\t<deleted>\t<path>` row
+ * Parse `git diff --numstat` output: one `<added>	<deleted>	<path>` row
  * per file, with `-` for binary files (counted as a changed file with zero
  * line deltas, matching `git diff --stat`'s "Bin 0 -> N bytes" row).
  */
@@ -179,7 +190,7 @@ export function parseNumstat(stdout: string): DiffStats {
 	for (const raw of stdout.split("\n")) {
 		const line = raw.trimEnd();
 		if (line === "") continue;
-		const [added, removed] = line.split("\t");
+		const [added, removed] = line.split("	");
 		if (added === undefined || removed === undefined) continue;
 		filesChanged++;
 		if (added !== "-") insertions += Number.parseInt(added, 10) || 0;

--- a/src/runs/reap/pipeline.ts
+++ b/src/runs/reap/pipeline.ts
@@ -492,12 +492,13 @@ export async function runReapPipeline(
 	// warren-ab2b: persist the reap-time outcome facts (commits_ahead + parsed
 	// diff totals) while the workspace / pushed branch is still readable.
 	// Skipped when finalize never measured (commitsAhead null ⇒ all unknown).
+	// warren-ba08: diff against the SAME ref finalize counted from (repair runs: a SHA).
 	if (state.commitsAhead !== null) {
 		state.diffStats = await recordOutcomeFacts({
 			runId: ctx.run.id,
 			workspacePath: ctx.workspacePath,
 			branch: ctx.branch,
-			baseBranch: ctx.baseBranch,
+			baseBranch: finalizeResult.commitsAheadBase ?? ctx.baseBranch,
 			project: ctx.project,
 			commitsAhead: state.commitsAhead,
 			branchPushed: state.branchPushed,

--- a/src/runs/reap/test-helpers.ts
+++ b/src/runs/reap/test-helpers.ts
@@ -142,6 +142,12 @@ export interface FakeExecOpts {
 	/** Throw on git rev-list calls (default: succeed). */
 	failRevList?: string;
 	/**
+	 * Stdout for `git rev-parse --verify <ref>` (warren-ba08: the pre-push
+	 * `origin/<branch>` tip finalize pins on a ref-dispatch repair run).
+	 * Default a fixed fake SHA; pass `""` to simulate a missing tracking ref.
+	 */
+	revParse?: string;
+	/**
 	 * Throw on `git cat-file -e <ref>:<path>` (default: succeed) — simulates
 	 * a seed drop absent from the base ref, i.e. untracked in every ref
 	 * (warren-0f18's seed_reset sweep test).
@@ -193,6 +199,15 @@ function handleRevList(failRevList: string | null, revListCount: string): ExecRe
 	return { stdout: `${revListCount}\n`, stderr: "" };
 }
 
+/** warren-ba08: `git rev-parse --verify` exits non-zero (throws) when the ref is missing. */
+function handleRevParse(revParse: string): ExecResult {
+	if (revParse === "") throw new Error("fatal: Needed a single revision");
+	return { stdout: `${revParse}\n`, stderr: "" };
+}
+
+/** The pre-run tip `fakeExec` resolves `origin/<branch>` to by default. */
+export const FAKE_REV_PARSE_SHA = "0123456789abcdef0123456789abcdef01234567";
+
 function handleStatus(failGitStatus: string | null, gitStatus: string): ExecResult {
 	if (failGitStatus !== null) throw new Error(failGitStatus);
 	return { stdout: gitStatus, stderr: "" };
@@ -215,6 +230,7 @@ export function fakeExec(opts: FakeExecOpts = {}): FakeExec {
 	const failRevList = opts.failRevList ?? null;
 	const failCatFile = opts.failCatFile === true;
 	const revListCount = opts.revListCount ?? "1";
+	const revParse = opts.revParse ?? FAKE_REV_PARSE_SHA;
 	const numstat = opts.numstat ?? "";
 	const stagedDelta = opts.stagedDelta === true;
 	const gitStatus = opts.gitStatus ?? "";
@@ -224,6 +240,7 @@ export function fakeExec(opts: FakeExecOpts = {}): FakeExec {
 	const route = (cmd: string, args: readonly string[]): ExecResult | null => {
 		if (isGitSub(cmd, args, "cat-file")) return handleCatFile(failCatFile);
 		if (isGitSub(cmd, args, "rev-list")) return handleRevList(failRevList, revListCount);
+		if (isGitSub(cmd, args, "rev-parse")) return handleRevParse(revParse);
 		if (isGitSub(cmd, args, "status") && args.includes("--porcelain")) {
 			return handleStatus(failGitStatus, gitStatus);
 		}

--- a/src/runs/reap/util.test.ts
+++ b/src/runs/reap/util.test.ts
@@ -4,8 +4,23 @@ import {
 	HARNESS_STATE_PREFIXES,
 	isBookkeepingOnlyDirty,
 	parseDirtyPaths,
+	repairBaseTrackingRef,
 	WARREN_RUNTIME_SCRATCH,
 } from "./util.ts";
+
+describe("repairBaseTrackingRef (warren-ba08)", () => {
+	test("a ref-dispatch repair run (branch === baseBranch) counts from origin/<base>", () => {
+		expect(repairBaseTrackingRef("fix/pr-head", "fix/pr-head")).toBe("origin/fix/pr-head");
+	});
+
+	test("a fresh-branch dispatch keeps the plain base ref", () => {
+		expect(repairBaseTrackingRef("warren/run-1", "main")).toBeNull();
+	});
+
+	test("an empty push branch (HEAD refspec) is never the repair topology", () => {
+		expect(repairBaseTrackingRef("", "")).toBeNull();
+	});
+});
 
 describe("parseDirtyPaths", () => {
 	test("parses porcelain status lines into workspace-relative paths", () => {

--- a/src/runs/reap/util.ts
+++ b/src/runs/reap/util.ts
@@ -208,6 +208,24 @@ const IGNORABLE_DIRTY_PREFIXES: readonly string[] = [
 ];
 
 /**
+ * The remote-tracking ref finalize must resolve BEFORE `branch_push` to count
+ * `commits_ahead` on a ref-dispatch repair run, or `null` when the plain
+ * `baseBranch..HEAD` range is the right one (warren-ba08, #979 / #994).
+ *
+ * On a repair run the push branch IS the base branch (`branch === baseBranch`,
+ * warren-709e): workspace init checks the target branch out directly and
+ * skips the per-run carve, so HEAD is attached to `baseBranch` and
+ * `rev-list --count baseBranch..HEAD` is empty by construction — whether the
+ * agent landed 0 commits or 10. The only ref still holding the pre-run tip is
+ * `origin/<baseBranch>`, and `git push origin HEAD:<baseBranch>` rewrites it
+ * on success, so the caller must `rev-parse` it before the push and count
+ * against the resolved SHA after.
+ */
+export function repairBaseTrackingRef(branch: string, baseBranch: string): string | null {
+	return branch !== "" && branch === baseBranch ? `origin/${baseBranch}` : null;
+}
+
+/**
  * True when the dirty tree is non-empty AND every dirty path lives under a
  * bookkeeping ({@link BOOKKEEPING_ARTIFACT_PREFIXES}) or harness-state
  * ({@link HARNESS_STATE_PREFIXES}) directory (warren-89b0, warren-f6f2). An

--- a/src/runtime/contract.ts
+++ b/src/runtime/contract.ts
@@ -348,24 +348,24 @@ export interface FinalizeResult {
 	/** warren-5ea1: set ONLY on a warren-SYNTHESIZED failed result — the in-pod finalize never POSTed one. */
 	unposted?: "timeout" | "pod_terminal" | "pod_gone";
 	/**
-	 * Commits the pushed branch is ahead of `intent.baseBranch`. WIDENED from
-	 * the design-doc's `number` to `number | null` to match reap's real shape
-	 * (warren-f3bb): the count is genuinely uncomputable when the push was
-	 * skipped/failed, no `baseBranch` was supplied, or `git rev-list` failed,
-	 * and collapsing that to `0` would masquerade a failed count as an empty
-	 * push. `0` means the push landed no new commits; positive means real work.
+	 * Commits the pushed branch is ahead of `intent.baseBranch`; `null` (warren-f3bb)
+	 * when the push was skipped/failed, `baseBranch` is absent, or rev-list failed —
+	 * `0` must mean "landed no new commits", never a failed count.
 	 */
 	commitsAhead: number | null;
+	/**
+	 * The ref the count ran against (warren-ba08): `baseBranch`, or on a repair run
+	 * (branch === base ⇒ `base..HEAD` is empty by construction) the pre-push
+	 * `origin/<base>` SHA. Outcome facts diff against it. Present iff `commitsAhead !== null`.
+	 */
+	commitsAheadBase?: string;
 	/** dropped-commit detection: pushed but zero commits ahead of the base */
 	emptyPush: boolean;
 	/**
-	 * Workspace-dirtiness at push time (warren-1f56): `git status --porcelain`
-	 * was non-empty. Probed ONLY when `pushed && commitsAhead === 0` (matching
-	 * reap's `commitsAheadStep`), `false` otherwise. The domain owns the
-	 * `droppedCommit` derivation (`dirty && outcome === "succeeded"`) and the
-	 * `reap.empty_push` emission — both need the run outcome, a domain concern
-	 * the provider seam does not carry, and the workspace is provider-owned +
-	 * destroyed by `terminate`, so the domain cannot re-probe post-finalize.
+	 * Workspace-dirtiness at push time (warren-1f56): `git status --porcelain` was
+	 * non-empty. Probed ONLY when `pushed && commitsAhead === 0` (reap's
+	 * `commitsAheadStep`), else `false`. The domain owns `droppedCommit` + the
+	 * `reap.empty_push` emission (they need the run outcome; `terminate` kills the workspace).
 	 */
 	dirty: boolean;
 	/**

--- a/src/runtime/k8s/finalize-collect.ts
+++ b/src/runtime/k8s/finalize-collect.ts
@@ -13,7 +13,7 @@
  */
 
 import { join } from "node:path";
-import { parseDirtyPaths } from "../../runs/reap/util.ts";
+import { parseDirtyPaths, repairBaseTrackingRef } from "../../runs/reap/util.ts";
 import { authenticatedCloneUrl } from "../../workspace/git/clone-url.ts";
 import type {
 	ArtifactDelta,
@@ -188,6 +188,8 @@ function bodyToFiles(path: string, body: string | null): ArtifactDeltaFile[] {
 export interface PushOutcome {
 	pushed: boolean;
 	commitsAhead: number | null;
+	/** The ref `commitsAhead` was counted against; null when not measured. */
+	commitsAheadBase: string | null;
 	emptyPush: boolean;
 	dirty: boolean;
 	dirtyPaths: readonly string[];
@@ -196,10 +198,42 @@ export interface PushOutcome {
 const NO_PUSH: PushOutcome = {
 	pushed: false,
 	commitsAhead: null,
+	commitsAheadBase: null,
 	emptyPush: false,
 	dirty: false,
 	dirtyPaths: [],
 };
+
+/**
+ * The base ref `commits_ahead` counts from, resolved BEFORE the push (parity
+ * with `../local/finalize.ts`): `intent.baseBranch` as-is, except on a
+ * ref-dispatch repair run where the pre-push tip of `origin/<baseBranch>` must
+ * be pinned to a SHA first (see `repairBaseTrackingRef`). `null` ⇒ no
+ * `baseBranch`, count skipped; an `error` ⇒ the tracking ref could not be
+ * resolved, count fails (never a structural `0`).
+ */
+type CountBase = { ref: string } | { error: Error } | null;
+
+async function resolveCountBase(
+	intent: InPodFinalizeIntent,
+	workspacePath: string,
+	git: FinalizeGitRunner,
+): Promise<CountBase> {
+	if (intent.baseBranch === undefined || intent.baseBranch === "") return null;
+	const trackingRef = repairBaseTrackingRef(intent.branch, intent.baseBranch);
+	if (trackingRef === null) return { ref: intent.baseBranch };
+	const res = await git(["rev-parse", "--verify", trackingRef], {
+		cwd: workspacePath,
+		timeoutMs: 10_000,
+	});
+	const sha = res.stdout.trim();
+	if (res.exitCode !== 0 || sha === "") {
+		return {
+			error: new Error(res.stderr.trim() || `git rev-parse ${trackingRef} returned no object`),
+		};
+	}
+	return { ref: sha };
+}
 
 /**
  * `git push origin HEAD:<branch>` then the commits-ahead / empty-push count,
@@ -220,10 +254,9 @@ async function runPush(
 		trail.skipped("commits_ahead");
 		return NO_PUSH;
 	}
-	const commitsAhead = await countCommitsAhead(intent, workspacePath, git, trail);
-	const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(workspacePath, git) : [];
-	const dirty = dirtyPaths.length > 0;
-
+	// warren-ba08: pin the count base before the push rewrites the
+	// remote-tracking ref on a repair run; the count itself stays post-push.
+	const countBase = await resolveCountBase(intent, workspacePath, git);
 	const refspec = intent.branch === "" ? "HEAD" : `HEAD:${intent.branch}`;
 	const restore = await authenticateOrigin(intent.gitToken, workspacePath, git);
 	try {
@@ -232,6 +265,7 @@ async function runPush(
 			const err = new Error(push.stderr.trim() || push.stdout.trim() || "git push failed");
 			trail.failed("branch_push", err);
 			collector.fail("branch_push", err, workspacePath);
+			trail.skipped("commits_ahead");
 			// warren-b68d: a policy refusal carries its own remediation onward.
 			// Both streams are read because git splits the remote's echo across
 			// them by version.
@@ -242,11 +276,18 @@ async function runPush(
 			return NO_PUSH;
 		}
 		trail.ok("branch_push");
+		const commitsAhead = await countCommitsAhead(countBase, workspacePath, git, trail);
+		// warren-89b0: capture dirty PATHS on a zero-commit push so warren can
+		// classify a bookkeeping-only no-op vs a dropped commit (parity with
+		// ../local/finalize.ts).
+		const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(workspacePath, git) : [];
 		return {
 			pushed: true,
 			commitsAhead,
+			commitsAheadBase:
+				commitsAhead !== null && countBase !== null && "ref" in countBase ? countBase.ref : null,
 			emptyPush: commitsAhead === 0,
-			dirty,
+			dirty: dirtyPaths.length > 0,
 			dirtyPaths,
 		};
 	} finally {
@@ -282,29 +323,23 @@ export async function authenticateOrigin(
 }
 
 async function countCommitsAhead(
-	intent: InPodFinalizeIntent,
+	countBase: CountBase,
 	workspacePath: string,
 	git: FinalizeGitRunner,
 	trail: StageTrail,
 ): Promise<number | null> {
-	if (intent.baseBranch === undefined || intent.baseBranch === "") {
+	if (countBase === null) {
 		trail.skipped("commits_ahead");
 		return null;
 	}
-	const baseRef =
-		intent.branch !== "" && intent.branch === intent.baseBranch
-			? `origin/${intent.baseBranch}`
-			: intent.baseBranch;
-	let res = await git(["rev-list", "--count", `${baseRef}..HEAD`], {
+	if ("error" in countBase) {
+		trail.failed("commits_ahead", countBase.error);
+		return null;
+	}
+	const res = await git(["rev-list", "--count", `${countBase.ref}..HEAD`], {
 		cwd: workspacePath,
 		timeoutMs: 10_000,
 	});
-	if (res.exitCode !== 0 && baseRef !== intent.baseBranch) {
-		res = await git(["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
-			cwd: workspacePath,
-			timeoutMs: 10_000,
-		});
-	}
 	if (res.exitCode !== 0) {
 		trail.failed("commits_ahead", new Error(res.stderr.trim() || "git rev-list failed"));
 		return null;
@@ -376,6 +411,7 @@ export async function collectFinalizeResult(
 	return {
 		pushed: push.pushed,
 		commitsAhead: push.commitsAhead,
+		...(push.commitsAheadBase !== null ? { commitsAheadBase: push.commitsAheadBase } : {}),
 		emptyPush: push.emptyPush,
 		dirty: push.dirty,
 		dirtyPaths: push.dirtyPaths,

--- a/src/runtime/k8s/finalize-collect.ts
+++ b/src/runtime/k8s/finalize-collect.ts
@@ -220,6 +220,10 @@ async function runPush(
 		trail.skipped("commits_ahead");
 		return NO_PUSH;
 	}
+	const commitsAhead = await countCommitsAhead(intent, workspacePath, git, trail);
+	const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(workspacePath, git) : [];
+	const dirty = dirtyPaths.length > 0;
+
 	const refspec = intent.branch === "" ? "HEAD" : `HEAD:${intent.branch}`;
 	const restore = await authenticateOrigin(intent.gitToken, workspacePath, git);
 	try {
@@ -228,7 +232,6 @@ async function runPush(
 			const err = new Error(push.stderr.trim() || push.stdout.trim() || "git push failed");
 			trail.failed("branch_push", err);
 			collector.fail("branch_push", err, workspacePath);
-			trail.skipped("commits_ahead");
 			// warren-b68d: a policy refusal carries its own remediation onward.
 			// Both streams are read because git splits the remote's echo across
 			// them by version.
@@ -239,16 +242,11 @@ async function runPush(
 			return NO_PUSH;
 		}
 		trail.ok("branch_push");
-		const commitsAhead = await countCommitsAhead(intent, workspacePath, git, trail);
-		// warren-89b0: capture dirty PATHS on a zero-commit push so warren can
-		// classify a bookkeeping-only no-op vs a dropped commit (parity with
-		// ../local/finalize.ts).
-		const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(workspacePath, git) : [];
 		return {
 			pushed: true,
 			commitsAhead,
 			emptyPush: commitsAhead === 0,
-			dirty: dirtyPaths.length > 0,
+			dirty,
 			dirtyPaths,
 		};
 	} finally {
@@ -293,10 +291,20 @@ async function countCommitsAhead(
 		trail.skipped("commits_ahead");
 		return null;
 	}
-	const res = await git(["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
+	const baseRef =
+		intent.branch !== "" && intent.branch === intent.baseBranch
+			? `origin/${intent.baseBranch}`
+			: intent.baseBranch;
+	let res = await git(["rev-list", "--count", `${baseRef}..HEAD`], {
 		cwd: workspacePath,
 		timeoutMs: 10_000,
 	});
+	if (res.exitCode !== 0 && baseRef !== intent.baseBranch) {
+		res = await git(["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
+			cwd: workspacePath,
+			timeoutMs: 10_000,
+		});
+	}
 	if (res.exitCode !== 0) {
 		trail.failed("commits_ahead", new Error(res.stderr.trim() || "git rev-list failed"));
 		return null;

--- a/src/runtime/k8s/finalize-entrypoint.repair-base.test.ts
+++ b/src/runtime/k8s/finalize-entrypoint.repair-base.test.ts
@@ -1,0 +1,124 @@
+/**
+ * In-pod `collectFinalizeResult` on the ref-dispatch REPAIR topology
+ * (warren-ba08, #979 / #994) — parity with
+ * `../local/finalize.repair-base.test.ts`. `branch === baseBranch` ⇒ pin the
+ * pre-push `origin/<base>` tip, push, then count `<sha>..HEAD`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	collectFinalizeResult,
+	type FinalizeFs,
+	type FinalizeGitRunner,
+} from "./finalize-collect.ts";
+import { IN_POD_FINALIZE_WIRE_VERSION, type InPodFinalizeIntent } from "./finalize-wire.ts";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+
+/** Empty fs seam — the repair intent merges no trackers. */
+const NO_FS: FinalizeFs = {
+	readFile: async (path) => {
+		throw new Error(`ENOENT ${path}`);
+	},
+	readdir: async (path) => {
+		throw new Error(`ENOTDIR ${path}`);
+	},
+};
+
+/** Git seam recording argv, returning scripted `{exitCode,stdout,stderr}` by first arg. */
+function fakeGit(
+	script: Partial<Record<string, { exitCode?: number; stdout?: string; stderr?: string }>> = {},
+): { git: FinalizeGitRunner; calls: string[][] } {
+	const calls: string[][] = [];
+	const git: FinalizeGitRunner = async (args) => {
+		calls.push(args);
+		const s = script[args[0] ?? ""] ?? {};
+		return { exitCode: s.exitCode ?? 0, stdout: s.stdout ?? "", stderr: s.stderr ?? "" };
+	};
+	return { git, calls };
+}
+
+function repairIntent(over: Partial<InPodFinalizeIntent> = {}): InPodFinalizeIntent {
+	return {
+		version: IN_POD_FINALIZE_WIRE_VERSION,
+		attemptId: "fin_abcdefghjkmn",
+		branch: "fix/pr-head",
+		baseBranch: "fix/pr-head",
+		push: true,
+		artifacts: [],
+		commit: [],
+		...over,
+	};
+}
+
+describe("collectFinalizeResult — ref-dispatch repair topology (warren-ba08)", () => {
+	test("pins origin/<base> before the push and counts against the SHA after it", async () => {
+		const { git, calls } = fakeGit({
+			"rev-parse": { stdout: `${SHA}\n` },
+			"rev-list": { stdout: "2" },
+		});
+		const r = await collectFinalizeResult(repairIntent(), "/ws", { fs: NO_FS, git });
+		expect(r.pushed).toBe(true);
+		expect(r.commitsAhead).toBe(2);
+		expect(r.emptyPush).toBe(false);
+		expect(r.prBranch).toBe("fix/pr-head");
+		expect(r.commitsAheadBase).toBe(SHA);
+		expect(calls).toEqual([
+			["rev-parse", "--verify", "origin/fix/pr-head"],
+			["push", "origin", "HEAD:fix/pr-head"],
+			["rev-list", "--count", `${SHA}..HEAD`],
+		]);
+		expect(r.stages).toEqual([
+			{ stage: "branch_push", status: "ok" },
+			{ stage: "commits_ahead", status: "ok" },
+		]);
+	});
+
+	test("an unresolvable tracking ref fails commits_ahead to null, never 0", async () => {
+		const { git, calls } = fakeGit({
+			"rev-parse": { exitCode: 128, stderr: "fatal: Needed a single revision\n" },
+			"rev-list": { stdout: "0" },
+		});
+		const r = await collectFinalizeResult(repairIntent(), "/ws", { fs: NO_FS, git });
+		expect(r.pushed).toBe(true);
+		expect(r.commitsAhead).toBeNull();
+		expect(r.commitsAheadBase).toBeUndefined();
+		expect(r.emptyPush).toBe(false);
+		expect(r.stages).toEqual([
+			{ stage: "branch_push", status: "ok" },
+			{ stage: "commits_ahead", status: "failed", error: "fatal: Needed a single revision" },
+		]);
+		expect(calls.some((c) => c[0] === "rev-list")).toBe(false);
+	});
+
+	test("a failed push skips the count even though the base was pinned", async () => {
+		const { git, calls } = fakeGit({
+			"rev-parse": { stdout: `${SHA}\n` },
+			push: { exitCode: 1, stderr: "remote: rejected" },
+		});
+		const r = await collectFinalizeResult(repairIntent(), "/ws", { fs: NO_FS, git });
+		expect(r.pushed).toBe(false);
+		expect(r.commitsAhead).toBeNull();
+		expect(r.commitsAheadBase).toBeUndefined();
+		expect(calls.map((c) => c[0])).toEqual(["rev-parse", "push"]);
+	});
+
+	test("a fresh-branch dispatch never rev-parses and reports the base branch", async () => {
+		const { git, calls } = fakeGit({ "rev-list": { stdout: "1" } });
+		const r = await collectFinalizeResult(
+			repairIntent({ branch: "warren/run_x", baseBranch: "main" }),
+			"/ws",
+			{ fs: NO_FS, git },
+		);
+		expect(r.commitsAhead).toBe(1);
+		expect(r.commitsAheadBase).toBe("main");
+		expect(calls.map((c) => c[0])).toEqual(["push", "rev-list"]);
+	});
+
+	test("the result round-trips the wire validator with commitsAheadBase intact", async () => {
+		const { git } = fakeGit({ "rev-parse": { stdout: `${SHA}\n` }, "rev-list": { stdout: "2" } });
+		const r = await collectFinalizeResult(repairIntent(), "/ws", { fs: NO_FS, git });
+		const { validateFinalizeResult } = await import("./finalize-wire.ts");
+		expect(validateFinalizeResult(JSON.parse(JSON.stringify(r))).commitsAheadBase).toBe(SHA);
+	});
+});

--- a/src/runtime/k8s/finalize-wire.test.ts
+++ b/src/runtime/k8s/finalize-wire.test.ts
@@ -47,6 +47,15 @@ describe("validateFinalizeResult", () => {
 		expect(validateFinalizeResult(JSON.parse(JSON.stringify(r)))).toEqual(r);
 	});
 
+	test("carries an optional commitsAheadBase and keeps it off the shape when absent (warren-ba08)", () => {
+		expect(validateFinalizeResult(fullResult())).not.toHaveProperty("commitsAheadBase");
+		const withBase = { ...fullResult(), commitsAheadBase: "0123abcd" };
+		expect(validateFinalizeResult(withBase).commitsAheadBase).toBe("0123abcd");
+		expect(() =>
+			validateFinalizeResult({ ...fullResult(), commitsAheadBase: 7 } as unknown),
+		).toThrow(ValidationError);
+	});
+
 	test("accepts commitsAhead: null (the widened shape)", () => {
 		const r = { ...fullResult(), commitsAhead: null };
 		expect(validateFinalizeResult(r).commitsAhead).toBeNull();

--- a/src/runtime/k8s/finalize-wire.ts
+++ b/src/runtime/k8s/finalize-wire.ts
@@ -271,9 +271,12 @@ export function validateFinalizeResult(value: unknown): FinalizeResult {
 	}
 
 	const dirtyPaths = optStringArray(o, "dirtyPaths", "result");
+	// warren-ba08: optional — an older in-pod image omits it (domain falls back to baseBranch).
+	const commitsAheadBase = optStringOrNull(o, "commitsAheadBase", "result");
 	return {
 		pushed: reqBoolean(o, "pushed", "result"),
 		commitsAhead: reqNumberOrNull(o, "commitsAhead", "result"),
+		...(commitsAheadBase !== null ? { commitsAheadBase } : {}),
 		emptyPush: reqBoolean(o, "emptyPush", "result"),
 		dirty: reqBoolean(o, "dirty", "result"),
 		...(dirtyPaths !== undefined ? { dirtyPaths } : {}),

--- a/src/runtime/local/finalize.repair-base.test.ts
+++ b/src/runtime/local/finalize.repair-base.test.ts
@@ -1,0 +1,126 @@
+/**
+ * `LocalProvider.finalize()` on the ref-dispatch REPAIR topology (warren-ba08,
+ * #979 / #994). A repair run pushes back onto the branch it was cut from
+ * (`branch === baseBranch`), so HEAD is attached to the base and
+ * `rev-list --count base..HEAD` is empty by construction — whether the agent
+ * landed 0 commits or 10. finalize must pin the pre-push `origin/<base>` tip
+ * BEFORE the push (which rewrites the tracking ref) and count `<sha>..HEAD`
+ * after it, reporting the SHA as `commitsAheadBase` so the domain's outcome
+ * facts diff the same range.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	FAKE_REV_PARSE_SHA,
+	fakeBurrowClient,
+	fakeExec,
+	fakeFs,
+	makeBurrow,
+} from "../../runs/reap/test-helpers.ts";
+import type { FinalizeIntent, RunHandle } from "../contract.ts";
+
+const WS = "/data/sandbox/ws";
+const HANDLE: RunHandle = {
+	runId: "run_domain0001",
+	sandboxId: "bur_aaaaaaaaaaaa",
+	providerRunId: "run_zzzzzzzzzzzz",
+};
+
+/** A repair-run intent: the push branch IS the base branch; no tracker merges. */
+function repairIntent(overrides: Partial<FinalizeIntent> = {}): FinalizeIntent {
+	return {
+		branch: "fix/pr-head",
+		baseBranch: "fix/pr-head",
+		push: true,
+		artifacts: [],
+		...overrides,
+	};
+}
+
+function finalizeWith(exec: ReturnType<typeof fakeExec>, intent: FinalizeIntent) {
+	const client = fakeBurrowClient(makeBurrow({ workspacePath: WS }));
+	return client.withFinalizeSeams(fakeFs().fs, exec.exec).finalize(HANDLE, intent);
+}
+
+describe("finalize — ref-dispatch repair topology (warren-ba08)", () => {
+	test("pins origin/<base> before the push and counts <sha>..HEAD after it", async () => {
+		const exec = fakeExec({ revListCount: "2" });
+		const result = await finalizeWith(exec, repairIntent());
+		expect(result.pushed).toBe(true);
+		expect(result.commitsAhead).toBe(2);
+		expect(result.emptyPush).toBe(false);
+		expect(result.prBranch).toBe("fix/pr-head");
+		expect(result.commitsAheadBase).toBe(FAKE_REV_PARSE_SHA);
+		expect(exec.calls.map((c) => c.args)).toEqual([
+			["rev-parse", "--verify", "origin/fix/pr-head"],
+			["push", "origin", "HEAD:fix/pr-head"],
+			["rev-list", "--count", `${FAKE_REV_PARSE_SHA}..HEAD`],
+		]);
+		// Every rev-parse / rev-list runs in the workspace.
+		expect(new Set(exec.calls.map((c) => c.cwd))).toEqual(new Set([WS]));
+		// The stage trail keeps its push-then-count order.
+		expect(result.stages).toEqual([
+			{ stage: "branch_push", status: "ok" },
+			{ stage: "commits_ahead", status: "ok" },
+		]);
+	});
+
+	test("a zero-commit repair run still reads as an empty push and probes dirtiness", async () => {
+		const exec = fakeExec({ revListCount: "0", gitStatus: " M src/foo.ts\n" });
+		const result = await finalizeWith(exec, repairIntent());
+		expect(result.commitsAhead).toBe(0);
+		expect(result.emptyPush).toBe(true);
+		expect(result.dirty).toBe(true);
+		expect(result.dirtyPaths).toEqual(["src/foo.ts"]);
+		expect(exec.calls.map((c) => c.args[0])).toEqual(["rev-parse", "push", "rev-list", "status"]);
+	});
+
+	test("an unresolvable tracking ref fails commits_ahead to null — never a structural 0", async () => {
+		const exec = fakeExec({ revParse: "" });
+		const result = await finalizeWith(exec, repairIntent());
+		expect(result.pushed).toBe(true);
+		expect(result.commitsAhead).toBe(null);
+		expect(result.commitsAheadBase).toBeUndefined();
+		expect(result.emptyPush).toBe(false);
+		expect(result.prBranch).toBe(null);
+		expect(result.stages).toEqual([
+			{ stage: "branch_push", status: "ok" },
+			{ stage: "commits_ahead", status: "failed", error: "fatal: Needed a single revision" },
+		]);
+		// No rev-list was attempted against the structurally-empty local range.
+		expect(exec.calls.some((c) => c.args[0] === "rev-list")).toBe(false);
+	});
+
+	test("a failed push skips the count even though the base was pinned", async () => {
+		const exec = fakeExec({ failPush: "remote: rejected" });
+		const result = await finalizeWith(exec, repairIntent());
+		expect(result.pushed).toBe(false);
+		expect(result.commitsAhead).toBe(null);
+		expect(result.commitsAheadBase).toBeUndefined();
+		expect(exec.calls.map((c) => c.args[0])).toEqual(["rev-parse", "push"]);
+		expect(result.stages).toEqual([
+			{ stage: "branch_push", status: "failed", error: "remote: rejected" },
+			{ stage: "commits_ahead", status: "skipped" },
+		]);
+	});
+
+	test("push:false skips the pin entirely", async () => {
+		const exec = fakeExec();
+		await finalizeWith(exec, repairIntent({ push: false }));
+		expect(exec.calls).toHaveLength(0);
+	});
+
+	test("a fresh-branch dispatch never rev-parses — the plain base ref is the count base", async () => {
+		const exec = fakeExec({ revListCount: "1" });
+		const result = await finalizeWith(
+			exec,
+			repairIntent({ branch: "warren/run-1", baseBranch: "main" }),
+		);
+		expect(result.commitsAhead).toBe(1);
+		expect(result.commitsAheadBase).toBe("main");
+		expect(exec.calls.map((c) => c.args)).toEqual([
+			["push", "origin", "HEAD:warren/run-1"],
+			["rev-list", "--count", "main..HEAD"],
+		]);
+	});
+});

--- a/src/runtime/local/finalize.test.ts
+++ b/src/runtime/local/finalize.test.ts
@@ -260,9 +260,22 @@ describe("finalize — stage trail + push reporting", () => {
 		const result = await p.finalize(HANDLE, intent({ artifacts: [], baseBranch: undefined }));
 		expect(result.pushed).toBe(true);
 		expect(result.commitsAhead).toBe(null);
+		expect(result.commitsAheadBase).toBeUndefined();
 		expect(result.stages).toEqual([
 			{ stage: "branch_push", status: "ok" },
 			{ stage: "commits_ahead", status: "skipped" },
+		]);
+	});
+
+	test("fresh-branch dispatch counts baseBranch..HEAD with no rev-parse and reports the base", async () => {
+		const fs = fakeFs(fullSeed());
+		const exec = fakeExec({ revListCount: "3" });
+		const result = await provider({ fs, exec }).finalize(HANDLE, intent({ artifacts: [] }));
+		expect(result.commitsAhead).toBe(3);
+		expect(result.commitsAheadBase).toBe("main");
+		expect(exec.calls.map((c) => c.args)).toEqual([
+			["push", "origin", "HEAD:warren/run-1"],
+			["rev-list", "--count", "main..HEAD"],
 		]);
 	});
 });

--- a/src/runtime/local/finalize.ts
+++ b/src/runtime/local/finalize.ts
@@ -36,7 +36,12 @@ import { mergeMulch } from "../../runs/reap/mulch.ts";
 import { mirrorPlans, mirrorSeeds } from "../../runs/reap/seeds.ts";
 import { stageSeedsForCommit } from "../../runs/reap/stage.ts";
 import type { ReapExec, ReapFs, ReapStep } from "../../runs/reap/types.ts";
-import { defaultExec, defaultFs, workspaceDirtyPaths } from "../../runs/reap/util.ts";
+import {
+	defaultExec,
+	defaultFs,
+	repairBaseTrackingRef,
+	workspaceDirtyPaths,
+} from "../../runs/reap/util.ts";
 import { githubCredentialGitEnv } from "../../workspace/git/credential-env.ts";
 import type {
 	ArtifactDelta,
@@ -164,6 +169,7 @@ export async function finalizeLocalWorkspace(
 	return {
 		pushed: push.pushed,
 		commitsAhead: push.commitsAhead,
+		...(push.commitsAheadBase !== null ? { commitsAheadBase: push.commitsAheadBase } : {}),
 		emptyPush: push.emptyPush,
 		dirty: push.dirty,
 		dirtyPaths: push.dirtyPaths,
@@ -342,9 +348,51 @@ async function finalizeSeedsCommit(
 interface PushOutcome {
 	pushed: boolean;
 	commitsAhead: number | null;
+	/** The ref `commitsAhead` was counted against; null when not measured. */
+	commitsAheadBase: string | null;
 	emptyPush: boolean;
 	dirty: boolean;
 	dirtyPaths: readonly string[];
+}
+
+const NO_PUSH: PushOutcome = {
+	pushed: false,
+	commitsAhead: null,
+	commitsAheadBase: null,
+	emptyPush: false,
+	dirty: false,
+	dirtyPaths: [],
+};
+
+/**
+ * The base ref `commits_ahead` counts from, resolved BEFORE the push: the
+ * intent's `baseBranch` as-is, except on a ref-dispatch repair run where the
+ * pre-push tip of `origin/<baseBranch>` must be pinned to a SHA first (see
+ * `repairBaseTrackingRef`). `null` ⇒ no `baseBranch`, count skipped; an
+ * `error` ⇒ the tracking ref could not be resolved, count fails (never a
+ * structural `0`).
+ */
+type CountBase = { ref: string } | { error: unknown } | null;
+
+async function resolveCountBase(
+	intent: FinalizeIntent,
+	workspacePath: string,
+	exec: ReapExec,
+): Promise<CountBase> {
+	if (intent.baseBranch === undefined || intent.baseBranch === "") return null;
+	const trackingRef = repairBaseTrackingRef(intent.branch, intent.baseBranch);
+	if (trackingRef === null) return { ref: intent.baseBranch };
+	try {
+		const out = await exec.run("git", ["rev-parse", "--verify", trackingRef], {
+			cwd: workspacePath,
+			timeoutMs: 10_000,
+		});
+		const sha = out.stdout.trim();
+		if (sha === "") throw new Error(`git rev-parse ${trackingRef} returned no object`);
+		return { ref: sha };
+	} catch (err) {
+		return { error: err };
+	}
 }
 
 /**
@@ -364,12 +412,11 @@ async function finalizePush(
 	if (!intent.push) {
 		trail.skipped("branch_push");
 		trail.skipped("commits_ahead");
-		return { pushed: false, commitsAhead: null, emptyPush: false, dirty: false, dirtyPaths: [] };
+		return NO_PUSH;
 	}
-	const commitsAhead = await countCommitsAhead(intent, workspacePath, exec, trail);
-	const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(exec, workspacePath) : [];
-	const dirty = dirtyPaths.length > 0;
-
+	// warren-ba08: pin the count base before the push rewrites the
+	// remote-tracking ref on a repair run; the count itself stays post-push.
+	const countBase = await resolveCountBase(intent, workspacePath, exec);
 	const refspec = intent.branch === "" ? "HEAD" : `HEAD:${intent.branch}`;
 	try {
 		// warren-4e1c: the push authenticates with the per-spawn credential the
@@ -381,47 +428,49 @@ async function finalizePush(
 			env: githubCredentialGitEnv(intent.gitToken),
 		});
 		trail.ok("branch_push");
-		return { pushed: true, commitsAhead, emptyPush: commitsAhead === 0, dirty, dirtyPaths };
 	} catch (err) {
 		trail.failed("branch_push", err);
 		await collector.fail("branch_push", err, workspacePath);
+		trail.skipped("commits_ahead");
 		// warren-b68d: `ReapExec.run` rejects with an Error whose message carries
 		// stderr, so the remote's own refusal text is what gets parsed here.
 		const rejection = parsePushRejection(err instanceof Error ? err.message : String(err));
 		if (rejection !== null) {
 			collector.events.push({ kind: PUSH_REJECTED_EVENT, payload: rejection });
 		}
-		return { pushed: false, commitsAhead: null, emptyPush: false, dirty: false, dirtyPaths: [] };
+		return NO_PUSH;
 	}
+	const commitsAhead = await countCommitsAhead(countBase, workspacePath, exec, trail);
+	// warren-72b9/89b0: capture dirty PATHS on a zero-commit push (dropped commit vs no-op).
+	const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(exec, workspacePath) : [];
+	const dirty = dirtyPaths.length > 0;
+	return {
+		pushed: true,
+		commitsAhead,
+		commitsAheadBase:
+			commitsAhead !== null && countBase !== null && "ref" in countBase ? countBase.ref : null,
+		emptyPush: commitsAhead === 0,
+		dirty,
+		dirtyPaths,
+	};
 }
 
 async function countCommitsAhead(
-	intent: FinalizeIntent,
+	countBase: CountBase,
 	workspacePath: string,
 	exec: ReapExec,
 	trail: StageTrail,
 ): Promise<number | null> {
-	if (intent.baseBranch === undefined || intent.baseBranch === "") {
+	if (countBase === null) {
 		trail.skipped("commits_ahead");
 		return null;
 	}
 	try {
-		const baseRef =
-			intent.branch !== "" && intent.branch === intent.baseBranch
-				? `origin/${intent.baseBranch}`
-				: intent.baseBranch;
-		let out = await exec
-			.run("git", ["rev-list", "--count", `${baseRef}..HEAD`], {
-				cwd: workspacePath,
-				timeoutMs: 10_000,
-			})
-			.catch(() => null);
-		if (out === null) {
-			out = await exec.run("git", ["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
-				cwd: workspacePath,
-				timeoutMs: 10_000,
-			});
-		}
+		if ("error" in countBase) throw countBase.error;
+		const out = await exec.run("git", ["rev-list", "--count", `${countBase.ref}..HEAD`], {
+			cwd: workspacePath,
+			timeoutMs: 10_000,
+		});
 		const parsed = Number.parseInt(out.stdout.trim(), 10);
 		trail.ok("commits_ahead");
 		return Number.isFinite(parsed) ? parsed : null;

--- a/src/runtime/local/finalize.ts
+++ b/src/runtime/local/finalize.ts
@@ -366,6 +366,10 @@ async function finalizePush(
 		trail.skipped("commits_ahead");
 		return { pushed: false, commitsAhead: null, emptyPush: false, dirty: false, dirtyPaths: [] };
 	}
+	const commitsAhead = await countCommitsAhead(intent, workspacePath, exec, trail);
+	const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(exec, workspacePath) : [];
+	const dirty = dirtyPaths.length > 0;
+
 	const refspec = intent.branch === "" ? "HEAD" : `HEAD:${intent.branch}`;
 	try {
 		// warren-4e1c: the push authenticates with the per-spawn credential the
@@ -377,10 +381,10 @@ async function finalizePush(
 			env: githubCredentialGitEnv(intent.gitToken),
 		});
 		trail.ok("branch_push");
+		return { pushed: true, commitsAhead, emptyPush: commitsAhead === 0, dirty, dirtyPaths };
 	} catch (err) {
 		trail.failed("branch_push", err);
 		await collector.fail("branch_push", err, workspacePath);
-		trail.skipped("commits_ahead");
 		// warren-b68d: `ReapExec.run` rejects with an Error whose message carries
 		// stderr, so the remote's own refusal text is what gets parsed here.
 		const rejection = parsePushRejection(err instanceof Error ? err.message : String(err));
@@ -389,11 +393,6 @@ async function finalizePush(
 		}
 		return { pushed: false, commitsAhead: null, emptyPush: false, dirty: false, dirtyPaths: [] };
 	}
-	const commitsAhead = await countCommitsAhead(intent, workspacePath, exec, trail);
-	// warren-72b9/89b0: capture dirty PATHS on a zero-commit push (dropped commit vs no-op).
-	const dirtyPaths = commitsAhead === 0 ? await workspaceDirtyPaths(exec, workspacePath) : [];
-	const dirty = dirtyPaths.length > 0;
-	return { pushed: true, commitsAhead, emptyPush: commitsAhead === 0, dirty, dirtyPaths };
 }
 
 async function countCommitsAhead(
@@ -407,10 +406,22 @@ async function countCommitsAhead(
 		return null;
 	}
 	try {
-		const out = await exec.run("git", ["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
-			cwd: workspacePath,
-			timeoutMs: 10_000,
-		});
+		const baseRef =
+			intent.branch !== "" && intent.branch === intent.baseBranch
+				? `origin/${intent.baseBranch}`
+				: intent.baseBranch;
+		let out = await exec
+			.run("git", ["rev-list", "--count", `${baseRef}..HEAD`], {
+				cwd: workspacePath,
+				timeoutMs: 10_000,
+			})
+			.catch(() => null);
+		if (out === null) {
+			out = await exec.run("git", ["rev-list", "--count", `${intent.baseBranch}..HEAD`], {
+				cwd: workspacePath,
+				timeoutMs: 10_000,
+			});
+		}
 		const parsed = Number.parseInt(out.stdout.trim(), 10);
 		trail.ok("commits_ahead");
 		return Number.isFinite(parsed) ? parsed : null;


### PR DESCRIPTION
## What

Supersedes #994 by @rookepoole (carried as the first commit, author preserved); reworks the implementation so the existing stage-trail contract and tests hold, and so the outcome-facts diff measures the same range as the count.

On a ref-dispatch repair run the push branch IS the base branch (`branch === baseBranch`, warren-709e): workspace init checks the target branch out directly and skips the per-run carve, so HEAD is attached to `baseBranch` and `git rev-list --count baseBranch..HEAD` is empty by construction — whether the agent landed 0 commits or 10 (#979 item 2). Since #992 flips zero-commit ref-dispatch runs to `failed`/`no_changes`, every productive repair run was being reaped as `no_changes`.

## How

- `repairBaseTrackingRef` (`src/runs/reap/util.ts`) names the topology: `branch === baseBranch` ⇒ count from `origin/<base>`.
- Both finalize twins (`src/runtime/local/finalize.ts`, `src/runtime/k8s/finalize-collect.ts`) `git rev-parse --verify origin/<base>` **before** `branch_push` (the push rewrites that tracking ref on success), then count `rev-list <sha>..HEAD` **after** the push as today. The `branch_push → commits_ahead` trail order and the "commits_ahead skipped on push failure" semantics are unchanged, so the five stage-order tests #994 broke stay green. A fresh-branch dispatch never rev-parses.
- An unresolvable tracking ref fails `commits_ahead` to `null` rather than falling back to the structurally-empty `base..HEAD` — never a false `0` (#994's fallback would have re-introduced the bug silently).
- `FinalizeResult.commitsAheadBase?: string` — the ref the count ran against; parsed by the K8s wire validator, optional so an older in-pod image degrades to the `baseBranch` fallback. `recordOutcomeFacts` diffs against it, so a productive repair run no longer stamps a `0/0/0` numstat beside `commitsAhead > 0` (#994 diffed `origin/<base>..HEAD` post-push, which is also empty).
- Reverts the stray `\t` → literal-tab rewrite #994 made in `outcome-facts.ts`.

## Tests

- `src/runtime/local/finalize.repair-base.test.ts`, `src/runtime/k8s/finalize-entrypoint.repair-base.test.ts` (new — split out to stay under the 500-line budget): pin-then-count order, zero-commit repair still probes dirtiness, unresolvable ref ⇒ null, failed push skips count, push:false skips pin, fresh-branch control, wire round-trip.
- `finalize-wire.test.ts`: optional `commitsAheadBase`.
- `no-changes.test.ts`: the reap-level productive-repair case now asserts the SHA-based `rev-list` and `numstat` calls and the persisted `commitsAhead`.
- `fakeExec` learns `git rev-parse` (`revParse` option); `util.test.ts` covers the topology helper.

`bun run check:all` → 12/12 on a clean checkout (5577 pass, coverage 91.48% / 93.94%).

Addresses #979 (the load-bearing half; #992 landed the `no_changes` surfacing). Closes #994.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fahc4QbJc9BLN4vZvKRJsJ