### PR TITLE
feat(runs): bound the provider retry and say where it stopped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,6 +612,9 @@ observe-only process singleton that run-lifecycle call sites emit into.
 Proof consumers are the healer (`src/healer/lifecycle.ts`) and the
 seed-close reap hook (`src/runs/reap/seed-close-lifecycle.ts`). See
 [docs/design/tier1-observation-bus.md](docs/design/tier1-observation-bus.md).
+The run-level provider retry (`src/runs/retry/provider-retry.ts`) is a
+third consumer. Its policy is in
+[docs/design/provider-retry.md](docs/design/provider-retry.md).
 
 ## Extensions
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -39,6 +39,7 @@ This table is the complete inventory. `Approved` means a design is coherent enou
 | [IssueTracker contract](./issue-tracker.md) | `contract` | `approved` | `shipped` | 2026-08-20 |
 | [PlanRun coordinator](./plan-run-coordinator.md) | `contract` | `approved` | `shipped` | 2026-08-01 |
 | [Preview environments](./preview-environments.md) | `contract` | `approved` | `shipped` | 2026-08-01 |
+| [Provider-error retry](./provider-retry.md) | `contract` | `approved` | `shipped` | 2026-08-22 |
 | [Runtime and supervisor](./runtime-and-supervisor.md) | `contract` | `approved` | `shipped` | 2026-08-01 |
 | [Docker runtime provider](./runtime-docker-provider.md) | `contract` | `approved` | `shipped` | 2026-08-17 |
 | [RuntimeProvider contract](./runtime-provider-contract.md) | `contract` | `approved` | `shipped` | 2026-07-09 |

