### PR TITLE
fix(k8s): keep judge secret template out of kustomize

### DIFF
--- a/deploy/k8s/extensions/judge/kustomization.yaml
+++ b/deploy/k8s/extensions/judge/kustomization.yaml
@@ -5,7 +5,8 @@
 #
 # Deploy with an overlay that pins the real image (see
 # ../../overlays/gke-live-judge, gitignored) after creating the judge
-# Secret imperatively (secrets.yaml documents the keys).
+# Secret imperatively. secrets.yaml documents the required keys but is
+# intentionally not rendered by this kustomization.
 #
 # The image (warren-ext-judge) is built + pushed by CI beside the other
 # warren images, and the release deploy rolls an EXISTING judge Deployment
@@ -15,7 +16,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - secrets.yaml
   - pvc.yaml
   - deployment.yaml
   - service.yaml


### PR DESCRIPTION
## Summary

The judge kustomization currently includes `secrets.yaml` in `resources`, even though that file is explicitly a placeholder template with `REPLACE_ME` values and its header says it must not be applied directly.

This change removes the template Secret from the rendered judge resources and clarifies that `secrets.yaml` is documentation-only. The real `judge-secrets` Secret remains operator-created, matching the existing deployment instructions and preventing `kubectl apply -k` from overwriting live credentials with placeholders.

Fixes #1038.

## Validation

- Audited the resulting diff: one file, `+2/-2`, with only the placeholder Secret resource removed and the deployment comment clarified.
- I did not run `kubectl kustomize` locally in this environment, so I am not claiming that command as executed validation.