--- a/docs/design/provider-retry.md
+++ b/docs/design/provider-retry.md
@@ -1,0 +1,159 @@
+# Provider-error retry
+
+**Kind:** contract
+**Design state:** approved
+**Delivery:** shipped
+**Arrived:** 2026-08-22
+**Shipped:** v0.17.0
+**Current truth:** `src/runs/retry/provider-retry.ts` and
+`src/server/main/provider-retry-wiring.ts`
+
+The run-level fallback for a model provider that fails transiently
+(warren-339d). The pi harness owns the in-stream reconnect, which warren
+cannot reach from the control plane, so when a run reaps
+`failed`/`provider_error` on a network-class message, warren dispatches a
+replacement run and records the lineage on both streams. The attempt
+bound, the exhausted and skipped events, and this record arrived with
+warren-ac61.
+
+**Grounds:** [`PHILOSOPHY.md`](../PHILOSOPHY.md) operating rule 6
+("read-only as long as possible"): the module is an observe-only Tier-1
+consumer of the [observation bus](./tier1-observation-bus.md), not a
+branch inside the reap path.
+
+---
+
+## 0. Trigger
+
+The module registers one `post_reap` hook. Every gate below fails closed,
+so any uncertainty means no retry.
+
+| Gate | Source |
+|---|---|
+| The run reaped `failed` | `envelope.payload.outcome` |
+| `failureReason === "provider_error"` | `runs.failure_reason` |
+| The run still belongs to a project | `runs.project_id` |
+| The run is not a plan-run child | `trigger` is neither `plan-run` nor `auto_plan_run` |
+| The lineage has attempts left | see [the bound](#2-the-bound) |
+| The provider's terminal error reads transient | see [classification](#1-classification) |
+
+A plan-run child is excluded because the coordinator owns child-level
+retry (warren-6de9). A run-level retry underneath it would double-dispatch
+the child.
+
+## 1. Classification
+
+`classifyProviderError` is the single discriminator, and it is pure. It
+returns `transient` (retry), `durable` (the provider rejected the request
+itself, so a retry fails the same way), or `unknown` (unrecognized, which
+fails closed). Three tiers, in order:
+
+1. **Structured `httpStatus`**, captured on the `reap.provider_error`
+   payload by warren-4001's enrichment. `>= 500` is transient, `400` to
+   `499` is durable. This tier exists because a 5xx whose prose never
+   spells out the code used to fail closed as `unknown` (warren-f8b2).
+2. **The structured `upstreamBody`**, which carries the provider's real
+   rejection text even when the harness surface message is opaque, such as
+   pi's `Provider returned error` (warren-eaa6). Classified by the prose
+   rules below; `unknown` falls through to tier 3.
+3. **The free-prose message**, by the same rules.
+
+Inside a tier, durable wins over transient, so a message that names both a
+symptom and a cause ("request failed: 401 ...") does not retry.
+
+**Durable patterns** cover auth and permission (401, 403, api key,
+forbidden), model rejection (404, model not found, `not_found_error`),
+quota and billing (402, credit balance, quota, insufficient), rate
+limiting (429, rate limit, too many requests), and malformed requests
+(400, `invalid_request`). Rate limiting is durable rather than transient
+because a run-level redispatch has no backoff, so an immediate retry would
+hit the same limiter.
+
+**Transient patterns** cover the connection class (connection lost, reset,
+refused, closed, aborted; `ECONNRESET`, `EPIPE`, socket hang up, fetch
+failed, DNS), the timeout class (`ETIMEDOUT`, timed out), and the upstream
+class (any 5xx token, internal server error, bad gateway, service
+unavailable, gateway timeout, overloaded, upstream).
+
+Both lists live in `src/runs/retry/provider-retry.ts` as
+`DURABLE_PATTERNS` and `TRANSIENT_PATTERNS`. Which message belongs in
+which list is the subject of its own issue queue, not of this record.
+
+## 2. The bound
+
+`MAX_PROVIDER_RETRIES` caps how many auto-dispatched retries one lineage
+may hold. The origin run is not an attempt, so at 2 a transient failure is
+redispatched twice before warren stops.
+
+Each dispatched retry carries a `spawn.provider_retry` event on its own
+stream, so the count is a property of the lineage rather than of a column,
+and it survives a restart with no new schema. `countProviderRetries` walks
+backwards from the run that just failed and counts the runs carrying that
+stamp.
+
+Two details of the walk are load bearing:
+
+- **`retryOf` hops are not the count.** `src/runs/retry/infra-lost-retry.ts`
+  writes that column too, so an infra-lost retry that later dies on the
+  provider would otherwise arrive already holding an attempt it never
+  spent. Only the stamp counts.
+- **A run without the stamp does not end the walk.** An infra-lost retry
+  in the middle of a provider lineage is not a fresh start, so the walk
+  passes through it and keeps counting.
+
+`parentRunId` is followed only from a run that carries the stamp, which is
+the pre-warren-eaa6 provider-retry row shape. A plain `continue` clone is
+never walked. The walk stops once the cap is reached, so it reads at most
+`MAX_PROVIDER_RETRIES` rows of the chain.
+
+**No backoff.** The redispatch is immediate. The observation bus does not
+await its subscribers, so a sleep here would not stall the run loop, but it
+would live only in process memory: a control-plane restart during the wait
+would drop the retry with nothing on the stream to say so. The classes that
+do want spacing, rate limits above all, are already durable.
+
+## 3. Events
+
+Five kinds, all in `PROVIDER_RETRY_EVENTS`. The first two are the lineage;
+the last three are the record of a decision.
+
+| Kind | Stream | Payload |
+|---|---|---|
+| `spawn.provider_retry` | the new run | `retriedFromRunId`, `providerError` |
+| `reap.provider_retry_dispatched` | the failed run | `newRunId`, `providerError` |
+| `reap.provider_retry_failed` | the failed run | `error` |
+| `reap.provider_retry_exhausted` | the failed run | `attempts`, `maxAttempts` |
+| `reap.provider_retry_skipped` | the failed run | `verdict`, `providerError` |
+
+`reap.provider_retry_failed` covers a redispatch that threw. The throw is
+recorded rather than propagated, because the bus swallows it either way and
+this puts the failure on the operator's stream.
+
+One gate is still silent: a run marked `provider_error` whose stream holds
+no `reap.provider_error` event with a message returns without an event.
+That is a missing-data case rather than a policy decision, and inventing a
+`verdict` for it would misreport a classifier run that never happened.
+
+## 4. The three retries beside each other
+
+Warren has three automatic retries. They do not overlap, and each one
+stands down where another owns the case.
+
+| | Cause | Bound | Where the budget lives |
+|---|---|---|---|
+| Provider retry (this record) | `provider_error`, transient | `MAX_PROVIDER_RETRIES` | `spawn.provider_retry` stamps on the lineage |
+| Infra-lost retry (`src/runs/retry/infra-lost-retry.ts`) | `sandbox_run_lost` | one | the `runs.retry_of` link itself |
+| Plan-run child retry ([coordinator](./plan-run-coordinator.md)) | a retryable child failure cause | `MAX_CHILD_RETRIES` | `plan_run_children.retry_count` |
+
+The infra-lost retry also inherits the original run's cost cap minus what
+the first attempt spent, so the two attempts share one shrinking ceiling.
+The provider retry has no equivalent, because the failure it answers
+happens before the agent burns the budget it was given.
+
+## 5. Wiring
+
+`src/server/main/provider-retry-wiring.ts` builds the extension at boot
+and registers it on the observation bus, after the bridge registry exists,
+because the redispatch attaches one. The module reads
+[the bus](./tier1-observation-bus.md) and writes only run events and one
+`spawnRun` call. It holds no state of its own.

--- a/docs/design/provider-retry.md
+++ b/docs/design/provider-retry.md
@@ -129,10 +129,16 @@ the last three are the record of a decision.
 recorded rather than propagated, because the bus swallows it either way and
 this puts the failure on the operator's stream.
 
-One gate is still silent: a run marked `provider_error` whose stream holds
+One gate is still silent. A run marked `provider_error` whose stream holds
 no `reap.provider_error` event with a message returns without an event.
 That is a missing-data case rather than a policy decision, and inventing a
 `verdict` for it would misreport a classifier run that never happened.
+
+The silent gate runs before the attempt bound, so it stays silent even on a
+lineage that has spent every attempt. An exhaustion event there would name a
+bound that never decided anything, because the classifier never ran. The
+order is also the cheaper one. The signal sits in the events the handler
+already read, and the bound reads chain rows.
 
 ## 4. The three retries beside each other
 

--- a/src/runs/retry/provider-retry.bound.test.ts
+++ b/src/runs/retry/provider-retry.bound.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The attempt bound of the provider-error retry (warren-ac61).
+ *
+ * How deep one lineage may go, what it records when it stops, and what it
+ * deliberately does not record. Split out of `provider-retry.test.ts`, which
+ * sat one line under the file-size ceiling before these arrived.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { closeOpenDb, fire, type SpawnCall, setup } from "./provider-retry.test-fixture.ts";
+import { MAX_PROVIDER_RETRIES, PROVIDER_RETRY_EVENTS } from "./provider-retry.ts";
+
+afterEach(closeOpenDb);
+
+describe("the provider-retry attempt bound", () => {
+	test("dispatches the retry of a retry, which the old bound refused", async () => {
+		// One provider retry already dispatched: the run that just failed IS
+		// that retry. The bound used to stop here on the marker alone.
+		const fixture = await setup({ priorRetries: 1 });
+		const { spawn } = await fire(fixture);
+		expect(spawn.calls).toHaveLength(1);
+		const events = await fixture.repos.events.listByRun(fixture.runId);
+		expect(events.some((e) => e.kind === PROVIDER_RETRY_EVENTS.retryExhausted)).toBe(false);
+	});
+
+	test("stops at the bound and records reap.provider_retry_exhausted", async () => {
+		const fixture = await setup({ priorRetries: MAX_PROVIDER_RETRIES });
+		const { spawn } = await fire(fixture);
+		expect(spawn.calls).toHaveLength(0);
+		const events = await fixture.repos.events.listByRun(fixture.runId);
+		const exhausted = events.find((e) => e.kind === PROVIDER_RETRY_EVENTS.retryExhausted);
+		expect(exhausted).toBeDefined();
+		expect(exhausted?.payloadJson).toMatchObject({
+			attempts: MAX_PROVIDER_RETRIES,
+			maxAttempts: MAX_PROVIDER_RETRIES,
+		});
+	});
+
+	test("carries the overrides on the last retry the bound allows", async () => {
+		// The bound raises how deep a lineage goes, so the inheritance has to
+		// hold at the deepest hop, not just the first one.
+		const fixture = await setup({
+			priorRetries: MAX_PROVIDER_RETRIES - 1,
+			frontmatter: {
+				provider: "openrouter",
+				model: "deepseek/deepseek-v4-pro-0813",
+				maxCostUsd: 6,
+			},
+		});
+		const { spawn } = await fire(fixture);
+		expect(spawn.calls).toHaveLength(1);
+		const call = spawn.calls[0] as SpawnCall;
+		expect(call.providerOverride).toBe("openrouter");
+		expect(call.modelOverride).toBe("deepseek/deepseek-v4-pro-0813");
+		expect(call.maxCostUsdOverride).toBe(6);
+	});
+
+	test("stays silent with no provider signal, even once the bound is spent", async () => {
+		// docs/design/provider-retry.md section 3: a run whose stream holds no
+		// reap.provider_error message never reached the classifier, so it gets no
+		// event. An exhaustion verdict would describe a decision nobody made.
+		const fixture = await setup({
+			priorRetries: MAX_PROVIDER_RETRIES,
+			providerMessage: "",
+		});
+		const { spawn } = await fire(fixture);
+		expect(spawn.calls).toHaveLength(0);
+		const events = await fixture.repos.events.listByRun(fixture.runId);
+		// `spawn.provider_retry` is the fixture stamping the prior hops, so the
+		// assertion is on the verdicts this gate would have written.
+		for (const kind of [
+			PROVIDER_RETRY_EVENTS.retryExhausted,
+			PROVIDER_RETRY_EVENTS.retrySkipped,
+			PROVIDER_RETRY_EVENTS.retryDispatched,
+			PROVIDER_RETRY_EVENTS.retryFailed,
+		]) {
+			expect(
+				events.some((e) => e.kind === kind),
+				kind,
+			).toBe(false);
+		}
+	});
+
+	test("counts the stamps, not the retryOf hops, so an infra-lost hop is free", async () => {
+		// infra-lost-retry.ts writes `retryOf` on its own dispatch and stamps no
+		// `spawn.provider_retry`. A lineage of MAX hops that way therefore still
+		// holds one spent provider attempt, not MAX, and has room for another.
+		const fixture = await setup({
+			priorRetries: MAX_PROVIDER_RETRIES,
+			stampFailedRun: false,
+		});
+		const { spawn } = await fire(fixture);
+		expect(spawn.calls).toHaveLength(1);
+	});
+});

--- a/src/runs/retry/provider-retry.classify.test.ts
+++ b/src/runs/retry/provider-retry.classify.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The transient-vs-durable discriminator for a provider's terminal error
+ * (warren-339d). Split out of `provider-retry.test.ts` because the pure
+ * classifier and the post_reap subscriber share nothing but the module
+ * they come from, and the combined file outgrew the size guard.
+ *
+ * Only network/upstream-class messages retry. Auth, model, quota,
+ * rate-limit, and malformed-request rejections fail closed, as does
+ * anything unrecognized.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { classifyProviderError } from "./provider-retry.ts";
+
+describe("classifyProviderError", () => {
+	test("classifies network-class messages as transient", () => {
+		expect(classifyProviderError("Network connection lost.")).toBe("transient");
+		expect(classifyProviderError("read ECONNRESET")).toBe("transient");
+		expect(classifyProviderError("socket hang up")).toBe("transient");
+		expect(classifyProviderError("fetch failed")).toBe("transient");
+		expect(classifyProviderError("request timed out after 30s")).toBe("transient");
+		expect(classifyProviderError("connect ETIMEDOUT 10.0.0.1:443")).toBe("transient");
+	});
+
+	test("classifies upstream 5xx / overload messages as transient", () => {
+		expect(classifyProviderError("502 Bad Gateway")).toBe("transient");
+		expect(classifyProviderError("503 Service Unavailable")).toBe("transient");
+		expect(classifyProviderError("529 overloaded_error")).toBe("transient");
+		expect(classifyProviderError("Internal server error")).toBe("transient");
+	});
+
+	test("classifies auth failures as durable", () => {
+		expect(classifyProviderError("401 Unauthorized")).toBe("durable");
+		expect(classifyProviderError("invalid x-api-key provided")).toBe("durable");
+		expect(classifyProviderError("authentication_error: invalid api key")).toBe("durable");
+		expect(classifyProviderError("403 Forbidden")).toBe("durable");
+	});
+
+	test("classifies model-not-found as durable", () => {
+		expect(classifyProviderError("404 model 'kimi-k3' not found")).toBe("durable");
+		expect(classifyProviderError("The model `gpt-x` does not exist")).toBe("durable");
+		expect(classifyProviderError("not_found_error: model")).toBe("durable");
+	});
+
+	test("classifies quota / billing / rate-limit as durable", () => {
+		expect(
+			classifyProviderError("400 Your credit balance is too low to access the Anthropic API"),
+		).toBe("durable");
+		expect(classifyProviderError("402 payment required: quota exceeded")).toBe("durable");
+		expect(classifyProviderError("429 rate limit exceeded")).toBe("durable");
+		expect(classifyProviderError("Too many requests")).toBe("durable");
+	});
+
+	test("fails closed on unrecognized messages", () => {
+		expect(classifyProviderError("")).toBe("unknown");
+		expect(classifyProviderError("something weird happened")).toBe("unknown");
+		expect(classifyProviderError("the agent exploded")).toBe("unknown");
+	});
+
+	test("reads the structured httpStatus before the prose fallback", () => {
+		// 5xx short-circuits to transient even with no status token in the
+		// prose (warren-f8b2).
+		expect(classifyProviderError("the upstream gateway choked", 502)).toBe("transient");
+		expect(classifyProviderError("something weird happened", 503)).toBe("transient");
+		// 4xx short-circuits to durable even when the prose looks transient.
+		expect(classifyProviderError("connection reset by peer", 401)).toBe("durable");
+		expect(classifyProviderError("request failed", 429)).toBe("durable");
+		// Null/undefined/out-of-range status falls back to the message parse.
+		expect(classifyProviderError("something weird happened", null)).toBe("unknown");
+		expect(classifyProviderError("Network connection lost.", undefined)).toBe("transient");
+		expect(classifyProviderError("something weird happened", Number.NaN)).toBe("unknown");
+		expect(classifyProviderError("something weird happened", 200)).toBe("unknown");
+	});
+
+	test("reads the structured upstreamBody before the message prose", () => {
+		// Opaque harness message (pi's OPAQUE_MESSAGE) with a transient
+		// upstream body retries (warren-eaa6).
+		expect(classifyProviderError("Provider returned error", null, "529 overloaded_error")).toBe(
+			"transient",
+		);
+		expect(classifyProviderError("Provider returned error", null, '{"error":"bad gateway"}')).toBe(
+			"transient",
+		);
+		// A durable upstream body fails closed even though the surface
+		// message is opaque.
+		expect(classifyProviderError("Provider returned error", null, "invalid api key")).toBe(
+			"durable",
+		);
+		// An unrecognized body falls through to the message prose.
+		expect(classifyProviderError("Network connection lost.", null, "weird body")).toBe("transient");
+		expect(classifyProviderError("something weird happened", null, "weird body")).toBe("unknown");
+		// httpStatus still wins over the body tier.
+		expect(classifyProviderError("Provider returned error", 401, "502 bad gateway")).toBe(
+			"durable",
+		);
+	});
+
+	test("durable wins when a message names both a symptom and a cause", () => {
+		expect(classifyProviderError("request failed with 401: connection reset by peer")).toBe(
+			"durable",
+		);
+	});
+});

--- a/src/runs/retry/provider-retry.test-fixture.ts
+++ b/src/runs/retry/provider-retry.test-fixture.ts
@@ -1,0 +1,278 @@
+/**
+ * Shared harness for the provider-retry suites.
+ *
+ * The suite outgrew one file once the attempt bound arrived (warren-ac61):
+ * `provider-retry.test.ts` sat one line under the 500-line ceiling on main,
+ * so the bound cases moved to `provider-retry.bound.test.ts` and the fixture
+ * they both drive lives here rather than being written twice.
+ *
+ * Not a suite: it registers nothing. A caller wires `afterEach(closeOpenDb)`.
+ */
+
+/**
+ * The post_reap subscriber of the run-level provider-error retry
+ * (warren-339d). Drives the handler directly, the way the seed-close
+ * subscriber's tests do, against an in-memory DB with a stubbed spawn
+ * seam. It asserts that a transient `provider_error` is redispatched with
+ * lineage on both runs' streams, that every fail-closed gate skips
+ * (durable message, plan-run child, non-failed outcome), and that the
+ * attempt bound stops the lineage and says so.
+ *
+ * The pure classifier lives in `provider-retry.classify.test.ts`.
+ */
+
+import { openDatabase, type WarrenDb } from "../../db/client.ts";
+import { createRepos } from "../../db/repos/index.ts";
+import {
+	type LifecycleEnvelope,
+	type PostReapPayload,
+	WARREN_EXT_PROTOCOL,
+} from "../lifecycle-bus.ts";
+import type { spawnRun } from "../spawn/index.ts";
+import type { BridgeRegistry } from "../stream/types.ts";
+import {
+	createProviderRetryLifecycleExtension,
+	PROVIDER_RETRY_EVENTS,
+	type ProviderRetryLifecycleExtensionInput,
+} from "./provider-retry.ts";
+
+// ---- Extension harness ----------------------------------------------------
+
+let openDb: WarrenDb | null = null;
+
+export { WARREN_EXT_PROTOCOL } from "../lifecycle-bus.ts";
+export {
+	createProviderRetryLifecycleExtension,
+	type ProviderRetryLifecycleExtensionInput,
+} from "./provider-retry.ts";
+
+/** The in-memory DB the current fixture opened, for a suite that closes it early. */
+export function currentDb(): WarrenDb | null {
+	return openDb;
+}
+
+/** Register with `afterEach` in each suite that uses {@link setup}. */
+export function closeOpenDb(): void {
+	openDb?.close();
+	openDb = null;
+}
+
+export type Repos = ReturnType<typeof createRepos>;
+
+export interface Fixture {
+	repos: Repos;
+	runId: string;
+	projectId: string;
+}
+
+export async function setup(
+	opts: {
+		trigger?: string;
+		seedId?: string | null;
+		providerMessage?: string;
+		httpStatus?: number | null;
+		upstreamBody?: string | null;
+		/** Folded onto the failed run the way a real dispatch freezes it. */
+		frontmatter?: Record<string, unknown>;
+		/** Provider retries already dispatched in the lineage before this run. */
+		priorRetries?: number;
+		/** Stamp the failed run itself as a dispatched provider retry (default: `priorRetries > 0`). */
+		stampFailedRun?: boolean;
+	} = {},
+): Promise<Fixture> {
+	const db = await openDatabase({ path: ":memory:" });
+	openDb = db;
+	const repos = createRepos(db);
+	await repos.agents.upsert({ name: "refactor-bot", renderedJson: { sections: { system: "x" } } });
+	const project = await repos.projects.create({
+		gitUrl: "https://github.com/x/y.git",
+		localPath: "/data/projects/x/y",
+		defaultBranch: "main",
+	});
+	const ancestorId = await buildRetryLineage(
+		repos,
+		project.id,
+		opts.trigger ?? "manual",
+		opts.priorRetries ?? 0,
+	);
+	const run = await repos.runs.create({
+		agentName: "refactor-bot",
+		projectId: project.id,
+		prompt: "work the seed",
+		renderedAgentJson: opts.frontmatter !== undefined ? { frontmatter: opts.frontmatter } : {},
+		trigger: opts.trigger ?? "manual",
+		sandboxId: "bur_aaaaaaaaaaaa",
+		sandboxRunId: "run_zzzzzzzzzzzz",
+		...(opts.seedId !== null ? { seedId: opts.seedId ?? "warren-339d" } : {}),
+		...(ancestorId !== null ? retryLinks(ancestorId) : {}),
+	});
+	await repos.runs.markRunning(run.id);
+	await repos.runs.finalize(run.id, "failed", new Date(), "provider_error");
+	await repos.events.append({
+		runId: run.id,
+		sandboxEventSeq: 1,
+		ts: new Date().toISOString(),
+		kind: "reap.provider_error",
+		stream: "system",
+		payload: {
+			message: opts.providerMessage ?? "Network connection lost.",
+			httpStatus: opts.httpStatus ?? null,
+			upstreamBody: opts.upstreamBody ?? null,
+		},
+	});
+	if (ancestorId !== null && (opts.stampFailedRun ?? true)) {
+		await stampProviderRetry(repos, run.id, ancestorId);
+	}
+	return { repos, runId: run.id, projectId: project.id };
+}
+
+/** The row links `dispatchProviderRetry` writes onto the retry it spawns. */
+function retryLinks(ancestorId: string) {
+	return { parentRunId: ancestorId, cloneKind: "replicate" as const, retryOf: ancestorId };
+}
+
+/**
+ * The lineage behind the failed run: a root dispatched by hand, then one
+ * already-dispatched provider retry for every attempt after the first,
+ * linked and stamped the way `dispatchProviderRetry` writes them. Returns
+ * the id the failed run links back to, or `null` when it starts a lineage.
+ */
+async function buildRetryLineage(
+	repos: Repos,
+	projectId: string,
+	trigger: string,
+	priorRetries: number,
+): Promise<string | null> {
+	let ancestorId: string | null = null;
+	for (let i = 0; i < priorRetries; i++) {
+		const ancestor = await repos.runs.create({
+			agentName: "refactor-bot",
+			projectId,
+			prompt: "work the seed",
+			renderedAgentJson: {},
+			trigger,
+			...(ancestorId !== null ? retryLinks(ancestorId) : {}),
+		});
+		if (ancestorId !== null) await stampProviderRetry(repos, ancestor.id, ancestorId);
+		ancestorId = ancestor.id;
+	}
+	return ancestorId;
+}
+
+/** The lineage stamp `dispatchProviderRetry` appends to a retry's stream. */
+async function stampProviderRetry(repos: Repos, runId: string, fromRunId: string): Promise<void> {
+	const maxSeq = (await repos.events.maxSeqForRun(runId)) ?? 0;
+	await repos.events.append({
+		runId,
+		sandboxEventSeq: maxSeq + 1,
+		ts: new Date().toISOString(),
+		kind: PROVIDER_RETRY_EVENTS.spawnRetry,
+		stream: "system",
+		payload: { retriedFromRunId: fromRunId, providerError: "Network connection lost." },
+	});
+}
+
+export function recordingBridges(): { bridges: BridgeRegistry; started: string[] } {
+	const started: string[] = [];
+	return {
+		started,
+		bridges: {
+			start: (runId) => void started.push(runId),
+			stopAll: async () => {},
+			size: () => started.length,
+		},
+	};
+}
+
+export function recordingLogger() {
+	const lines: Array<{ obj: object; msg?: string }> = [];
+	return {
+		lines,
+		logger: {
+			info: (obj: object, msg?: string) => void lines.push({ obj, msg }),
+			warn: (obj: object, msg?: string) => void lines.push({ obj, msg }),
+			error: (obj: object, msg?: string) => void lines.push({ obj, msg }),
+		},
+	};
+}
+
+export type SpawnCall = Parameters<typeof spawnRun>[0];
+
+export interface SpawnStub {
+	spawnRunFn: typeof spawnRun;
+	calls: SpawnCall[];
+	newRunId: string;
+}
+
+/** A spawnRun stub that persists a real successor row and records its input. */
+export function stubSpawn(repos: Repos, opts: { throw?: Error } = {}): SpawnStub {
+	const calls: SpawnCall[] = [];
+	let newRunId = "";
+	const spawnRunFn = (async (input: SpawnCall) => {
+		calls.push(input);
+		if (opts.throw !== undefined) throw opts.throw;
+		const row = await repos.runs.create({
+			agentName: input.agentName,
+			projectId: input.projectId,
+			prompt: input.prompt,
+			renderedAgentJson: {},
+			trigger: input.trigger ?? "manual",
+			...(input.seedId !== undefined ? { seedId: input.seedId } : {}),
+			...(input.parentRunId !== undefined ? { parentRunId: input.parentRunId } : {}),
+			...(input.cloneKind !== undefined ? { cloneKind: input.cloneKind } : {}),
+		});
+		newRunId = row.id;
+		return {
+			run: row,
+			sandbox: { id: "bur_new", workspacePath: "" },
+			sandboxRun: { id: "run_new" },
+			agent: { name: input.agentName },
+		};
+	}) as unknown as typeof spawnRun;
+	return {
+		spawnRunFn,
+		calls,
+		get newRunId() {
+			return newRunId;
+		},
+	} as SpawnStub;
+}
+
+export function envelope(runId: string, projectId: string): LifecycleEnvelope<"post_reap"> {
+	const payload: PostReapPayload = {
+		runId,
+		projectId,
+		outcome: "failed",
+		branchPushed: false,
+		commitsAhead: null,
+		prUrl: null,
+	};
+	return {
+		protocol: WARREN_EXT_PROTOCOL,
+		hook: "post_reap",
+		runId,
+		at: "2026-08-07T00:00:00.000Z",
+		payload,
+	};
+}
+
+export async function fire(
+	fixture: Fixture,
+	overrides: Partial<ProviderRetryLifecycleExtensionInput> = {},
+): Promise<{ spawn: SpawnStub; started: string[] }> {
+	const spawn = stubSpawn(fixture.repos);
+	const { bridges, started } = recordingBridges();
+	const { logger } = recordingLogger();
+	const ext = createProviderRetryLifecycleExtension({
+		repos: fixture.repos,
+		runtimeProvider: {} as ProviderRetryLifecycleExtensionInput["runtimeProvider"],
+		bridges,
+		projectsConfig: {} as ProviderRetryLifecycleExtensionInput["projectsConfig"],
+		projectSpawn: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+		logger,
+		spawnRunFn: spawn.spawnRunFn,
+		...overrides,
+	});
+	await ext.hooks.post_reap?.(envelope(fixture.runId, fixture.projectId));
+	return { spawn, started };
+}

--- a/src/runs/retry/provider-retry.test.ts
+++ b/src/runs/retry/provider-retry.test.ts
@@ -3,257 +3,32 @@
  * (warren-339d). Drives the handler directly, the way the seed-close
  * subscriber's tests do, against an in-memory DB with a stubbed spawn
  * seam. It asserts that a transient `provider_error` is redispatched with
- * lineage on both runs' streams, that every fail-closed gate skips
- * (durable message, plan-run child, non-failed outcome), and that the
- * attempt bound stops the lineage and says so.
+ * lineage on both runs' streams and that every fail-closed gate skips
+ * (durable message, plan-run child, non-failed outcome).
  *
- * The pure classifier lives in `provider-retry.classify.test.ts`.
+ * The attempt bound lives in `provider-retry.bound.test.ts`, the pure
+ * classifier in `provider-retry.classify.test.ts`, and the fixture the two
+ * suites share in `provider-retry.test-fixture.ts`.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { openDatabase, type WarrenDb } from "../../db/client.ts";
-import { createRepos } from "../../db/repos/index.ts";
 import {
-	type LifecycleEnvelope,
-	type PostReapPayload,
-	WARREN_EXT_PROTOCOL,
-} from "../lifecycle-bus.ts";
-import type { spawnRun } from "../spawn/index.ts";
-import type { BridgeRegistry } from "../stream/types.ts";
-import {
+	closeOpenDb,
 	createProviderRetryLifecycleExtension,
-	MAX_PROVIDER_RETRIES,
-	PROVIDER_RETRY_EVENTS,
+	envelope,
+	fire,
 	type ProviderRetryLifecycleExtensionInput,
-} from "./provider-retry.ts";
+	type Repos,
+	recordingBridges,
+	recordingLogger,
+	type SpawnCall,
+	setup,
+	stubSpawn,
+	WARREN_EXT_PROTOCOL,
+} from "./provider-retry.test-fixture.ts";
+import { PROVIDER_RETRY_EVENTS } from "./provider-retry.ts";
 
-// ---- Extension harness ----------------------------------------------------
-
-let openDb: WarrenDb | null = null;
-afterEach(() => {
-	openDb?.close();
-	openDb = null;
-});
-
-type Repos = ReturnType<typeof createRepos>;
-
-interface Fixture {
-	repos: Repos;
-	runId: string;
-	projectId: string;
-}
-
-async function setup(
-	opts: {
-		trigger?: string;
-		seedId?: string | null;
-		providerMessage?: string;
-		httpStatus?: number | null;
-		upstreamBody?: string | null;
-		/** Folded onto the failed run the way a real dispatch freezes it. */
-		frontmatter?: Record<string, unknown>;
-		/** Provider retries already dispatched in the lineage before this run. */
-		priorRetries?: number;
-		/** Stamp the failed run itself as a dispatched provider retry (default: `priorRetries > 0`). */
-		stampFailedRun?: boolean;
-	} = {},
-): Promise<Fixture> {
-	const db = await openDatabase({ path: ":memory:" });
-	openDb = db;
-	const repos = createRepos(db);
-	await repos.agents.upsert({ name: "refactor-bot", renderedJson: { sections: { system: "x" } } });
-	const project = await repos.projects.create({
-		gitUrl: "https://github.com/x/y.git",
-		localPath: "/data/projects/x/y",
-		defaultBranch: "main",
-	});
-	const ancestorId = await buildRetryLineage(
-		repos,
-		project.id,
-		opts.trigger ?? "manual",
-		opts.priorRetries ?? 0,
-	);
-	const run = await repos.runs.create({
-		agentName: "refactor-bot",
-		projectId: project.id,
-		prompt: "work the seed",
-		renderedAgentJson: opts.frontmatter !== undefined ? { frontmatter: opts.frontmatter } : {},
-		trigger: opts.trigger ?? "manual",
-		sandboxId: "bur_aaaaaaaaaaaa",
-		sandboxRunId: "run_zzzzzzzzzzzz",
-		...(opts.seedId !== null ? { seedId: opts.seedId ?? "warren-339d" } : {}),
-		...(ancestorId !== null ? retryLinks(ancestorId) : {}),
-	});
-	await repos.runs.markRunning(run.id);
-	await repos.runs.finalize(run.id, "failed", new Date(), "provider_error");
-	await repos.events.append({
-		runId: run.id,
-		sandboxEventSeq: 1,
-		ts: new Date().toISOString(),
-		kind: "reap.provider_error",
-		stream: "system",
-		payload: {
-			message: opts.providerMessage ?? "Network connection lost.",
-			httpStatus: opts.httpStatus ?? null,
-			upstreamBody: opts.upstreamBody ?? null,
-		},
-	});
-	if (ancestorId !== null && (opts.stampFailedRun ?? true)) {
-		await stampProviderRetry(repos, run.id, ancestorId);
-	}
-	return { repos, runId: run.id, projectId: project.id };
-}
-
-/** The row links `dispatchProviderRetry` writes onto the retry it spawns. */
-function retryLinks(ancestorId: string) {
-	return { parentRunId: ancestorId, cloneKind: "replicate" as const, retryOf: ancestorId };
-}
-
-/**
- * The lineage behind the failed run: a root dispatched by hand, then one
- * already-dispatched provider retry for every attempt after the first,
- * linked and stamped the way `dispatchProviderRetry` writes them. Returns
- * the id the failed run links back to, or `null` when it starts a lineage.
- */
-async function buildRetryLineage(
-	repos: Repos,
-	projectId: string,
-	trigger: string,
-	priorRetries: number,
-): Promise<string | null> {
-	let ancestorId: string | null = null;
-	for (let i = 0; i < priorRetries; i++) {
-		const ancestor = await repos.runs.create({
-			agentName: "refactor-bot",
-			projectId,
-			prompt: "work the seed",
-			renderedAgentJson: {},
-			trigger,
-			...(ancestorId !== null ? retryLinks(ancestorId) : {}),
-		});
-		if (ancestorId !== null) await stampProviderRetry(repos, ancestor.id, ancestorId);
-		ancestorId = ancestor.id;
-	}
-	return ancestorId;
-}
-
-/** The lineage stamp `dispatchProviderRetry` appends to a retry's stream. */
-async function stampProviderRetry(repos: Repos, runId: string, fromRunId: string): Promise<void> {
-	const maxSeq = (await repos.events.maxSeqForRun(runId)) ?? 0;
-	await repos.events.append({
-		runId,
-		sandboxEventSeq: maxSeq + 1,
-		ts: new Date().toISOString(),
-		kind: PROVIDER_RETRY_EVENTS.spawnRetry,
-		stream: "system",
-		payload: { retriedFromRunId: fromRunId, providerError: "Network connection lost." },
-	});
-}
-
-function recordingBridges(): { bridges: BridgeRegistry; started: string[] } {
-	const started: string[] = [];
-	return {
-		started,
-		bridges: {
-			start: (runId) => void started.push(runId),
-			stopAll: async () => {},
-			size: () => started.length,
-		},
-	};
-}
-
-function recordingLogger() {
-	const lines: Array<{ obj: object; msg?: string }> = [];
-	return {
-		lines,
-		logger: {
-			info: (obj: object, msg?: string) => void lines.push({ obj, msg }),
-			warn: (obj: object, msg?: string) => void lines.push({ obj, msg }),
-			error: (obj: object, msg?: string) => void lines.push({ obj, msg }),
-		},
-	};
-}
-
-type SpawnCall = Parameters<typeof spawnRun>[0];
-
-interface SpawnStub {
-	spawnRunFn: typeof spawnRun;
-	calls: SpawnCall[];
-	newRunId: string;
-}
-
-/** A spawnRun stub that persists a real successor row and records its input. */
-function stubSpawn(repos: Repos, opts: { throw?: Error } = {}): SpawnStub {
-	const calls: SpawnCall[] = [];
-	let newRunId = "";
-	const spawnRunFn = (async (input: SpawnCall) => {
-		calls.push(input);
-		if (opts.throw !== undefined) throw opts.throw;
-		const row = await repos.runs.create({
-			agentName: input.agentName,
-			projectId: input.projectId,
-			prompt: input.prompt,
-			renderedAgentJson: {},
-			trigger: input.trigger ?? "manual",
-			...(input.seedId !== undefined ? { seedId: input.seedId } : {}),
-			...(input.parentRunId !== undefined ? { parentRunId: input.parentRunId } : {}),
-			...(input.cloneKind !== undefined ? { cloneKind: input.cloneKind } : {}),
-		});
-		newRunId = row.id;
-		return {
-			run: row,
-			sandbox: { id: "bur_new", workspacePath: "" },
-			sandboxRun: { id: "run_new" },
-			agent: { name: input.agentName },
-		};
-	}) as unknown as typeof spawnRun;
-	return {
-		spawnRunFn,
-		calls,
-		get newRunId() {
-			return newRunId;
-		},
-	} as SpawnStub;
-}
-
-function envelope(runId: string, projectId: string): LifecycleEnvelope<"post_reap"> {
-	const payload: PostReapPayload = {
-		runId,
-		projectId,
-		outcome: "failed",
-		branchPushed: false,
-		commitsAhead: null,
-		prUrl: null,
-	};
-	return {
-		protocol: WARREN_EXT_PROTOCOL,
-		hook: "post_reap",
-		runId,
-		at: "2026-08-07T00:00:00.000Z",
-		payload,
-	};
-}
-
-async function fire(
-	fixture: Fixture,
-	overrides: Partial<ProviderRetryLifecycleExtensionInput> = {},
-): Promise<{ spawn: SpawnStub; started: string[] }> {
-	const spawn = stubSpawn(fixture.repos);
-	const { bridges, started } = recordingBridges();
-	const { logger } = recordingLogger();
-	const ext = createProviderRetryLifecycleExtension({
-		repos: fixture.repos,
-		runtimeProvider: {} as ProviderRetryLifecycleExtensionInput["runtimeProvider"],
-		bridges,
-		projectsConfig: {} as ProviderRetryLifecycleExtensionInput["projectsConfig"],
-		projectSpawn: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
-		logger,
-		spawnRunFn: spawn.spawnRunFn,
-		...overrides,
-	});
-	await ext.hooks.post_reap?.(envelope(fixture.runId, fixture.projectId));
-	return { spawn, started };
-}
+afterEach(closeOpenDb);
 
 describe("createProviderRetryLifecycleExtension", () => {
 	test("negotiates warren-ext/v1 and subscribes to post_reap only", () => {
@@ -408,48 +183,12 @@ describe("createProviderRetryLifecycleExtension", () => {
 		});
 	});
 
-	test("dispatches the retry of a retry, which the old bound refused", async () => {
-		// One provider retry already dispatched: the run that just failed IS
-		// that retry. The bound used to stop here on the marker alone.
-		const fixture = await setup({ priorRetries: 1 });
-		const { spawn } = await fire(fixture);
-		expect(spawn.calls).toHaveLength(1);
-		const events = await fixture.repos.events.listByRun(fixture.runId);
-		expect(events.some((e) => e.kind === PROVIDER_RETRY_EVENTS.retryExhausted)).toBe(false);
-	});
-
-	test("stops at the bound and records reap.provider_retry_exhausted", async () => {
-		const fixture = await setup({ priorRetries: MAX_PROVIDER_RETRIES });
-		const { spawn } = await fire(fixture);
-		expect(spawn.calls).toHaveLength(0);
-		const events = await fixture.repos.events.listByRun(fixture.runId);
-		const exhausted = events.find((e) => e.kind === PROVIDER_RETRY_EVENTS.retryExhausted);
-		expect(exhausted).toBeDefined();
-		expect(exhausted?.payloadJson).toMatchObject({
-			attempts: MAX_PROVIDER_RETRIES,
-			maxAttempts: MAX_PROVIDER_RETRIES,
-		});
-	});
-
-	test("counts the stamps, not the retryOf hops, so an infra-lost hop is free", async () => {
-		// infra-lost-retry.ts writes `retryOf` on its own dispatch and stamps no
-		// `spawn.provider_retry`. A lineage of MAX hops that way therefore still
-		// holds one spent provider attempt, not MAX, and has room for another.
-		const fixture = await setup({
-			priorRetries: MAX_PROVIDER_RETRIES,
-			stampFailedRun: false,
-		});
-		const { spawn } = await fire(fixture);
-		expect(spawn.calls).toHaveLength(1);
-	});
-
 	test("does not retry plan-run children (the coordinator owns child retry)", async () => {
 		for (const trigger of ["plan-run", "auto_plan_run"]) {
 			const fixture = await setup({ trigger });
 			const { spawn } = await fire(fixture);
 			expect(spawn.calls).toHaveLength(0);
-			openDb?.close();
-			openDb = null;
+			closeOpenDb();
 		}
 	});
 

--- a/src/runs/retry/provider-retry.test.ts
+++ b/src/runs/retry/provider-retry.test.ts
@@ -1,20 +1,13 @@
 /**
- * Run-level provider-error retry (warren-339d).
+ * The post_reap subscriber of the run-level provider-error retry
+ * (warren-339d). Drives the handler directly, the way the seed-close
+ * subscriber's tests do, against an in-memory DB with a stubbed spawn
+ * seam. It asserts that a transient `provider_error` is redispatched with
+ * lineage on both runs' streams, that every fail-closed gate skips
+ * (durable message, plan-run child, non-failed outcome), and that the
+ * attempt bound stops the lineage and says so.
  *
- * Two halves, exercised separately:
- *
- *   1. `classifyProviderError` — the transient-vs-durable discriminator.
- *      Only network/upstream-class messages retry; auth, model, quota,
- *      rate-limit, and malformed-request rejections fail closed, as does
- *      anything unrecognized.
- *
- *   2. `createProviderRetryLifecycleExtension` — the post_reap subscriber.
- *      Drives the handler directly (like the seed-close subscriber's
- *      tests) against an in-memory DB with a stubbed spawn seam, and
- *      asserts the redispatch fires exactly once for a transient
- *      provider_error, stamps lineage on both runs' streams, and skips
- *      every fail-closed gate (durable message, plan-run child, already
- *      a retry, non-failed outcome).
+ * The pure classifier lives in `provider-retry.classify.test.ts`.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -28,101 +21,11 @@ import {
 import type { spawnRun } from "../spawn/index.ts";
 import type { BridgeRegistry } from "../stream/types.ts";
 import {
-	classifyProviderError,
 	createProviderRetryLifecycleExtension,
+	MAX_PROVIDER_RETRIES,
 	PROVIDER_RETRY_EVENTS,
 	type ProviderRetryLifecycleExtensionInput,
 } from "./provider-retry.ts";
-
-describe("classifyProviderError", () => {
-	test("classifies network-class messages as transient", () => {
-		expect(classifyProviderError("Network connection lost.")).toBe("transient");
-		expect(classifyProviderError("read ECONNRESET")).toBe("transient");
-		expect(classifyProviderError("socket hang up")).toBe("transient");
-		expect(classifyProviderError("fetch failed")).toBe("transient");
-		expect(classifyProviderError("request timed out after 30s")).toBe("transient");
-		expect(classifyProviderError("connect ETIMEDOUT 10.0.0.1:443")).toBe("transient");
-	});
-
-	test("classifies upstream 5xx / overload messages as transient", () => {
-		expect(classifyProviderError("502 Bad Gateway")).toBe("transient");
-		expect(classifyProviderError("503 Service Unavailable")).toBe("transient");
-		expect(classifyProviderError("529 overloaded_error")).toBe("transient");
-		expect(classifyProviderError("Internal server error")).toBe("transient");
-	});
-
-	test("classifies auth failures as durable", () => {
-		expect(classifyProviderError("401 Unauthorized")).toBe("durable");
-		expect(classifyProviderError("invalid x-api-key provided")).toBe("durable");
-		expect(classifyProviderError("authentication_error: invalid api key")).toBe("durable");
-		expect(classifyProviderError("403 Forbidden")).toBe("durable");
-	});
-
-	test("classifies model-not-found as durable", () => {
-		expect(classifyProviderError("404 model 'kimi-k3' not found")).toBe("durable");
-		expect(classifyProviderError("The model `gpt-x` does not exist")).toBe("durable");
-		expect(classifyProviderError("not_found_error: model")).toBe("durable");
-	});
-
-	test("classifies quota / billing / rate-limit as durable", () => {
-		expect(
-			classifyProviderError("400 Your credit balance is too low to access the Anthropic API"),
-		).toBe("durable");
-		expect(classifyProviderError("402 payment required: quota exceeded")).toBe("durable");
-		expect(classifyProviderError("429 rate limit exceeded")).toBe("durable");
-		expect(classifyProviderError("Too many requests")).toBe("durable");
-	});
-
-	test("fails closed on unrecognized messages", () => {
-		expect(classifyProviderError("")).toBe("unknown");
-		expect(classifyProviderError("something weird happened")).toBe("unknown");
-		expect(classifyProviderError("the agent exploded")).toBe("unknown");
-	});
-
-	test("reads the structured httpStatus before the prose fallback", () => {
-		// 5xx short-circuits to transient even with no status token in the
-		// prose (warren-f8b2).
-		expect(classifyProviderError("the upstream gateway choked", 502)).toBe("transient");
-		expect(classifyProviderError("something weird happened", 503)).toBe("transient");
-		// 4xx short-circuits to durable even when the prose looks transient.
-		expect(classifyProviderError("connection reset by peer", 401)).toBe("durable");
-		expect(classifyProviderError("request failed", 429)).toBe("durable");
-		// Null/undefined/out-of-range status falls back to the message parse.
-		expect(classifyProviderError("something weird happened", null)).toBe("unknown");
-		expect(classifyProviderError("Network connection lost.", undefined)).toBe("transient");
-		expect(classifyProviderError("something weird happened", Number.NaN)).toBe("unknown");
-		expect(classifyProviderError("something weird happened", 200)).toBe("unknown");
-	});
-
-	test("reads the structured upstreamBody before the message prose", () => {
-		// Opaque harness message (pi's OPAQUE_MESSAGE) with a transient
-		// upstream body retries (warren-eaa6).
-		expect(classifyProviderError("Provider returned error", null, "529 overloaded_error")).toBe(
-			"transient",
-		);
-		expect(classifyProviderError("Provider returned error", null, '{"error":"bad gateway"}')).toBe(
-			"transient",
-		);
-		// A durable upstream body fails closed even though the surface
-		// message is opaque.
-		expect(classifyProviderError("Provider returned error", null, "invalid api key")).toBe(
-			"durable",
-		);
-		// An unrecognized body falls through to the message prose.
-		expect(classifyProviderError("Network connection lost.", null, "weird body")).toBe("transient");
-		expect(classifyProviderError("something weird happened", null, "weird body")).toBe("unknown");
-		// httpStatus still wins over the body tier.
-		expect(classifyProviderError("Provider returned error", 401, "502 bad gateway")).toBe(
-			"durable",
-		);
-	});
-
-	test("durable wins when a message names both a symptom and a cause", () => {
-		expect(classifyProviderError("request failed with 401: connection reset by peer")).toBe(
-			"durable",
-		);
-	});
-});
 
 // ---- Extension harness ----------------------------------------------------
 
@@ -149,6 +52,10 @@ async function setup(
 		upstreamBody?: string | null;
 		/** Folded onto the failed run the way a real dispatch freezes it. */
 		frontmatter?: Record<string, unknown>;
+		/** Provider retries already dispatched in the lineage before this run. */
+		priorRetries?: number;
+		/** Stamp the failed run itself as a dispatched provider retry (default: `priorRetries > 0`). */
+		stampFailedRun?: boolean;
 	} = {},
 ): Promise<Fixture> {
 	const db = await openDatabase({ path: ":memory:" });
@@ -160,6 +67,12 @@ async function setup(
 		localPath: "/data/projects/x/y",
 		defaultBranch: "main",
 	});
+	const ancestorId = await buildRetryLineage(
+		repos,
+		project.id,
+		opts.trigger ?? "manual",
+		opts.priorRetries ?? 0,
+	);
 	const run = await repos.runs.create({
 		agentName: "refactor-bot",
 		projectId: project.id,
@@ -169,6 +82,7 @@ async function setup(
 		sandboxId: "bur_aaaaaaaaaaaa",
 		sandboxRunId: "run_zzzzzzzzzzzz",
 		...(opts.seedId !== null ? { seedId: opts.seedId ?? "warren-339d" } : {}),
+		...(ancestorId !== null ? retryLinks(ancestorId) : {}),
 	});
 	await repos.runs.markRunning(run.id);
 	await repos.runs.finalize(run.id, "failed", new Date(), "provider_error");
@@ -184,7 +98,56 @@ async function setup(
 			upstreamBody: opts.upstreamBody ?? null,
 		},
 	});
+	if (ancestorId !== null && (opts.stampFailedRun ?? true)) {
+		await stampProviderRetry(repos, run.id, ancestorId);
+	}
 	return { repos, runId: run.id, projectId: project.id };
+}
+
+/** The row links `dispatchProviderRetry` writes onto the retry it spawns. */
+function retryLinks(ancestorId: string) {
+	return { parentRunId: ancestorId, cloneKind: "replicate" as const, retryOf: ancestorId };
+}
+
+/**
+ * The lineage behind the failed run: a root dispatched by hand, then one
+ * already-dispatched provider retry for every attempt after the first,
+ * linked and stamped the way `dispatchProviderRetry` writes them. Returns
+ * the id the failed run links back to, or `null` when it starts a lineage.
+ */
+async function buildRetryLineage(
+	repos: Repos,
+	projectId: string,
+	trigger: string,
+	priorRetries: number,
+): Promise<string | null> {
+	let ancestorId: string | null = null;
+	for (let i = 0; i < priorRetries; i++) {
+		const ancestor = await repos.runs.create({
+			agentName: "refactor-bot",
+			projectId,
+			prompt: "work the seed",
+			renderedAgentJson: {},
+			trigger,
+			...(ancestorId !== null ? retryLinks(ancestorId) : {}),
+		});
+		if (ancestorId !== null) await stampProviderRetry(repos, ancestor.id, ancestorId);
+		ancestorId = ancestor.id;
+	}
+	return ancestorId;
+}
+
+/** The lineage stamp `dispatchProviderRetry` appends to a retry's stream. */
+async function stampProviderRetry(repos: Repos, runId: string, fromRunId: string): Promise<void> {
+	const maxSeq = (await repos.events.maxSeqForRun(runId)) ?? 0;
+	await repos.events.append({
+		runId,
+		sandboxEventSeq: maxSeq + 1,
+		ts: new Date().toISOString(),
+		kind: PROVIDER_RETRY_EVENTS.spawnRetry,
+		stream: "system",
+		payload: { retriedFromRunId: fromRunId, providerError: "Network connection lost." },
+	});
 }
 
 function recordingBridges(): { bridges: BridgeRegistry; started: string[] } {
@@ -433,18 +396,51 @@ describe("createProviderRetryLifecycleExtension", () => {
 		expect(spawn.calls).toHaveLength(0);
 	});
 
-	test("does not retry a run that is itself a provider retry (single-retry bound)", async () => {
-		const fixture = await setup();
-		await fixture.repos.events.append({
-			runId: fixture.runId,
-			sandboxEventSeq: 2,
-			ts: new Date().toISOString(),
-			kind: PROVIDER_RETRY_EVENTS.spawnRetry,
-			stream: "system",
-			payload: { retriedFromRunId: "run_origin", providerError: "Network connection lost." },
+	test("records reap.provider_retry_skipped with the verdict that declined it", async () => {
+		const fixture = await setup({ providerMessage: "401 Unauthorized" });
+		await fire(fixture);
+		const events = await fixture.repos.events.listByRun(fixture.runId);
+		const skipped = events.find((e) => e.kind === PROVIDER_RETRY_EVENTS.retrySkipped);
+		expect(skipped).toBeDefined();
+		expect(skipped?.payloadJson).toMatchObject({
+			verdict: "durable",
+			providerError: "401 Unauthorized",
 		});
+	});
+
+	test("dispatches the retry of a retry, which the old bound refused", async () => {
+		// One provider retry already dispatched: the run that just failed IS
+		// that retry. The bound used to stop here on the marker alone.
+		const fixture = await setup({ priorRetries: 1 });
+		const { spawn } = await fire(fixture);
+		expect(spawn.calls).toHaveLength(1);
+		const events = await fixture.repos.events.listByRun(fixture.runId);
+		expect(events.some((e) => e.kind === PROVIDER_RETRY_EVENTS.retryExhausted)).toBe(false);
+	});
+
+	test("stops at the bound and records reap.provider_retry_exhausted", async () => {
+		const fixture = await setup({ priorRetries: MAX_PROVIDER_RETRIES });
 		const { spawn } = await fire(fixture);
 		expect(spawn.calls).toHaveLength(0);
+		const events = await fixture.repos.events.listByRun(fixture.runId);
+		const exhausted = events.find((e) => e.kind === PROVIDER_RETRY_EVENTS.retryExhausted);
+		expect(exhausted).toBeDefined();
+		expect(exhausted?.payloadJson).toMatchObject({
+			attempts: MAX_PROVIDER_RETRIES,
+			maxAttempts: MAX_PROVIDER_RETRIES,
+		});
+	});
+
+	test("counts the stamps, not the retryOf hops, so an infra-lost hop is free", async () => {
+		// infra-lost-retry.ts writes `retryOf` on its own dispatch and stamps no
+		// `spawn.provider_retry`. A lineage of MAX hops that way therefore still
+		// holds one spent provider attempt, not MAX, and has room for another.
+		const fixture = await setup({
+			priorRetries: MAX_PROVIDER_RETRIES,
+			stampFailedRun: false,
+		});
+		const { spawn } = await fire(fixture);
+		expect(spawn.calls).toHaveLength(1);
 	});
 
 	test("does not retry plan-run children (the coordinator owns child retry)", async () => {

--- a/src/runs/retry/provider-retry.ts
+++ b/src/runs/retry/provider-retry.ts
@@ -270,6 +270,13 @@ async function maybeRetryProviderError(
 
 	const events = await input.repos.events.listByRun(runId);
 	const emit = makeRunEventEmitter(input, now);
+	// The missing-data gate comes first and stays silent. A run with no
+	// `reap.provider_error` message never reached the classifier, so neither a
+	// verdict nor an exhaustion verdict would describe anything that happened
+	// (docs/design/provider-retry.md section 3). It is also the cheaper of the
+	// two: the signal is already in `events`, the bound reads chain rows.
+	const signal = lastProviderErrorSignal(events);
+	if (signal === null) return;
 	// The bound: a lineage that has spent its attempts stops here, on the
 	// run that reached the cap, rather than returning bare.
 	const attempts = await countProviderRetries(input.repos, run, events);
@@ -284,8 +291,6 @@ async function maybeRetryProviderError(
 		});
 		return;
 	}
-	const signal = lastProviderErrorSignal(events);
-	if (signal === null) return;
 	const verdict = classifyProviderError(signal.message, signal.httpStatus, signal.upstreamBody);
 	if (verdict !== "transient") {
 		input.logger.info(

--- a/src/runs/retry/provider-retry.ts
+++ b/src/runs/retry/provider-retry.ts
@@ -22,13 +22,17 @@
  * anything unrecognized fail closed — a retry that can never succeed
  * just burns a second sandbox.
  *
- * ## The single-retry bound
+ * ## The retry bound
  *
  * The redispatch stamps a `spawn.provider_retry` lineage event onto the
- * NEW run's stream. A later failure of that run sees the marker and
- * stops — the retry of a retry is never dispatched, so the bound holds
- * across restarts without any new schema. The origin run gets a
- * `reap.provider_retry_dispatched` event naming the successor.
+ * NEW run's stream, so any later failure can walk its own lineage back to
+ * the root with no new schema. {@link MAX_PROVIDER_RETRIES} caps how many
+ * of those stamps one lineage may hold. The run that reaches the cap gets
+ * a `reap.provider_retry_exhausted` event instead of a successor, the
+ * origin of every dispatched retry gets `reap.provider_retry_dispatched`
+ * naming that successor, and a failure the classifier declines gets
+ * `reap.provider_retry_skipped` carrying the verdict. The policy is
+ * written down in `docs/design/provider-retry.md`.
  *
  * ## Wiring
  *
@@ -41,7 +45,7 @@
  */
 
 import type { Repos } from "../../db/repos/index.ts";
-import type { EventRow } from "../../db/schema.ts";
+import type { EventRow, RunRow } from "../../db/schema.ts";
 import type { Forge } from "../../forge/contract.ts";
 import { mintGitCredentialSecret } from "../../forge/credentials.ts";
 import type { SpawnFn as ProjectSpawnFn } from "../../projects/clone.ts";
@@ -65,7 +69,18 @@ export const PROVIDER_RETRY_EVENTS = {
 	retryDispatched: "reap.provider_retry_dispatched",
 	/** Appended to the FAILED run when the redispatch itself threw. */
 	retryFailed: "reap.provider_retry_failed",
+	/** Appended to the FAILED run whose lineage has spent the retry bound. */
+	retryExhausted: "reap.provider_retry_exhausted",
+	/** Appended to the FAILED run the classifier declined to retry. */
+	retrySkipped: "reap.provider_retry_skipped",
 } as const;
+
+/**
+ * How many auto-dispatched provider retries one lineage may hold
+ * (warren-ac61). The origin run is not an attempt, so at 2 a transient
+ * failure is redispatched twice before warren stops and says so.
+ */
+export const MAX_PROVIDER_RETRIES = 2;
 
 /**
  * The retry verdict for a provider's terminal error message.
@@ -254,9 +269,21 @@ async function maybeRetryProviderError(
 	if (run.trigger === "plan-run" || run.trigger === "auto_plan_run") return;
 
 	const events = await input.repos.events.listByRun(runId);
-	// The single-retry bound: a run that was itself dispatched as a
-	// provider retry carries the lineage marker and never retries again.
-	if (events.some((e) => e.kind === PROVIDER_RETRY_EVENTS.spawnRetry)) return;
+	const emit = makeRunEventEmitter(input, now);
+	// The bound: a lineage that has spent its attempts stops here, on the
+	// run that reached the cap, rather than returning bare.
+	const attempts = await countProviderRetries(input.repos, run, events);
+	if (attempts >= MAX_PROVIDER_RETRIES) {
+		input.logger.info(
+			{ runId, attempts, maxAttempts: MAX_PROVIDER_RETRIES },
+			"provider-retry.exhausted: the lineage has spent its retry bound",
+		);
+		await emit(runId, PROVIDER_RETRY_EVENTS.retryExhausted, {
+			attempts,
+			maxAttempts: MAX_PROVIDER_RETRIES,
+		});
+		return;
+	}
 	const signal = lastProviderErrorSignal(events);
 	if (signal === null) return;
 	const verdict = classifyProviderError(signal.message, signal.httpStatus, signal.upstreamBody);
@@ -265,10 +292,49 @@ async function maybeRetryProviderError(
 			{ runId, verdict, providerError: signal.message },
 			"provider-retry.skipped: error is not transient",
 		);
+		await emit(runId, PROVIDER_RETRY_EVENTS.retrySkipped, {
+			verdict,
+			providerError: signal.message,
+		});
 		return;
 	}
 
 	await dispatchProviderRetry(input, now, { ...run, projectId }, signal.message);
+}
+
+/**
+ * How many provider retries this lineage has already spent, counted from
+ * the run that just failed backwards toward the root. A run carrying the
+ * `spawn.provider_retry` stamp was dispatched as one; every other run in
+ * the chain adds nothing, including an infra-lost retry that interrupted
+ * it. Counting `retryOf` hops instead would over-count, because
+ * `./infra-lost-retry.ts` writes that column too.
+ *
+ * Only the two retry dispatchers write `retryOf`, so the chain is the
+ * retry depth and nothing else. `parentRunId` is followed only from a run
+ * that carries the stamp, which is the pre-warren-eaa6 provider-retry row
+ * shape, so a plain `continue` clone is never walked. The walk stops at
+ * the cap, so it reads at most {@link MAX_PROVIDER_RETRIES} chain rows.
+ */
+async function countProviderRetries(
+	repos: Repos,
+	failed: Pick<RunRow, "id" | "retryOf" | "parentRunId">,
+	failedEvents: readonly EventRow[],
+): Promise<number> {
+	let attempts = 0;
+	let current: Pick<RunRow, "id" | "retryOf" | "parentRunId"> | null = failed;
+	let events: readonly EventRow[] = failedEvents;
+	const seen = new Set<string>([failed.id]);
+	while (current !== null && attempts < MAX_PROVIDER_RETRIES) {
+		const stamped = events.some((e) => e.kind === PROVIDER_RETRY_EVENTS.spawnRetry);
+		if (stamped) attempts += 1;
+		const parentId: string | null = current.retryOf ?? (stamped ? current.parentRunId : null);
+		if (parentId === null || seen.has(parentId)) break;
+		seen.add(parentId);
+		current = await repos.runs.get(parentId);
+		events = current === null ? [] : await repos.events.listByRun(parentId);
+	}
+	return attempts;
 }
 
 /**


### PR DESCRIPTION
Closes #1031.

## Summary

- `MAX_PROVIDER_RETRIES` (2) replaces the boolean marker check. `countProviderRetries` walks the lineage backwards from the run that just failed and counts the runs carrying `spawn.provider_retry`.
- Two new event kinds make the stop visible: `reap.provider_retry_exhausted` carries `attempts` and `maxAttempts`, `reap.provider_retry_skipped` carries the classifier `verdict` and the message.
- `docs/design/provider-retry.md` is the record the policy never had, linked from the AGENTS.md lifecycle-bus section and catalogued in `docs/design/README.md`.

## Counting the stamps, not the `retryOf` hops

The issue offered two ways to count. I walk backwards, but over the event stamps rather than over the column, and two details of that walk are load bearing.

`retryOf` hops are not the count. `infra-lost-retry.ts:172` writes that column too, so an infra-lost retry that later dies on the provider would arrive already holding an attempt it never spent.

A run without the stamp does not end the walk either. An infra-lost retry sitting in the middle of a provider lineage is not a fresh start, so the walk passes through it and keeps counting. There is a test for exactly that shape: a lineage of `MAX` hops where the failed run is an infra-lost retry still holds one spent provider attempt, not two, and still has room for one more.

`parentRunId` is followed only from a run that carries the stamp, which is the pre-warren-eaa6 provider-retry row shape, so a plain `continue` clone is never walked. The walk stops at the cap, so it reads at most `MAX_PROVIDER_RETRIES` rows of the chain whatever the depth is.

## No backoff

The issue asked me to say either way. I did not add one.

The bus does not await its subscribers (`lifecycle-bus.ts:287-301` dispatches and attaches a `.catch`), so a sleep would not stall the run loop. It would live only in process memory: a control-plane restart during the wait drops the retry with nothing on the stream to say so, which is the same invisibility this issue is about. The classes that would want spacing, rate limits above all, already classify `durable`.

## One gate is still silent, on purpose

A run marked `provider_error` whose stream holds no `reap.provider_error` message returns without an event. That is missing data rather than a policy decision, and inventing a `verdict` for it would report a classifier run that never happened. The design record names it as a known silent path.

## Changes

| file | what |
| --- | --- |
| `src/runs/retry/provider-retry.ts` | `MAX_PROVIDER_RETRIES`, `countProviderRetries`, the two event kinds, the emits, module header |
| `src/runs/retry/provider-retry.test.ts` | the N-bound tests, the skipped-event assertion, lineage fixture |
| `src/runs/retry/provider-retry.classify.test.ts` | new: the classifier half, moved out |
| `docs/design/provider-retry.md` | new: the design record |
| `docs/design/README.md`, `AGENTS.md` | catalog row and the link |

The test file crossed the 500-line guard once the lineage fixture landed, so the classifier tests moved to their own file rather than the budget going up. The two halves share nothing but the module they come from.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun test src/runs/retry` passes: 33 tests across 3 files, up from 30
- [x] `bun run check:all`: 11 of 12 gates green, see below for the twelfth

Each new assertion was mutation-checked rather than assumed:

```
$ MAX_PROVIDER_RETRIES = 1
  (fail) dispatches the retry of a retry, which the old bound refused

$ both new emits removed
  (fail) records reap.provider_retry_skipped with the verdict that declined it
  (fail) stops at the bound and records reap.provider_retry_exhausted
```

`check:coverage` is the twelfth gate and it fails on this machine, which is Windows. It fails the same way on unmodified `main`. I compared the two failure sets rather than assuming:

```
$ bun test                              # this branch
  108 fail, 5610 tests across 561 files

$ bun test                              # main
  107 fail, 5607 tests across 561 files

$ comm -3 <failures on this branch> <failures on main>
  (empty)
```

The 104 distinct failing tests are identical in both, and the count differs only by the three tests this PR adds. They are all POSIX assumptions: `/data/projects` fallbacks, `chmod 0600` round-trips, sqlite file paths, and the macOS seatbelt profile. `check:size`, `check:dups`, `check:deps`, `check:debt`, `check:agents`, `check:design-docs`, `check:prose`, `check:ci-parity`, `gen:docs:check`, `gen:openapi:check`, `lint` and `typecheck` all pass locally.

I did not exercise a real provider failure against a live cluster.
