### PR TITLE
feat(extensions): add the Jira tracker, warren-tracker/v1 over Jira Cloud

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -624,13 +624,16 @@ imports it. `check:layers` enforces both directions, because an import
 either way compiles the extension into core and makes its removal
 breaking.
 
-Two extensions ship today. The flagship is `extensions/audit-log/`
+Three extensions ship today. The flagship is `extensions/audit-log/`
 (plan pl-116e), a collector that tails run events, normalizes them
 into an append-only audit log, and exports it over
 `GET /audit-log.jsonl`. Beside it sits `extensions/judge/`
 (plan pl-17ca), which reads finished runs, judges them against the
 15-class rubric v1, stores verdicts append-only, and exports them
-over `GET /verdicts.jsonl`.
+over `GET /verdicts.jsonl`. `extensions/tracker-jira/` (warren-27d9)
+is the third. It speaks the warren-tracker/v1 protocol against Jira Cloud and holds
+its own Jira credential. Its README carries the friction list for that
+build.
 
 `extensions/audit-log/FRICTION.md` logs every place the extension
 author had to work around a missing warren surface, and that list is

--- a/extensions/tracker-jira/.dockerignore
+++ b/extensions/tracker-jira/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+*.md

--- a/extensions/tracker-jira/.gitignore
+++ b/extensions/tracker-jira/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/extensions/tracker-jira/Dockerfile
+++ b/extensions/tracker-jira/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+# @warren-ext/tracker-jira - warren-tracker/v1 over the Jira Cloud REST
+# API (warren-27d9).
+#
+# This image builds from THIS DIRECTORY ALONE (docs/design/extensions.md §2):
+#   docker build -t warren-ext-tracker-jira .
+#
+# It needs a Jira site, a credential and a query. Nothing is baked in:
+#   docker run --rm -p 8080:8080 \
+#     -e JIRA_BASE_URL=https://acme.atlassian.net \
+#     -e JIRA_EMAIL=bot@acme.example \
+#     -e JIRA_API_TOKEN=... \
+#     -e JIRA_JQL='project = WAR AND labels = warren' \
+#     warren-ext-tracker-jira
+#
+# The Jira credential arrives at runtime and is never written to disk or
+# logged. Pass it as a secret in any orchestrator that has one.
+
+# ---- deps stage: resolve node_modules from the package's OWN lockfile ----
+FROM oven/bun:1.2 AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+# ---- runtime stage ----
+FROM oven/bun:1.2-slim
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json ./
+COPY src ./src
+
+USER bun
+
+ENV TRACKER_PORT=8080
+
+EXPOSE 8080
+
+# /capabilities is answered locally, so the probe reports whether this
+# container is up without spending a Jira call every 30 seconds. It
+# carries TRACKER_BEARER when one is set, or a protected container would
+# answer its own healthcheck with a 401.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+	CMD bun -e "const t=process.env.TRACKER_BEARER;fetch('http://127.0.0.1:'+(process.env.TRACKER_PORT??'8080')+'/capabilities',{headers:t?{authorization:'Bearer '+t}:{}}).then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["bun", "run", "src/index.ts"]

--- a/extensions/tracker-jira/README.md
+++ b/extensions/tracker-jira/README.md
@@ -123,6 +123,7 @@ rather than a transient one, and warren does not retry a 4xx.
 | 401 / 403 | `502 upstream_unauthorized` | **this container's** Jira credential was rejected. Passing 401 through would send an operator to warren's bearer, the wrong secret |
 | 429 | `429 upstream_rate_limited`, `Retry-After` passed through | warren's bridge already backs off on 429 and honors the header |
 | 5xx or unreachable | `502 upstream_error` / `upstream_unreachable` | the tracker answered; the system behind it did not |
+| n/a | `400 invalid_issue_id` | the path segment is not valid percent-encoding, so there is no id to look up |
 
 There are no retries in this container. A second, unsynchronized backoff
 underneath warren's own would only make the wait harder to predict.

--- a/extensions/tracker-jira/README.md
+++ b/extensions/tracker-jira/README.md
@@ -1,0 +1,205 @@
+# @warren-ext/tracker-jira
+
+A **warren-tracker/v1** server backed by the **Jira Cloud REST API**
+(warren-27d9). It runs out of process, holds its own Jira credential, and
+warren stores none of it.
+
+Warren reaches it through the per-project `tracker:` block in
+`.warren/config.yaml`:
+
+```yaml
+tracker:
+  url: http://tracker-jira:8080
+  tokenEnv: WARREN_TRACKER_BEARER   # optional
+```
+
+## Capabilities
+
+```json
+{ "supportsPlans": false, "supportsMetadata": false,
+  "supportsScheduledIssues": false, "isGitNative": false }
+```
+
+Base contract only, which is what Jira maps onto without inventing
+anything.
+
+- **No plans.** Jira has no object warren could walk as a plan. Drive
+  serial execution with `POST /plan-runs` and an explicit ordered
+  `issues: ["WAR-12", "WAR-13"]` list, which the base contract is enough
+  to serve (docs/design/issue-tracker.md §4).
+- **No metadata.** Storing warren's keys would need a Jira custom field
+  per key, and which field is a decision only the site admin can make.
+- **No scheduled issues.** Jira has a due date, but whether a due date
+  means "warren should pick this up then" is a convention, not a fact
+  about the field.
+- **Not git-native.** Jira issues and the repository are separate
+  systems, which is exactly the shape the bridge was built for.
+
+## Configuration
+
+All configuration is environment. Missing or contradictory values fail at
+boot with the variable named, rather than surfacing as an upstream error
+inside a run.
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `JIRA_BASE_URL` | yes | Site root, no trailing slash: `https://acme.atlassian.net` |
+| `JIRA_EMAIL` + `JIRA_API_TOKEN` | yes* | Atlassian account email plus an [API token](https://id.atlassian.com/manage-profile/security/api-tokens) |
+| `JIRA_BEARER` | yes* | An OAuth access token, instead of the pair above |
+| `JIRA_JQL` | yes | The query that decides which issues warren sees at all |
+| `JIRA_DONE_TRANSITION` | no | Transition name used to close. Unset picks the first `done`-category one |
+| `JIRA_BLOCKED_BY_INWARD` | no | Inward link description for a blocker. Default `is blocked by` |
+| `JIRA_SEARCH_PAGE_SIZE` | no | Issues per search page. Default 100 |
+| `JIRA_MAX_SEARCH_PAGES` | no | Pagination backstop. Default 50 |
+| `TRACKER_PORT` | no | Listen port. Default 8080 |
+| `TRACKER_BEARER` | no | The token **warren** must present to this server |
+
+\* Exactly one of the two auth modes. Setting both is refused rather than
+resolved by precedence.
+
+`TRACKER_BEARER` and the Jira credential are unrelated. One is what
+warren shows this container, the other is what this container shows Jira.
+
+## Run it
+
+```bash
+bun install
+JIRA_BASE_URL=https://acme.atlassian.net \
+JIRA_EMAIL=bot@acme.example \
+JIRA_API_TOKEN=... \
+JIRA_JQL='project = WAR AND labels = warren' \
+bun run start
+```
+
+In docker, which builds from this directory alone:
+
+```bash
+docker build -t warren-ext-tracker-jira .
+docker run --rm -p 8080:8080 \
+  -e JIRA_BASE_URL=https://acme.atlassian.net \
+  -e JIRA_EMAIL=bot@acme.example \
+  -e JIRA_API_TOKEN=... \
+  -e JIRA_JQL='project = WAR AND labels = warren' \
+  warren-ext-tracker-jira
+```
+
+## How each operation maps
+
+| warren-tracker/v1 | Jira |
+|---|---|
+| `GET /capabilities` | nothing; answered locally, so a boot probe costs no round trip |
+| `GET /issues/{key}` | `GET /rest/api/3/issue/{key}?fields=summary,description,status,issuelinks` |
+| `GET /issue-statuses` | `GET /rest/api/3/search/jql` over `JIRA_JQL`, every page |
+| `POST /issues/{key}/close` | read the issue, then a workflow transition if it is not already terminal |
+
+`status` on the wire is Jira's raw status name. Warren normalizes to its
+own three-state vocabulary at its bridge, so this server never guesses.
+
+`description` arrives as an Atlassian Document Format tree on v3 and is
+flattened to text. A plain string passes through, which is what v2 and
+some proxies return.
+
+`blockedBy` reads the **inward** side of a link (`is blocked by`), which
+is the blocker. The outward side is the issue this one blocks, and it is
+deliberately not reported.
+
+### Close, and why it reads first
+
+Jira has no close verb, only workflow transitions, and a workflow usually
+offers no transition out of a terminal status. So close reads the issue
+first: if Jira already considers it terminal (`statusCategory.key` is
+`done`), the read is the whole answer and nothing is transitioned.
+Closing twice is 200 both times, which the protocol requires.
+
+If the issue is open and the workflow offers no way to a terminal status,
+the answer is `409 no_close_transition`. That is a configuration answer
+rather than a transient one, and warren does not retry a 4xx.
+
+### Failure mapping
+
+| Jira | This server | Why |
+|---|---|---|
+| 404 | `404 issue_not_found` | the one reserved protocol code |
+| 401 / 403 | `502 upstream_unauthorized` | **this container's** Jira credential was rejected. Passing 401 through would send an operator to warren's bearer, the wrong secret |
+| 429 | `429 upstream_rate_limited`, `Retry-After` passed through | warren's bridge already backs off on 429 and honors the header |
+| 5xx or unreachable | `502 upstream_error` / `upstream_unreachable` | the tracker answered; the system behind it did not |
+
+There are no retries in this container. A second, unsynchronized backoff
+underneath warren's own would only make the wait harder to predict.
+
+## Scope
+
+**Jira Cloud, REST v3.** Jira Server and Data Center are not covered.
+Their search endpoint (`/rest/api/2/search`, offset paginated) and their
+auth (a personal access token as a bearer) both differ, and shipping an
+untested second path would be a guess wearing a feature's clothes. The
+pieces that would need to change are `JiraClient.issueStatuses` and the
+API version in the four paths in `src/jira/client.ts`.
+
+## Tests
+
+```bash
+bun test
+bun run typecheck
+```
+
+The interesting one is the protocol suite, which needs a Jira on the
+other side. `src/fake-jira.ts` is that Jira: a `fetch`-shaped stub of the
+four endpoints this tracker calls, transcribed from Atlassian's
+documented v3 response shapes. `bun run dev-server` serves the real
+handler, the real client and the real mapping over it, so the suite
+judges this package end to end:
+
+```bash
+bun run dev-server --port 8080
+# in another shell
+cd ../tracker-conformance && bun run check http://127.0.0.1:8080
+```
+
+## What is and is not verified
+
+**Verified.** The tracker passes
+`@warren-ext/tracker-conformance` unchanged, in both auth modes:
+
+```
+warren-tracker/v1 conformance: 7 case groups against http://127.0.0.1:8792
+```
+
+followed by the suite's pass line and exit code 0.
+
+**Not verified.** No call has ever reached a real Jira. FakeJira is a
+statement of what this tracker EXPECTS Jira to return, not evidence of
+what it does return. The first live run against a real site is what
+confirms or corrects it, and the places it would show up are narrow: the
+ADF shape of `description`, the `issuelinks` inward description on a site
+whose admin renamed the link type, and the `nextPageToken` pagination of
+`/search/jql`.
+
+## Friction
+
+Four things the protocol left to the server author, in rough order of how
+long each took to decide.
+
+1. **A tracker with no close verb.** The idempotent-close rule is the
+   right rule and it is the one that took the most thought here, because
+   Jira cannot express it directly. A protocol that had modeled close as
+   "set the status to X" would not have been implementable at all. Worth
+   keeping.
+2. **The retry contract is documented from warren's side only.**
+   docs/design/issue-tracker.md §5 says warren retries 429 and 5xx and
+   does not retry other 4xx. A server author has to read that and infer
+   "so a permanent refusal must be a 4xx", which is how
+   `no_close_transition` became a 409. Stating it as a rule for servers
+   would save the inference.
+3. **Nothing says what to do when the server's own upstream rejects
+   it.** The protocol covers the bearer warren presents, and 401 is
+   documented for that. It says nothing about the other credential, and
+   the naive answer, passing the upstream 401 through, points the
+   operator at the wrong secret. This one deserves a line in the
+   protocol.
+4. **`issue_not_found` is the only reserved code**, which is a good
+   minimum, but it leaves every other code as a per-server invention.
+   Two servers will spell the same failure differently. Not urgent while
+   warren maps everything else to one `TrackerError`.
+
+Nothing here required a warren surface that does not exist.

--- a/extensions/tracker-jira/bun.lock
+++ b/extensions/tracker-jira/bun.lock
@@ -1,0 +1,24 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@warren-ext/tracker-jira",
+      "devDependencies": {
+        "@types/bun": "^1.2.0",
+        "typescript": "^5.6.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+  }
+}

--- a/extensions/tracker-jira/package.json
+++ b/extensions/tracker-jira/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "@warren-ext/tracker-jira",
+	"version": "0.0.0",
+	"description": "Warren issue-tracker extension: warren-tracker/v1 over the Jira REST API, out of process (warren-27d9)",
+	"private": true,
+	"type": "module",
+	"main": "src/index.ts",
+	"scripts": {
+		"start": "bun run src/index.ts",
+		"test": "bun test",
+		"typecheck": "tsc --noEmit -p tsconfig.json",
+		"dev-server": "bun run src/dev-server.ts"
+	},
+	"license": "MIT",
+	"engines": {
+		"bun": ">=1.1.0"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.2.0",
+		"typescript": "^5.6.0"
+	}
+}

--- a/extensions/tracker-jira/src/config.test.ts
+++ b/extensions/tracker-jira/src/config.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { ConfigError, jiraAuthHeader, loadConfig } from "./config.ts";
+
+const base = {
+	JIRA_BASE_URL: "https://acme.atlassian.net",
+	JIRA_EMAIL: "bot@acme.example",
+	JIRA_API_TOKEN: "token-123",
+	JIRA_JQL: "project = WAR AND labels = warren",
+};
+
+describe("loadConfig", () => {
+	test("reads the minimum a Jira Cloud site needs", () => {
+		const config = loadConfig(base);
+		expect(config.baseUrl).toBe("https://acme.atlassian.net");
+		expect(config.auth).toEqual({
+			kind: "basic",
+			email: "bot@acme.example",
+			apiToken: "token-123",
+		});
+		expect(config.jql).toBe("project = WAR AND labels = warren");
+		expect(config.port).toBe(8080);
+		expect(config.blockedByInward).toBe("is blocked by");
+		expect(config.bearerToken).toBeUndefined();
+	});
+
+	test("trims the trailing slash off the site url", () => {
+		expect(loadConfig({ ...base, JIRA_BASE_URL: "https://acme.atlassian.net//" }).baseUrl).toBe(
+			"https://acme.atlassian.net",
+		);
+	});
+
+	test("names the variable that is missing", () => {
+		expect(() => loadConfig({ ...base, JIRA_JQL: undefined })).toThrow(/JIRA_JQL is required/);
+		expect(() => loadConfig({ ...base, JIRA_BASE_URL: "  " })).toThrow(/JIRA_BASE_URL is required/);
+	});
+
+	test("refuses a site url that is not http", () => {
+		expect(() => loadConfig({ ...base, JIRA_BASE_URL: "acme.atlassian.net" })).toThrow(ConfigError);
+	});
+
+	test("takes JIRA_BEARER instead of the email and token pair", () => {
+		const config = loadConfig({
+			...base,
+			JIRA_EMAIL: undefined,
+			JIRA_API_TOKEN: undefined,
+			JIRA_BEARER: "oauth-abc",
+		});
+		expect(config.auth).toEqual({ kind: "bearer", token: "oauth-abc" });
+	});
+
+	test("refuses both auth modes at once rather than picking one", () => {
+		expect(() => loadConfig({ ...base, JIRA_BEARER: "oauth-abc" })).toThrow(/not both/);
+	});
+
+	test("refuses half of the basic pair", () => {
+		expect(() => loadConfig({ ...base, JIRA_API_TOKEN: undefined })).toThrow(/JIRA_API_TOKEN/);
+	});
+
+	test("refuses a port that is not a positive whole number", () => {
+		expect(() => loadConfig({ ...base, TRACKER_PORT: "0" })).toThrow(/positive whole number/);
+		expect(() => loadConfig({ ...base, TRACKER_PORT: "http" })).toThrow(/positive whole number/);
+		expect(loadConfig({ ...base, TRACKER_PORT: "9000" }).port).toBe(9000);
+	});
+
+	test("carries the warren-facing bearer separately from the Jira credential", () => {
+		const config = loadConfig({ ...base, TRACKER_BEARER: "warren-side" });
+		expect(config.bearerToken).toBe("warren-side");
+		expect(config.auth).toEqual({
+			kind: "basic",
+			email: "bot@acme.example",
+			apiToken: "token-123",
+		});
+	});
+});
+
+describe("jiraAuthHeader", () => {
+	test("base64-encodes the email and token for basic auth", () => {
+		const header = jiraAuthHeader({ kind: "basic", email: "a@b.c", apiToken: "t" });
+		expect(header).toBe(`Basic ${Buffer.from("a@b.c:t").toString("base64")}`);
+	});
+
+	test("passes a bearer token through", () => {
+		expect(jiraAuthHeader({ kind: "bearer", token: "abc" })).toBe("Bearer abc");
+	});
+});

--- a/extensions/tracker-jira/src/config.ts
+++ b/extensions/tracker-jira/src/config.ts
@@ -1,0 +1,116 @@
+/**
+ * Configuration, read once from the environment at boot.
+ *
+ * The credential posture is the one the protocol asks for
+ * (docs/design/issue-tracker.md §5): this container holds the Jira
+ * credential and warren stores none. `TRACKER_BEARER` is the other
+ * direction, the token warren must present to this server, and it is
+ * unrelated to the Jira one.
+ *
+ * Every miss fails loud at boot and names the variable. A tracker that
+ * starts unconfigured turns into a confusing upstream error three layers
+ * away, inside a run, which is the worst place to read it.
+ */
+
+/** How this container authenticates to Jira. */
+export type JiraAuth =
+	| { readonly kind: "basic"; readonly email: string; readonly apiToken: string }
+	| { readonly kind: "bearer"; readonly token: string };
+
+export interface JiraTrackerConfig {
+	/** Jira Cloud site root, no trailing slash: `https://acme.atlassian.net`. */
+	readonly baseUrl: string;
+	readonly auth: JiraAuth;
+	/** The query that decides which issues warren sees at all. */
+	readonly jql: string;
+	/** Transition name used to close. Unset picks the first `done`-category one. */
+	readonly doneTransition?: string;
+	/** The inward link description Jira uses for a blocking relationship. */
+	readonly blockedByInward: string;
+	readonly port: number;
+	/** The bearer warren must present to THIS server. Unset means no auth. */
+	readonly bearerToken?: string;
+	/** Issues per search page. Jira caps this server-side anyway. */
+	readonly searchPageSize: number;
+	/** Hard stop on search pagination, so a runaway query cannot loop forever. */
+	readonly maxSearchPages: number;
+}
+
+export class ConfigError extends Error {}
+
+function required(env: Readonly<Record<string, string | undefined>>, name: string): string {
+	const value = env[name];
+	if (value === undefined || value.trim() === "") {
+		throw new ConfigError(`${name} is required`);
+	}
+	return value.trim();
+}
+
+function optional(
+	env: Readonly<Record<string, string | undefined>>,
+	name: string,
+): string | undefined {
+	const value = env[name];
+	if (value === undefined || value.trim() === "") return undefined;
+	return value.trim();
+}
+
+function positiveInt(
+	env: Readonly<Record<string, string | undefined>>,
+	name: string,
+	fallback: number,
+): number {
+	const raw = optional(env, name);
+	if (raw === undefined) return fallback;
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value <= 0) {
+		throw new ConfigError(`${name} must be a positive whole number, got "${raw}"`);
+	}
+	return value;
+}
+
+/**
+ * Basic with an Atlassian account email plus an API token is the
+ * documented Jira Cloud path. `JIRA_BEARER` covers a setup that issues an
+ * OAuth access token instead. Configuring both is a mistake worth naming
+ * rather than resolving by precedence.
+ */
+function resolveAuth(env: Readonly<Record<string, string | undefined>>): JiraAuth {
+	const bearer = optional(env, "JIRA_BEARER");
+	const email = optional(env, "JIRA_EMAIL");
+	const apiToken = optional(env, "JIRA_API_TOKEN");
+	if (bearer !== undefined && (email !== undefined || apiToken !== undefined)) {
+		throw new ConfigError("set either JIRA_BEARER or JIRA_EMAIL + JIRA_API_TOKEN, not both");
+	}
+	if (bearer !== undefined) return { kind: "bearer", token: bearer };
+	if (email === undefined || apiToken === undefined) {
+		throw new ConfigError("JIRA_EMAIL and JIRA_API_TOKEN are required (or JIRA_BEARER instead)");
+	}
+	return { kind: "basic", email, apiToken };
+}
+
+export function loadConfig(env: Readonly<Record<string, string | undefined>>): JiraTrackerConfig {
+	const baseUrl = required(env, "JIRA_BASE_URL").replace(/\/+$/, "");
+	if (!/^https?:\/\//.test(baseUrl)) {
+		throw new ConfigError(`JIRA_BASE_URL must be an http(s) URL, got "${baseUrl}"`);
+	}
+	const doneTransition = optional(env, "JIRA_DONE_TRANSITION");
+	const bearerToken = optional(env, "TRACKER_BEARER");
+	return {
+		baseUrl,
+		auth: resolveAuth(env),
+		jql: required(env, "JIRA_JQL"),
+		...(doneTransition !== undefined ? { doneTransition } : {}),
+		blockedByInward: optional(env, "JIRA_BLOCKED_BY_INWARD") ?? "is blocked by",
+		port: positiveInt(env, "TRACKER_PORT", 8080),
+		...(bearerToken !== undefined ? { bearerToken } : {}),
+		searchPageSize: positiveInt(env, "JIRA_SEARCH_PAGE_SIZE", 100),
+		maxSearchPages: positiveInt(env, "JIRA_MAX_SEARCH_PAGES", 50),
+	};
+}
+
+/** The `Authorization` header value this container sends to Jira. */
+export function jiraAuthHeader(auth: JiraAuth): string {
+	if (auth.kind === "bearer") return `Bearer ${auth.token}`;
+	return `Basic ${Buffer.from(`${auth.email}:${auth.apiToken}`).toString("base64")}`;
+}

--- a/extensions/tracker-jira/src/dev-server.ts
+++ b/extensions/tracker-jira/src/dev-server.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+/**
+ * The tracker, served against FakeJira instead of a real site.
+ *
+ * This is how the conformance suite runs without an Atlassian account:
+ *
+ *   bun run dev-server --port 8080
+ *   cd ../tracker-conformance && bun run check http://127.0.0.1:8080
+ *
+ * It is the real handler, the real client and the real mapping. Only the
+ * transport underneath is fake, so what the suite judges is this
+ * package's protocol behavior end to end.
+ */
+
+import { loadConfig } from "./config.ts";
+import { createFakeJira, SAMPLE_ISSUES } from "./fake-jira.ts";
+import { createJiraTrackerHandler } from "./server.ts";
+
+function flag(name: string): string | undefined {
+	const index = process.argv.indexOf(`--${name}`);
+	if (index === -1) return undefined;
+	return process.argv[index + 1];
+}
+
+const config = loadConfig({
+	JIRA_BASE_URL: "https://fake.atlassian.invalid",
+	JIRA_EMAIL: "dev@fake.invalid",
+	JIRA_API_TOKEN: "dev-token",
+	JIRA_JQL: "project = WAR",
+	TRACKER_PORT: flag("port") ?? "8080",
+	...(flag("bearer") !== undefined ? { TRACKER_BEARER: flag("bearer") } : {}),
+});
+
+const jira = createFakeJira({ issues: SAMPLE_ISSUES });
+const server = Bun.serve({
+	port: config.port,
+	hostname: "127.0.0.1",
+	fetch: createJiraTrackerHandler({ config, fetchImpl: jira.fetchImpl }),
+});
+
+console.log(`tracker-jira (fake upstream) listening on ${server.port}`);

--- a/extensions/tracker-jira/src/fake-jira.ts
+++ b/extensions/tracker-jira/src/fake-jira.ts
@@ -1,0 +1,196 @@
+/**
+ * FakeJira: enough of the Jira Cloud REST v3 surface to drive this
+ * tracker, in memory.
+ *
+ * It exists because the useful test of this package is not "does the code
+ * run" but "does the tracker survive the warren-tracker/v1 conformance
+ * suite", and that needs a Jira on the other side. It is a `fetch`-shaped
+ * function, so it drops straight into {@link JiraClient}'s transport seam
+ * with no socket in the way.
+ *
+ * The payload shapes are transcribed from Atlassian's documented v3
+ * responses. That is exactly the assumption this package cannot verify
+ * without a real instance, so treat FakeJira as a statement of what this
+ * tracker EXPECTS Jira to return, and the first live run against a real
+ * site as the thing that confirms or corrects it.
+ */
+
+export interface FakeJiraIssue {
+	key: string;
+	summary?: string;
+	/** ADF node tree, or a plain string. */
+	description?: unknown;
+	status: string;
+	/** Jira's status category key: `new`, `indeterminate` or `done`. */
+	statusCategory: "new" | "indeterminate" | "done";
+	/** Keys of issues that block this one. */
+	blockedBy?: string[];
+}
+
+export interface FakeJiraTransition {
+	id: string;
+	name: string;
+	toStatus: string;
+	toCategory: "new" | "indeterminate" | "done";
+}
+
+export interface FakeJiraOptions {
+	readonly issues: readonly FakeJiraIssue[];
+	/** Transitions offered from any non-terminal status. */
+	readonly transitions?: readonly FakeJiraTransition[];
+	/** Issues per page, so the client's pagination loop is exercised. */
+	readonly pageSize?: number;
+	/** Fail every call with this status, for the error-mapping tests. */
+	readonly failWith?: { readonly status: number; readonly retryAfter?: string };
+}
+
+const DEFAULT_TRANSITIONS: readonly FakeJiraTransition[] = [
+	{ id: "11", name: "In Progress", toStatus: "In Progress", toCategory: "indeterminate" },
+	{ id: "31", name: "Done", toStatus: "Done", toCategory: "done" },
+	// A second terminal transition, so the tests can tell "the configured
+	// name won" apart from "the done category won".
+	{ id: "41", name: "Reject", toStatus: "Rejected", toCategory: "done" },
+];
+
+export interface FakeJira {
+	/** Drop-in for `fetch`, to hand {@link JiraClient}. */
+	readonly fetchImpl: typeof fetch;
+	/** Live view of the issues, so a test can assert what a close did. */
+	readonly issues: Map<string, FakeJiraIssue>;
+	/** Every request as `METHOD path`, in order. */
+	readonly calls: string[];
+}
+
+function json(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json", ...headers },
+	});
+}
+
+function issueBody(issue: FakeJiraIssue): unknown {
+	return {
+		key: issue.key,
+		fields: {
+			summary: issue.summary ?? null,
+			description: issue.description ?? null,
+			status: { name: issue.status, statusCategory: { key: issue.statusCategory } },
+			issuelinks: (issue.blockedBy ?? []).map((key) => ({
+				type: { name: "Blocks", inward: "is blocked by", outward: "blocks" },
+				inwardIssue: { key },
+			})),
+		},
+	};
+}
+
+const ISSUE = /^\/rest\/api\/3\/issue\/([^/]+)$/;
+const TRANSITIONS = /^\/rest\/api\/3\/issue\/([^/]+)\/transitions$/;
+
+export function createFakeJira(options: FakeJiraOptions): FakeJira {
+	const issues = new Map(options.issues.map((i) => [i.key, { ...i }]));
+	const transitions = options.transitions ?? DEFAULT_TRANSITIONS;
+	const pageSize = options.pageSize ?? 100;
+	const calls: string[] = [];
+
+	const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+		const url = new URL(typeof input === "string" ? input : input.toString());
+		const method = init?.method ?? "GET";
+		calls.push(`${method} ${url.pathname}`);
+
+		if (options.failWith !== undefined) {
+			const headers: Record<string, string> =
+				options.failWith.retryAfter === undefined
+					? {}
+					: { "retry-after": options.failWith.retryAfter };
+			return json({ errorMessages: ["fake jira failure"] }, options.failWith.status, headers);
+		}
+
+		const issueMatch = ISSUE.exec(url.pathname);
+		if (method === "GET" && issueMatch !== null) {
+			const issue = issues.get(decodeURIComponent(issueMatch[1] ?? ""));
+			if (issue === undefined) return json({ errorMessages: ["Issue does not exist"] }, 404);
+			return json(issueBody(issue));
+		}
+
+		if (method === "GET" && url.pathname === "/rest/api/3/search/jql") {
+			return searchPage(url);
+		}
+
+		const transitionMatch = TRANSITIONS.exec(url.pathname);
+		if (transitionMatch !== null) {
+			const key = decodeURIComponent(transitionMatch[1] ?? "");
+			const issue = issues.get(key);
+			if (issue === undefined) return json({ errorMessages: ["Issue does not exist"] }, 404);
+			if (method === "GET") {
+				// Jira offers no transitions out of a terminal status in the
+				// default workflow, which is what makes the already-done read
+				// the only honest answer for an idempotent close.
+				const offered = issue.statusCategory === "done" ? [] : transitions;
+				return json({
+					transitions: offered.map((t) => ({
+						id: t.id,
+						name: t.name,
+						to: { name: t.toStatus, statusCategory: { key: t.toCategory } },
+					})),
+				});
+			}
+			const body = (await new Response(init?.body as BodyInit).json()) as {
+				transition?: { id?: string };
+			};
+			const chosen = transitions.find((t) => t.id === body.transition?.id);
+			if (chosen === undefined) return json({ errorMessages: ["Transition is not valid"] }, 400);
+			issue.status = chosen.toStatus;
+			issue.statusCategory = chosen.toCategory;
+			return new Response(null, { status: 204 });
+		}
+
+		return json({ errorMessages: [`no fake route: ${method} ${url.pathname}`] }, 404);
+	}) as unknown as typeof fetch;
+
+	function searchPage(url: URL): Response {
+		const all = [...issues.values()];
+		const start = Number(url.searchParams.get("nextPageToken") ?? "0");
+		const slice = all.slice(start, start + pageSize);
+		const next = start + pageSize;
+		const isLast = next >= all.length;
+		return json({
+			issues: slice.map((i) => ({
+				key: i.key,
+				fields: { status: { name: i.status, statusCategory: { key: i.statusCategory } } },
+			})),
+			isLast,
+			...(isLast ? {} : { nextPageToken: String(next) }),
+		});
+	}
+
+	return { fetchImpl, issues, calls };
+}
+
+/** The fixture the tests and the conformance run share. */
+export const SAMPLE_ISSUES: readonly FakeJiraIssue[] = [
+	{
+		key: "WAR-1",
+		summary: "Redis connection pool leaks under load",
+		description: {
+			type: "doc",
+			version: 1,
+			content: [
+				{
+					type: "paragraph",
+					content: [
+						{ type: "text", text: "Connections are never returned after a timeout." },
+					],
+				},
+				{
+					type: "paragraph",
+					content: [{ type: "text", text: "Reproduced on staging twice." }],
+				},
+			],
+		},
+		status: "To Do",
+		statusCategory: "new",
+		blockedBy: ["WAR-2"],
+	},
+	{ key: "WAR-2", summary: "Upgrade the redis client", status: "In Progress", statusCategory: "indeterminate" },
+	{ key: "WAR-3", summary: "Old migration cleanup", status: "Done", statusCategory: "done" },
+];

--- a/extensions/tracker-jira/src/index.ts
+++ b/extensions/tracker-jira/src/index.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+/**
+ * Entrypoint. Reads the environment, fails loud on a bad one, and serves.
+ *
+ * The Jira credential never leaves this process and is never logged. The
+ * boot line names the site and the query so an operator can see WHICH
+ * Jira and WHICH issues this container speaks for, which is the pair that
+ * goes wrong in practice.
+ */
+
+import { ConfigError, loadConfig } from "./config.ts";
+import { startJiraTracker } from "./server.ts";
+
+async function main(): Promise<void> {
+	let config: ReturnType<typeof loadConfig>;
+	try {
+		config = loadConfig(process.env);
+	} catch (err) {
+		if (err instanceof ConfigError) {
+			console.error(`tracker-jira: ${err.message}`);
+			process.exit(2);
+		}
+		throw err;
+	}
+	const server = await startJiraTracker({ config });
+	console.log(
+		`tracker-jira listening on ${server.port} (site ${config.baseUrl}, auth ${config.auth.kind}, jql ${config.jql})`,
+	);
+}
+
+if (import.meta.main) await main();

--- a/extensions/tracker-jira/src/jira/client.test.ts
+++ b/extensions/tracker-jira/src/jira/client.test.ts
@@ -1,0 +1,199 @@
+/**
+ * The transport, driven directly rather than through the handler.
+ *
+ * The cases here are the ones the server tests cannot reach: what the
+ * request actually carries to Jira, and how the client reads a response
+ * that is not a plain JSON body. This is the layer most likely to be
+ * wrong against a real site, so it is worth pinning on its own.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { loadConfig } from "../config.ts";
+import { JiraApiError, JiraClient } from "./client.ts";
+
+interface RecordedRequest {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	body: string | undefined;
+}
+
+function recordingFetch(responder: (request: RecordedRequest) => Response): {
+	fetchImpl: typeof fetch;
+	requests: RecordedRequest[];
+} {
+	const requests: RecordedRequest[] = [];
+	const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+		const headers: Record<string, string> = {};
+		for (const [key, value] of Object.entries((init?.headers ?? {}) as Record<string, string>)) {
+			headers[key.toLowerCase()] = value;
+		}
+		const record: RecordedRequest = {
+			url: typeof input === "string" ? input : input.toString(),
+			method: init?.method ?? "GET",
+			headers,
+			body: typeof init?.body === "string" ? init.body : undefined,
+		};
+		requests.push(record);
+		return responder(record);
+	}) as unknown as typeof fetch;
+	return { fetchImpl, requests };
+}
+
+const BASE = {
+	JIRA_BASE_URL: "https://acme.atlassian.net",
+	JIRA_EMAIL: "bot@acme.example",
+	JIRA_API_TOKEN: "token-123",
+	JIRA_JQL: "project = WAR",
+};
+
+function json(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("JiraClient request shape", () => {
+	test("sends basic auth built from the email and token", async () => {
+		const { fetchImpl, requests } = recordingFetch(() => json({ key: "WAR-1" }));
+		await new JiraClient(loadConfig(BASE), fetchImpl).getIssue("WAR-1");
+		expect(requests[0]?.headers.authorization).toBe(
+			`Basic ${Buffer.from("bot@acme.example:token-123").toString("base64")}`,
+		);
+	});
+
+	test("sends a bearer when that is how the container is configured", async () => {
+		const { fetchImpl, requests } = recordingFetch(() => json({ key: "WAR-1" }));
+		const config = loadConfig({
+			...BASE,
+			JIRA_EMAIL: undefined,
+			JIRA_API_TOKEN: undefined,
+			JIRA_BEARER: "oauth-abc",
+		});
+		await new JiraClient(config, fetchImpl).getIssue("WAR-1");
+		expect(requests[0]?.headers.authorization).toBe("Bearer oauth-abc");
+	});
+
+	test("asks for only the fields it maps, and escapes the key in the path", async () => {
+		const { fetchImpl, requests } = recordingFetch(() => json({ key: "a/b" }));
+		await new JiraClient(loadConfig(BASE), fetchImpl).getIssue("a/b");
+		expect(requests[0]?.url).toBe(
+			"https://acme.atlassian.net/rest/api/3/issue/a%2Fb?fields=summary,description,status,issuelinks",
+		);
+	});
+
+	test("posts the transition id in the body Jira expects", async () => {
+		const { fetchImpl, requests } = recordingFetch(() => new Response(null, { status: 204 }));
+		await new JiraClient(loadConfig(BASE), fetchImpl).applyTransition("WAR-1", "31");
+		expect(requests[0]?.method).toBe("POST");
+		expect(requests[0]?.headers["content-type"]).toBe("application/json");
+		expect(JSON.parse(requests[0]?.body ?? "{}")).toEqual({ transition: { id: "31" } });
+	});
+});
+
+describe("JiraClient.issueStatuses", () => {
+	test("carries the configured JQL and page size on every page", async () => {
+		let page = 0;
+		const { fetchImpl, requests } = recordingFetch(() => {
+			page += 1;
+			return page === 1
+				? json({ issues: [{ key: "WAR-1", fields: { status: { name: "To Do" } } }], nextPageToken: "t2" })
+				: json({ issues: [{ key: "WAR-2", fields: { status: { name: "Done" } } }], isLast: true });
+		});
+		const statuses = await new JiraClient(loadConfig(BASE), fetchImpl).issueStatuses();
+
+		expect(statuses).toEqual({ "WAR-1": "To Do", "WAR-2": "Done" });
+		expect(requests).toHaveLength(2);
+		for (const request of requests) {
+			const url = new URL(request.url);
+			expect(url.searchParams.get("jql")).toBe("project = WAR");
+			expect(url.searchParams.get("maxResults")).toBe("100");
+		}
+		expect(new URL(requests[0]?.url ?? "").searchParams.get("nextPageToken")).toBeNull();
+		expect(new URL(requests[1]?.url ?? "").searchParams.get("nextPageToken")).toBe("t2");
+	});
+
+	test("stops on isLast even when the page still carries a token", async () => {
+		const { fetchImpl, requests } = recordingFetch(() =>
+			json({ issues: [{ key: "WAR-1", fields: { status: { name: "To Do" } } }], isLast: true, nextPageToken: "t2" }),
+		);
+		await new JiraClient(loadConfig(BASE), fetchImpl).issueStatuses();
+		expect(requests).toHaveLength(1);
+	});
+
+	test("records an empty status for an issue whose workflow reports none", async () => {
+		const { fetchImpl } = recordingFetch(() => json({ issues: [{ key: "WAR-1" }], isLast: true }));
+		expect(await new JiraClient(loadConfig(BASE), fetchImpl).issueStatuses()).toEqual({
+			"WAR-1": "",
+		});
+	});
+
+	test("skips a row Jira returned without a key rather than keying on undefined", async () => {
+		const { fetchImpl } = recordingFetch(() =>
+			json({ issues: [{ fields: { status: { name: "To Do" } } }], isLast: true }),
+		);
+		expect(await new JiraClient(loadConfig(BASE), fetchImpl).issueStatuses()).toEqual({});
+	});
+});
+
+describe("JiraClient failures", () => {
+	test("carries the upstream status onto the error", async () => {
+		const { fetchImpl } = recordingFetch(() => json({ errorMessages: ["nope"] }, 403));
+		const client = new JiraClient(loadConfig(BASE), fetchImpl);
+		await expect(client.getIssue("WAR-1")).rejects.toMatchObject({
+			name: "JiraApiError",
+			status: 403,
+		});
+	});
+
+	test("keeps Retry-After off a rate-limited response", async () => {
+		const { fetchImpl } = recordingFetch(
+			() => new Response("{}", { status: 429, headers: { "retry-after": "12" } }),
+		);
+		const client = new JiraClient(loadConfig(BASE), fetchImpl);
+		const err = await client.getIssue("WAR-1").catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(JiraApiError);
+		expect((err as JiraApiError).retryAfter).toBe("12");
+	});
+
+	test("reads an unreachable Jira as status 0, which is not an HTTP answer", async () => {
+		const fetchImpl = (async () => {
+			throw new TypeError("Unable to connect");
+		}) as unknown as typeof fetch;
+		const err = await new JiraClient(loadConfig(BASE), fetchImpl)
+			.getIssue("WAR-1")
+			.catch((e: unknown) => e);
+		expect((err as JiraApiError).status).toBe(0);
+		expect((err as JiraApiError).message).toMatch(/jira unreachable/);
+	});
+
+	test("treats a 204 as no body rather than failing to parse one", async () => {
+		const { fetchImpl } = recordingFetch(() => new Response(null, { status: 204 }));
+		await expect(
+			new JiraClient(loadConfig(BASE), fetchImpl).applyTransition("WAR-1", "31"),
+		).resolves.toBeUndefined();
+	});
+
+	test("reads an empty 200 body as an upstream problem, not as an issue", async () => {
+		// A proxy in front of Jira can answer 200 with nothing. Letting that
+		// reach the mapping as undefined would surface as an internal error.
+		const { fetchImpl } = recordingFetch(() => new Response("   ", { status: 200 }));
+		const err = await new JiraClient(loadConfig(BASE), fetchImpl)
+			.getIssue("WAR-1")
+			.catch((e: unknown) => e);
+		expect((err as JiraApiError).status).toBe(502);
+		expect((err as JiraApiError).message).toMatch(/no object/);
+	});
+
+	test("says so when a 200 body is not JSON at all", async () => {
+		const { fetchImpl } = recordingFetch(
+			() => new Response("<html>proxy error</html>", { status: 200 }),
+		);
+		const err = await new JiraClient(loadConfig(BASE), fetchImpl)
+			.getIssue("WAR-1")
+			.catch((e: unknown) => e);
+		expect((err as JiraApiError).status).toBe(502);
+		expect((err as JiraApiError).message).toMatch(/not JSON/);
+	});
+});

--- a/extensions/tracker-jira/src/jira/client.ts
+++ b/extensions/tracker-jira/src/jira/client.ts
@@ -42,7 +42,7 @@ export class JiraClient {
 
 	async getIssue(key: string): Promise<JiraIssue> {
 		const path = `/rest/api/3/issue/${encodeURIComponent(key)}?fields=${ISSUE_FIELDS}`;
-		return (await this.request("GET", path)) as JiraIssue;
+		return requireObject(await this.request("GET", path), `GET ${path}`) as JiraIssue;
 	}
 
 	/**
@@ -63,7 +63,8 @@ export class JiraClient {
 				maxResults: String(this.config.searchPageSize),
 			});
 			if (token !== undefined) query.set("nextPageToken", token);
-			const body = (await this.request("GET", `/rest/api/3/search/jql?${query}`)) as JiraSearchPage;
+			const path = `/rest/api/3/search/jql?${query}`;
+			const body = requireObject(await this.request("GET", path), `GET ${path}`) as JiraSearchPage;
 			for (const issue of body.issues ?? []) {
 				if (typeof issue.key === "string" && issue.key.length > 0) {
 					statuses[issue.key] = issue.fields?.status?.name ?? "";
@@ -80,7 +81,7 @@ export class JiraClient {
 
 	async transitions(key: string): Promise<JiraTransitionsResponse> {
 		const path = `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`;
-		return (await this.request("GET", path)) as JiraTransitionsResponse;
+		return requireObject(await this.request("GET", path), `GET ${path}`) as JiraTransitionsResponse;
 	}
 
 	async applyTransition(key: string, transitionId: string): Promise<void> {
@@ -123,6 +124,19 @@ export class JiraClient {
 			throw new JiraApiError(`jira ${method} ${path} returned a body that is not JSON`, 502);
 		}
 	}
+}
+
+/**
+ * A 2xx that carried no object. `applyTransition` expects exactly that and
+ * does not come through here, but a read does: a proxy answering 200 with
+ * an empty body would otherwise reach the mapping as `undefined` and
+ * surface as an internal error rather than as the upstream problem it is.
+ */
+function requireObject(body: unknown, what: string): object {
+	if (body === null || typeof body !== "object") {
+		throw new JiraApiError(`jira ${what} answered 2xx with no object`, 502);
+	}
+	return body;
 }
 
 /**

--- a/extensions/tracker-jira/src/jira/client.ts
+++ b/extensions/tracker-jira/src/jira/client.ts
@@ -1,0 +1,141 @@
+/**
+ * The Jira Cloud REST v3 client.
+ *
+ * Every call goes through {@link JiraClient.request}, so the credential
+ * is attached in one place and an upstream failure becomes one error type
+ * carrying the status. `fetchImpl` is the seam the tests drive with
+ * recorded Jira payloads.
+ *
+ * No retries live here. Warren's bridge already retries 429 and 5xx with
+ * backoff that honors `Retry-After` (docs/design/issue-tracker.md §5), so
+ * this server passes the upstream's answer up rather than growing a
+ * second, unsynchronized backoff underneath the first.
+ */
+
+import { jiraAuthHeader, type JiraTrackerConfig } from "../config.ts";
+import type { JiraIssue, JiraSearchPage, JiraTransitionsResponse } from "./types.ts";
+
+/** A non-2xx or unreachable Jira. `status` is 0 when the call never landed. */
+export class JiraApiError extends Error {
+	readonly status: number;
+	readonly retryAfter: string | null;
+
+	constructor(message: string, status: number, retryAfter: string | null = null) {
+		super(message);
+		this.name = "JiraApiError";
+		this.status = status;
+		this.retryAfter = retryAfter;
+	}
+}
+
+/** The issue fields this tracker reads. Anything else is Jira's business. */
+const ISSUE_FIELDS = "summary,description,status,issuelinks";
+
+export class JiraClient {
+	private readonly config: JiraTrackerConfig;
+	private readonly fetchImpl: typeof fetch;
+
+	constructor(config: JiraTrackerConfig, fetchImpl: typeof fetch = fetch) {
+		this.config = config;
+		this.fetchImpl = fetchImpl;
+	}
+
+	async getIssue(key: string): Promise<JiraIssue> {
+		const path = `/rest/api/3/issue/${encodeURIComponent(key)}?fields=${ISSUE_FIELDS}`;
+		return (await this.request("GET", path)) as JiraIssue;
+	}
+
+	/**
+	 * The raw `key -> status name` map for every issue the configured JQL
+	 * selects, walked page by page. Jira Cloud's enhanced search paginates
+	 * on an opaque `nextPageToken` rather than an offset, and stops when it
+	 * stops returning one. `maxSearchPages` is the backstop against a query
+	 * that never stops, and it throws rather than truncating: a silently
+	 * short status map would read to warren as issues that vanished.
+	 */
+	async issueStatuses(): Promise<Record<string, string>> {
+		const statuses: Record<string, string> = {};
+		let token: string | undefined;
+		for (let page = 0; page < this.config.maxSearchPages; page++) {
+			const query = new URLSearchParams({
+				jql: this.config.jql,
+				fields: "status",
+				maxResults: String(this.config.searchPageSize),
+			});
+			if (token !== undefined) query.set("nextPageToken", token);
+			const body = (await this.request("GET", `/rest/api/3/search/jql?${query}`)) as JiraSearchPage;
+			for (const issue of body.issues ?? []) {
+				if (typeof issue.key === "string" && issue.key.length > 0) {
+					statuses[issue.key] = issue.fields?.status?.name ?? "";
+				}
+			}
+			token = body.isLast === true ? undefined : body.nextPageToken;
+			if (token === undefined || token === "") return statuses;
+		}
+		throw new JiraApiError(
+			`the configured JQL returned more than ${this.config.maxSearchPages} pages; narrow it or raise JIRA_MAX_SEARCH_PAGES`,
+			0,
+		);
+	}
+
+	async transitions(key: string): Promise<JiraTransitionsResponse> {
+		const path = `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`;
+		return (await this.request("GET", path)) as JiraTransitionsResponse;
+	}
+
+	async applyTransition(key: string, transitionId: string): Promise<void> {
+		const path = `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`;
+		await this.request("POST", path, { transition: { id: transitionId } });
+	}
+
+	private async request(method: string, path: string, body?: unknown): Promise<unknown> {
+		const headers: Record<string, string> = {
+			accept: "application/json",
+			authorization: jiraAuthHeader(this.config.auth),
+		};
+		if (body !== undefined) headers["content-type"] = "application/json";
+		let response: Response;
+		try {
+			response = await this.fetchImpl(`${this.config.baseUrl}${path}`, {
+				method,
+				headers,
+				...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+			});
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+			throw new JiraApiError(`jira unreachable: ${reason}`, 0);
+		}
+		if (!response.ok) {
+			throw new JiraApiError(
+				`jira ${method} ${path} failed: ${response.status} ${await errorText(response)}`,
+				response.status,
+				response.headers.get("retry-after"),
+			);
+		}
+		// A transition returns 204 with no body, and so may a proxy on a
+		// path that normally carries one.
+		if (response.status === 204) return undefined;
+		const text = await response.text();
+		if (text.trim() === "") return undefined;
+		try {
+			return JSON.parse(text) as unknown;
+		} catch {
+			throw new JiraApiError(`jira ${method} ${path} returned a body that is not JSON`, 502);
+		}
+	}
+}
+
+/**
+ * Jira's error bodies come in several shapes (`errorMessages`, `errors`,
+ * an HTML page from a proxy), so the text is only ever a diagnostic
+ * string. It is bounded because it lands in this server's logs and in the
+ * message warren surfaces.
+ */
+async function errorText(response: Response): Promise<string> {
+	try {
+		const text = await response.text();
+		return text.slice(0, 300);
+	} catch {
+		return "<unreadable body>";
+	}
+}

--- a/extensions/tracker-jira/src/jira/map.test.ts
+++ b/extensions/tracker-jira/src/jira/map.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import { blockedByKeys, flattenAdf, isDone, pickCloseTransition, toIssueResponse } from "./map.ts";
+
+describe("flattenAdf", () => {
+	test("joins paragraphs of an ADF tree into readable text", () => {
+		expect(
+			flattenAdf({
+				type: "doc",
+				version: 1,
+				content: [
+					{ type: "paragraph", content: [{ type: "text", text: "first" }] },
+					{ type: "paragraph", content: [{ type: "text", text: "second" }] },
+				],
+			}),
+		).toBe("first\n\nsecond");
+	});
+
+	test("keeps the text of a node type it does not know", () => {
+		expect(
+			flattenAdf({
+				type: "doc",
+				content: [
+					{
+						type: "paragraph",
+						content: [
+							{ type: "text", text: "see " },
+							{ type: "inlineCard", content: [{ type: "text", text: "WAR-9" }] },
+						],
+					},
+				],
+			}),
+		).toBe("see WAR-9");
+	});
+
+	test("reads a hard break as a newline", () => {
+		expect(
+			flattenAdf({
+				type: "paragraph",
+				content: [{ type: "text", text: "a" }, { type: "hardBreak" }, { type: "text", text: "b" }],
+			}),
+		).toBe("a\nb");
+	});
+
+	test("passes a plain string through, which is what v2 returns", () => {
+		expect(flattenAdf("just text")).toBe("just text");
+	});
+
+	test("returns undefined for an empty or absent description", () => {
+		expect(flattenAdf(null)).toBeUndefined();
+		expect(flattenAdf(undefined)).toBeUndefined();
+		expect(flattenAdf("")).toBeUndefined();
+		expect(flattenAdf({ type: "doc", content: [] })).toBeUndefined();
+	});
+});
+
+describe("blockedByKeys", () => {
+	const links = [
+		{
+			type: { name: "Blocks", inward: "is blocked by", outward: "blocks" },
+			inwardIssue: { key: "WAR-2" },
+		},
+		{
+			type: { name: "Blocks", inward: "is blocked by", outward: "blocks" },
+			outwardIssue: { key: "WAR-7" },
+		},
+		{
+			type: { name: "Relates", inward: "relates to", outward: "relates to" },
+			inwardIssue: { key: "WAR-8" },
+		},
+	];
+
+	test("takes the inward side, which is the blocker", () => {
+		expect(blockedByKeys(links, "is blocked by")).toEqual(["WAR-2"]);
+	});
+
+	test("ignores the outward side, which is the issue this one blocks", () => {
+		expect(blockedByKeys(links, "is blocked by")).not.toContain("WAR-7");
+	});
+
+	test("matches the description regardless of case and padding", () => {
+		expect(blockedByKeys(links, "  Is Blocked By ")).toEqual(["WAR-2"]);
+	});
+
+	test("honours a renamed link type", () => {
+		expect(blockedByKeys(links, "relates to")).toEqual(["WAR-8"]);
+	});
+
+	test("returns an empty list when the issue carries no links", () => {
+		expect(blockedByKeys(undefined, "is blocked by")).toEqual([]);
+	});
+});
+
+describe("toIssueResponse", () => {
+	test("carries the raw Jira status name, not a normalized one", () => {
+		const response = toIssueResponse(
+			{
+				key: "WAR-1",
+				fields: { status: { name: "In Progress", statusCategory: { key: "indeterminate" } } },
+			},
+			"WAR-1",
+			"is blocked by",
+		);
+		expect(response.status).toBe("In Progress");
+	});
+
+	test("leaves out the optional fields Jira did not fill", () => {
+		const response = toIssueResponse({ key: "WAR-1", fields: {} }, "WAR-1", "is blocked by");
+		expect(response).toEqual({ id: "WAR-1", status: "" });
+	});
+
+	test("falls back to the requested key when the payload carries none", () => {
+		expect(toIssueResponse({}, "WAR-4", "is blocked by").id).toBe("WAR-4");
+	});
+});
+
+describe("isDone", () => {
+	test("reads the status category, not the status name", () => {
+		expect(
+			isDone({ fields: { status: { name: "Shipped", statusCategory: { key: "done" } } } }),
+		).toBe(true);
+		expect(
+			isDone({ fields: { status: { name: "Done-ish", statusCategory: { key: "new" } } } }),
+		).toBe(false);
+		expect(isDone({ fields: { status: { name: "Done" } } })).toBe(false);
+	});
+});
+
+describe("pickCloseTransition", () => {
+	const transitions = [
+		{
+			id: "11",
+			name: "Start",
+			to: { name: "In Progress", statusCategory: { key: "indeterminate" } },
+		},
+		{ id: "31", name: "Done", to: { name: "Done", statusCategory: { key: "done" } } },
+		{ id: "41", name: "Reject", to: { name: "Rejected", statusCategory: { key: "done" } } },
+	];
+
+	test("takes the first transition landing in the done category", () => {
+		expect(pickCloseTransition(transitions, undefined)?.id).toBe("31");
+	});
+
+	test("prefers the configured name over the category", () => {
+		expect(pickCloseTransition(transitions, "reject")?.id).toBe("41");
+	});
+
+	test("returns undefined when the configured name is not on offer", () => {
+		expect(pickCloseTransition(transitions, "Archive")).toBeUndefined();
+	});
+
+	test("returns undefined when the workflow offers no way out", () => {
+		expect(pickCloseTransition([], undefined)).toBeUndefined();
+		expect(pickCloseTransition(undefined, undefined)).toBeUndefined();
+	});
+
+	test("skips a transition Jira reported without an id", () => {
+		expect(
+			pickCloseTransition([{ name: "Done", to: { statusCategory: { key: "done" } } }], undefined),
+		).toBeUndefined();
+	});
+});

--- a/extensions/tracker-jira/src/jira/map.ts
+++ b/extensions/tracker-jira/src/jira/map.ts
@@ -1,0 +1,141 @@
+/**
+ * Jira payloads to warren-tracker/v1 shapes. Pure, and defensive about
+ * every field: these values crossed an HTTP boundary.
+ *
+ * The one rule worth stating twice is the status rule. `status` on the
+ * wire is Jira's RAW status name ("In Progress", "Done", whatever the
+ * workflow calls it). Warren normalizes to its own three-state vocabulary
+ * at its bridge, and a server that pre-normalizes would be answering a
+ * question it was not asked.
+ */
+
+import {
+	JIRA_DONE_CATEGORY,
+	type JiraIssue,
+	type JiraIssueLink,
+	type JiraTransition,
+} from "./types.ts";
+import type { RemoteIssueResponse } from "../protocol.ts";
+
+/**
+ * Flatten an Atlassian Document Format tree to text. v3 returns
+ * `description` as a node tree; v2 and some proxies return a plain
+ * string, so a string passes through untouched.
+ *
+ * Block-level nodes separate with a blank line and inline nodes join
+ * directly, which is enough to keep a paragraph readable in a prompt.
+ * A hard break is a newline. Anything unrecognized contributes its
+ * children, so an unknown node type loses its formatting rather than its
+ * text.
+ */
+export function flattenAdf(description: unknown): string | undefined {
+	if (typeof description === "string") {
+		return description.length > 0 ? description : undefined;
+	}
+	if (description === null || typeof description !== "object") return undefined;
+	const text = renderNode(description as AdfNode).trim();
+	return text.length > 0 ? text : undefined;
+}
+
+interface AdfNode {
+	readonly type?: string;
+	readonly text?: string;
+	readonly content?: readonly unknown[];
+}
+
+const BLOCK_TYPES = new Set([
+	"paragraph",
+	"heading",
+	"blockquote",
+	"codeBlock",
+	"listItem",
+	"panel",
+	"rule",
+	"mediaSingle",
+	"table",
+	"tableRow",
+]);
+
+function renderNode(node: AdfNode): string {
+	if (typeof node.text === "string") return node.text;
+	if (node.type === "hardBreak") return "\n";
+	const children = Array.isArray(node.content) ? node.content : [];
+	const parts: string[] = [];
+	for (const child of children) {
+		if (child === null || typeof child !== "object") continue;
+		parts.push(renderNode(child as AdfNode));
+	}
+	const joined = parts.join("");
+	return BLOCK_TYPES.has(node.type ?? "") ? `${joined}\n\n` : joined;
+}
+
+/**
+ * The keys of the issues that block this one. Jira models the
+ * relationship on the link type's INWARD side, so an issue that is
+ * blocked carries a link whose `type.inward` reads "is blocked by" and
+ * whose `inwardIssue` is the blocker. The description is workflow text a
+ * Jira admin can rename, which is why it is configurable.
+ */
+export function blockedByKeys(
+	links: readonly JiraIssueLink[] | undefined,
+	inwardDescription: string,
+): string[] {
+	if (links === undefined) return [];
+	const wanted = inwardDescription.trim().toLowerCase();
+	const keys: string[] = [];
+	for (const link of links) {
+		const inward = link.type?.inward?.trim().toLowerCase();
+		const key = link.inwardIssue?.key;
+		if (inward === wanted && typeof key === "string" && key.length > 0) keys.push(key);
+	}
+	return keys;
+}
+
+/** True when Jira considers the issue terminal, whatever the status is called. */
+export function isDone(issue: JiraIssue): boolean {
+	return issue.fields?.status?.statusCategory?.key === JIRA_DONE_CATEGORY;
+}
+
+/** The raw status name, or an empty string when the workflow reports none. */
+export function statusName(issue: JiraIssue): string {
+	return issue.fields?.status?.name ?? "";
+}
+
+export function toIssueResponse(
+	issue: JiraIssue,
+	fallbackKey: string,
+	inwardDescription: string,
+): RemoteIssueResponse {
+	const title = issue.fields?.summary ?? undefined;
+	const description = flattenAdf(issue.fields?.description);
+	const blockedBy = blockedByKeys(issue.fields?.issuelinks, inwardDescription);
+	return {
+		id: issue.key ?? fallbackKey,
+		status: statusName(issue),
+		...(typeof title === "string" && title.length > 0 ? { title } : {}),
+		...(description !== undefined ? { description } : {}),
+		...(blockedBy.length > 0 ? { blockedBy } : {}),
+	};
+}
+
+/**
+ * The transition that closes the issue. A configured name wins and is
+ * matched case-insensitively, because an operator who named one means
+ * that one. Otherwise the first transition landing in the `done` category
+ * is the answer, which is how Jira itself defines terminal.
+ *
+ * Returns undefined when the workflow offers no way out from here. That
+ * is a real configuration answer, not a transient failure, so the caller
+ * must not retry it.
+ */
+export function pickCloseTransition(
+	transitions: readonly JiraTransition[] | undefined,
+	configuredName: string | undefined,
+): JiraTransition | undefined {
+	const available = (transitions ?? []).filter((t) => typeof t.id === "string" && t.id.length > 0);
+	if (configuredName !== undefined) {
+		const wanted = configuredName.trim().toLowerCase();
+		return available.find((t) => t.name?.trim().toLowerCase() === wanted);
+	}
+	return available.find((t) => t.to?.statusCategory?.key === JIRA_DONE_CATEGORY);
+}

--- a/extensions/tracker-jira/src/jira/types.ts
+++ b/extensions/tracker-jira/src/jira/types.ts
@@ -1,0 +1,69 @@
+/**
+ * The slice of the Jira Cloud REST v3 response shapes this tracker reads.
+ *
+ * Everything is optional on purpose. Jira returns fields per the `fields`
+ * query parameter, a workflow can leave a status category unset, and a
+ * self-hosted proxy can strip things, so the mapping narrows rather than
+ * trusts. Nothing here is a Jira type import: the payloads cross an HTTP
+ * boundary, so they are parsed, not asserted.
+ */
+
+export interface JiraStatusCategory {
+	readonly key?: string;
+	readonly name?: string;
+}
+
+export interface JiraStatus {
+	readonly name?: string;
+	readonly statusCategory?: JiraStatusCategory;
+}
+
+export interface JiraLinkedIssueRef {
+	readonly key?: string;
+}
+
+export interface JiraIssueLinkType {
+	readonly name?: string;
+	readonly inward?: string;
+	readonly outward?: string;
+}
+
+export interface JiraIssueLink {
+	readonly type?: JiraIssueLinkType;
+	readonly inwardIssue?: JiraLinkedIssueRef;
+	readonly outwardIssue?: JiraLinkedIssueRef;
+}
+
+export interface JiraIssueFields {
+	readonly summary?: string | null;
+	/** Atlassian Document Format node tree on v3; a plain string on v2. */
+	readonly description?: unknown;
+	readonly status?: JiraStatus;
+	readonly issuelinks?: readonly JiraIssueLink[];
+}
+
+export interface JiraIssue {
+	readonly key?: string;
+	readonly fields?: JiraIssueFields;
+}
+
+/** `GET /rest/api/3/search/jql` page. */
+export interface JiraSearchPage {
+	readonly issues?: readonly JiraIssue[];
+	readonly nextPageToken?: string;
+	readonly isLast?: boolean;
+}
+
+export interface JiraTransition {
+	readonly id?: string;
+	readonly name?: string;
+	readonly to?: JiraStatus;
+}
+
+/** `GET /rest/api/3/issue/{key}/transitions` response. */
+export interface JiraTransitionsResponse {
+	readonly transitions?: readonly JiraTransition[];
+}
+
+/** The status category key Jira uses for every terminal status. */
+export const JIRA_DONE_CATEGORY = "done";

--- a/extensions/tracker-jira/src/operations.ts
+++ b/extensions/tracker-jira/src/operations.ts
@@ -1,0 +1,122 @@
+/**
+ * The three base-contract operations, over the Jira client.
+ *
+ * This is where a Jira failure becomes a protocol failure. The mapping is
+ * the interesting part, because the two sides mean different things by
+ * the same status code:
+ *
+ *   - Jira 404 is the one case that IS the protocol's `issue_not_found`.
+ *   - Jira 401/403 means THIS container's credential is wrong. Passing it
+ *     through would tell warren its own bearer was rejected, sending an
+ *     operator to the wrong secret, so it surfaces as 502.
+ *   - Jira 429 passes through with `Retry-After`, because warren's bridge
+ *     already backs off on it and knows how to wait.
+ *   - Everything else, unreachable included, is 502: the tracker is
+ *     present but the system behind it did not answer.
+ */
+
+import type { JiraTrackerConfig } from "./config.ts";
+import { JiraApiError, type JiraClient } from "./jira/client.ts";
+import { isDone, pickCloseTransition, toIssueResponse } from "./jira/map.ts";
+import type { RemoteIssueResponse } from "./protocol.ts";
+import { TRACKER_ISSUE_NOT_FOUND_CODE } from "./protocol.ts";
+
+/** A failure already shaped for the wire. */
+export class TrackerOperationError extends Error {
+	readonly code: string;
+	readonly status: number;
+	readonly retryAfter: string | null;
+
+	constructor(code: string, message: string, status: number, retryAfter: string | null = null) {
+		super(message);
+		this.name = "TrackerOperationError";
+		this.code = code;
+		this.status = status;
+		this.retryAfter = retryAfter;
+	}
+}
+
+export function toTrackerError(err: unknown, key?: string): TrackerOperationError {
+	if (!(err instanceof JiraApiError)) {
+		const reason = err instanceof Error ? err.message : String(err);
+		return new TrackerOperationError("internal_error", reason, 500);
+	}
+	if (err.status === 404 && key !== undefined) {
+		return new TrackerOperationError(TRACKER_ISSUE_NOT_FOUND_CODE, `issue not found: ${key}`, 404);
+	}
+	if (err.status === 401 || err.status === 403) {
+		return new TrackerOperationError(
+			"upstream_unauthorized",
+			`jira rejected this tracker's own credential: ${err.message}`,
+			502,
+		);
+	}
+	if (err.status === 429) {
+		return new TrackerOperationError("upstream_rate_limited", err.message, 429, err.retryAfter);
+	}
+	if (err.status === 0) {
+		return new TrackerOperationError("upstream_unreachable", err.message, 502);
+	}
+	return new TrackerOperationError("upstream_error", err.message, 502);
+}
+
+export async function readIssue(
+	client: JiraClient,
+	config: JiraTrackerConfig,
+	key: string,
+): Promise<RemoteIssueResponse> {
+	try {
+		const issue = await client.getIssue(key);
+		return toIssueResponse(issue, key, config.blockedByInward);
+	} catch (err) {
+		throw toTrackerError(err, key);
+	}
+}
+
+export async function readStatuses(client: JiraClient): Promise<Record<string, string>> {
+	try {
+		return await client.issueStatuses();
+	} catch (err) {
+		throw toTrackerError(err);
+	}
+}
+
+/**
+ * Close, idempotently. Jira has no close verb, only workflow transitions,
+ * and a workflow usually offers none out of a terminal status. So the
+ * already-done case is answered by the read and never reaches a
+ * transition: closing twice is 200 both times, which the protocol
+ * requires and the conformance suite checks.
+ *
+ * A workflow that offers no way to a terminal status from here is a
+ * configuration answer rather than a transient failure, so it surfaces as
+ * 409. Warren does not retry a 4xx.
+ */
+export async function closeIssue(
+	client: JiraClient,
+	config: JiraTrackerConfig,
+	key: string,
+): Promise<RemoteIssueResponse> {
+	try {
+		const current = await client.getIssue(key);
+		if (isDone(current)) return toIssueResponse(current, key, config.blockedByInward);
+
+		const { transitions } = await client.transitions(key);
+		const transition = pickCloseTransition(transitions, config.doneTransition);
+		if (transition?.id === undefined) {
+			throw new TrackerOperationError(
+				"no_close_transition",
+				config.doneTransition === undefined
+					? `no transition from "${current.fields?.status?.name ?? "?"}" lands in the done category for ${key}`
+					: `transition "${config.doneTransition}" is not available on ${key} right now`,
+				409,
+			);
+		}
+		await client.applyTransition(key, transition.id);
+		const closed = await client.getIssue(key);
+		return toIssueResponse(closed, key, config.blockedByInward);
+	} catch (err) {
+		if (err instanceof TrackerOperationError) throw err;
+		throw toTrackerError(err, key);
+	}
+}

--- a/extensions/tracker-jira/src/protocol.ts
+++ b/extensions/tracker-jira/src/protocol.ts
@@ -1,0 +1,63 @@
+/**
+ * The warren-tracker/v1 wire protocol, base-contract subset.
+ *
+ * PUBLISHED VOCABULARY COPY. The extension seam
+ * (docs/design/extensions.md) forbids importing warren internals, so this
+ * is a deliberate copy of the published declaration that ships with
+ * `@warren-ext/tracker-conformance` (`src/protocol.ts`), which is itself
+ * the extension-side mirror of warren's canonical
+ * `src/tracker/remote/protocol.ts`. The conformance suite is what holds
+ * all three to the same behavior, so run it after touching this file.
+ *
+ * Only the base contract lives here. This tracker declares
+ * `supportsPlans`, `supportsMetadata` and `supportsScheduledIssues` all
+ * false, and warren never calls a surface whose capability was not
+ * declared, so copying the plan, metadata and scheduled-issue shapes
+ * would be copying vocabulary this package cannot speak.
+ */
+
+/** The single protocol version warren's bridge speaks. */
+export const TRACKER_PROTOCOL_VERSION = "warren-tracker/v1";
+
+/** Reserved error code: the requested issue id does not exist. */
+export const TRACKER_ISSUE_NOT_FOUND_CODE = "issue_not_found";
+
+/** Returned on an optional surface this tracker does not declare. */
+export const CAPABILITY_NOT_SUPPORTED_CODE = "capability_not_supported";
+
+/** The capability flag set a server declares on `GET /capabilities`. */
+export interface RemoteTrackerCapabilities {
+	readonly supportsPlans: boolean;
+	readonly supportsMetadata: boolean;
+	readonly supportsScheduledIssues: boolean;
+	readonly isGitNative: boolean;
+}
+
+/** `GET /capabilities` response. */
+export interface CapabilitiesResponse {
+	readonly protocolVersion: string;
+	readonly capabilities: RemoteTrackerCapabilities;
+}
+
+/** `GET /issues/{id}` response. `status` is the tracker's RAW string. */
+export interface RemoteIssueResponse {
+	readonly id: string;
+	readonly status: string;
+	readonly title?: string;
+	readonly description?: string;
+	readonly blockedBy?: readonly string[];
+	readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+/** `GET /issue-statuses` response: a raw `id -> status` map. */
+export interface RemoteIssueStatusesResponse {
+	readonly statuses: Readonly<Record<string, string>>;
+}
+
+/** The error envelope every non-2xx response carries. */
+export interface TrackerErrorResponse {
+	readonly error: {
+		readonly code: string;
+		readonly message: string;
+	};
+}

--- a/extensions/tracker-jira/src/protocol.ts
+++ b/extensions/tracker-jira/src/protocol.ts
@@ -22,6 +22,9 @@ export const TRACKER_PROTOCOL_VERSION = "warren-tracker/v1";
 /** Reserved error code: the requested issue id does not exist. */
 export const TRACKER_ISSUE_NOT_FOUND_CODE = "issue_not_found";
 
+/** Returned when a path segment is not valid percent-encoding. */
+export const INVALID_ISSUE_ID_CODE = "invalid_issue_id";
+
 /** Returned on an optional surface this tracker does not declare. */
 export const CAPABILITY_NOT_SUPPORTED_CODE = "capability_not_supported";
 

--- a/extensions/tracker-jira/src/server.test.ts
+++ b/extensions/tracker-jira/src/server.test.ts
@@ -1,0 +1,225 @@
+/**
+ * The warren-tracker/v1 surface, driven against FakeJira.
+ *
+ * These cover the protocol obligations that are easy to get wrong on a
+ * tracker with no close verb: idempotent close, the reserved
+ * `issue_not_found` code on both paths, and the error mapping that keeps
+ * a Jira credential failure from reading as a warren credential failure.
+ * The suite in `@warren-ext/tracker-conformance` is the authority; these
+ * are the cases worth failing fast on before it runs.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { loadConfig } from "./config.ts";
+import { createFakeJira, type FakeJiraOptions, SAMPLE_ISSUES } from "./fake-jira.ts";
+import { createJiraTrackerHandler } from "./server.ts";
+
+function harness(options: Partial<FakeJiraOptions> = {}, env: Record<string, string> = {}) {
+	const jira = createFakeJira({ issues: SAMPLE_ISSUES, ...options });
+	const config = loadConfig({
+		JIRA_BASE_URL: "https://acme.atlassian.net",
+		JIRA_EMAIL: "bot@acme.example",
+		JIRA_API_TOKEN: "token-123",
+		JIRA_JQL: "project = WAR",
+		...env,
+	});
+	const handler = createJiraTrackerHandler({ config, fetchImpl: jira.fetchImpl });
+	const call = (method: string, path: string, headers: Record<string, string> = {}) =>
+		handler(new Request(`http://tracker${path}`, { method, headers }));
+	return { jira, call };
+}
+
+describe("GET /capabilities", () => {
+	test("negotiates warren-tracker/v1 and declares the base contract only", async () => {
+		const { call } = harness();
+		const response = await call("GET", "/capabilities");
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("application/json");
+		expect(await response.json()).toEqual({
+			protocolVersion: "warren-tracker/v1",
+			capabilities: {
+				supportsPlans: false,
+				supportsMetadata: false,
+				supportsScheduledIssues: false,
+				isGitNative: false,
+			},
+		});
+	});
+
+	test("answers without touching Jira, so a boot probe needs no credential round trip", async () => {
+		const { jira, call } = harness();
+		await call("GET", "/capabilities");
+		expect(jira.calls).toEqual([]);
+	});
+});
+
+describe("GET /issues/{id}", () => {
+	test("maps a Jira issue onto the wire shape", async () => {
+		const { call } = harness();
+		const body = await (await call("GET", "/issues/WAR-1")).json();
+		expect(body).toEqual({
+			id: "WAR-1",
+			status: "To Do",
+			title: "Redis connection pool leaks under load",
+			description: "Connections are never returned after a timeout.\n\nReproduced on staging twice.",
+			blockedBy: ["WAR-2"],
+		});
+	});
+
+	test("answers a missing id with the reserved code", async () => {
+		const { call } = harness();
+		const response = await call("GET", "/issues/WAR-404");
+		expect(response.status).toBe(404);
+		expect(await response.json()).toEqual({
+			error: { code: "issue_not_found", message: "issue not found: WAR-404" },
+		});
+	});
+});
+
+describe("GET /issue-statuses", () => {
+	test("returns the raw id to status map for the configured query", async () => {
+		const { call } = harness();
+		const body = (await (await call("GET", "/issue-statuses")).json()) as {
+			statuses: Record<string, string>;
+		};
+		expect(body.statuses).toEqual({ "WAR-1": "To Do", "WAR-2": "In Progress", "WAR-3": "Done" });
+	});
+
+	test("walks every page rather than returning the first one", async () => {
+		const { jira, call } = harness({ pageSize: 1 });
+		const body = (await (await call("GET", "/issue-statuses")).json()) as {
+			statuses: Record<string, string>;
+		};
+		expect(Object.keys(body.statuses)).toHaveLength(3);
+		expect(jira.calls.filter((c) => c.includes("/search/jql"))).toHaveLength(3);
+	});
+
+	test("fails loud rather than truncating when the query never stops paginating", async () => {
+		const { call } = harness({ pageSize: 1 }, { JIRA_MAX_SEARCH_PAGES: "2" });
+		const response = await call("GET", "/issue-statuses");
+		expect(response.status).toBe(502);
+		expect(((await response.json()) as { error: { message: string } }).error.message).toMatch(
+			/JIRA_MAX_SEARCH_PAGES/,
+		);
+	});
+});
+
+describe("POST /issues/{id}/close", () => {
+	test("transitions the issue into the done category", async () => {
+		const { jira, call } = harness();
+		const response = await call("POST", "/issues/WAR-1/close");
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({ id: "WAR-1", status: "Done" });
+		expect(jira.issues.get("WAR-1")?.statusCategory).toBe("done");
+	});
+
+	test("closing an already-closed issue is 200 and transitions nothing", async () => {
+		const { jira, call } = harness();
+		const first = await call("POST", "/issues/WAR-1/close");
+		const before = jira.calls.length;
+		const second = await call("POST", "/issues/WAR-1/close");
+
+		expect(first.status).toBe(200);
+		expect(second.status).toBe(200);
+		expect(await second.json()).toMatchObject({ id: "WAR-1", status: "Done" });
+		// The second close reads the issue and stops there: no transition
+		// list, no transition POST.
+		expect(jira.calls.slice(before)).toEqual(["GET /rest/api/3/issue/WAR-1"]);
+	});
+
+	test("uses the transition an operator named", async () => {
+		const { jira, call } = harness({}, { JIRA_DONE_TRANSITION: "Reject" });
+		await call("POST", "/issues/WAR-1/close");
+		expect(jira.issues.get("WAR-1")?.status).toBe("Rejected");
+	});
+
+	test("answers 409 when the workflow offers no way to a terminal status", async () => {
+		const { call } = harness({
+			transitions: [
+				{ id: "11", name: "Start", toStatus: "In Progress", toCategory: "indeterminate" },
+			],
+		});
+		const response = await call("POST", "/issues/WAR-1/close");
+		expect(response.status).toBe(409);
+		expect((await response.json()) as unknown).toMatchObject({
+			error: { code: "no_close_transition" },
+		});
+	});
+
+	test("answers a missing id with the reserved code", async () => {
+		const { call } = harness();
+		const response = await call("POST", "/issues/WAR-404/close");
+		expect(response.status).toBe(404);
+		expect((await response.json()) as unknown).toMatchObject({
+			error: { code: "issue_not_found" },
+		});
+	});
+});
+
+describe("upstream failures", () => {
+	test("a rejected Jira credential is 502, never 401", async () => {
+		const { call } = harness({ failWith: { status: 401 } });
+		const response = await call("GET", "/issues/WAR-1");
+		expect(response.status).toBe(502);
+		expect((await response.json()) as unknown).toMatchObject({
+			error: { code: "upstream_unauthorized" },
+		});
+	});
+
+	test("a Jira rate limit passes through with its Retry-After", async () => {
+		const { call } = harness({ failWith: { status: 429, retryAfter: "30" } });
+		const response = await call("GET", "/issues/WAR-1");
+		expect(response.status).toBe(429);
+		expect(response.headers.get("retry-after")).toBe("30");
+		expect((await response.json()) as unknown).toMatchObject({
+			error: { code: "upstream_rate_limited" },
+		});
+	});
+
+	test("a Jira 5xx is 502", async () => {
+		const { call } = harness({ failWith: { status: 503 } });
+		const response = await call("GET", "/issues/WAR-1");
+		expect(response.status).toBe(502);
+		expect((await response.json()) as unknown).toMatchObject({ error: { code: "upstream_error" } });
+	});
+});
+
+describe("the warren-facing bearer", () => {
+	test("rejects a request without the configured token", async () => {
+		const { call } = harness({}, { TRACKER_BEARER: "secret" });
+		const response = await call("GET", "/capabilities");
+		expect(response.status).toBe(401);
+		expect((await response.json()) as unknown).toMatchObject({ error: { code: "unauthorized" } });
+	});
+
+	test("admits a request carrying it", async () => {
+		const { call } = harness({}, { TRACKER_BEARER: "secret" });
+		const response = await call("GET", "/capabilities", { authorization: "Bearer secret" });
+		expect(response.status).toBe(200);
+	});
+});
+
+describe("the undeclared surfaces", () => {
+	test("answer 404 capability_not_supported instead of a bare no-route", async () => {
+		const { call } = harness();
+		for (const [method, path] of [
+			["GET", "/plans"],
+			["GET", "/plans/pl-1"],
+			["POST", "/issues/WAR-1/metadata"],
+			["GET", "/scheduled-issues"],
+		] as const) {
+			const response = await call(method, path);
+			expect(response.status, `${method} ${path}`).toBe(404);
+			expect((await response.json()) as unknown, `${method} ${path}`).toMatchObject({
+				error: { code: "capability_not_supported" },
+			});
+		}
+	});
+
+	test("an unknown route is a plain not_found", async () => {
+		const { call } = harness();
+		const response = await call("GET", "/nope");
+		expect(response.status).toBe(404);
+		expect((await response.json()) as unknown).toMatchObject({ error: { code: "not_found" } });
+	});
+});

--- a/extensions/tracker-jira/src/server.test.ts
+++ b/extensions/tracker-jira/src/server.test.ts
@@ -223,3 +223,30 @@ describe("the undeclared surfaces", () => {
 		expect((await response.json()) as unknown).toMatchObject({ error: { code: "not_found" } });
 	});
 });
+
+describe("a malformed path segment", () => {
+	test("leaves through the error envelope instead of a URIError", async () => {
+		const { call } = harness();
+		for (const [method, path] of [
+			["GET", "/issues/%"],
+			["GET", "/issues/%zz"],
+			["POST", "/issues/%/close"],
+			["POST", "/issues/%e0%a4%a/close"],
+		] as const) {
+			const response = await call(method, path);
+			expect(response.status, `${method} ${path}`).toBe(400);
+			expect(response.headers.get("content-type"), `${method} ${path}`).toContain(
+				"application/json",
+			);
+			expect((await response.json()) as unknown, `${method} ${path}`).toMatchObject({
+				error: { code: "invalid_issue_id" },
+			});
+		}
+	});
+
+	test("still decodes a well-formed escape", async () => {
+		const { call } = harness();
+		const response = await call("GET", `/issues/${encodeURIComponent("WAR-1")}`);
+		expect(response.status).toBe(200);
+	});
+});

--- a/extensions/tracker-jira/src/server.ts
+++ b/extensions/tracker-jira/src/server.ts
@@ -17,6 +17,7 @@ import { JiraClient } from "./jira/client.ts";
 import {
 	CAPABILITY_NOT_SUPPORTED_CODE,
 	type CapabilitiesResponse,
+	INVALID_ISSUE_ID_CODE,
 	type RemoteIssueStatusesResponse,
 	type RemoteTrackerCapabilities,
 	TRACKER_PROTOCOL_VERSION,
@@ -59,6 +60,27 @@ function errorJson(
 ): Response {
 	const body: TrackerErrorResponse = { error: { code, message } };
 	return json(body, status, headers);
+}
+
+/**
+ * Percent-decode one path segment. A malformed escape such as the `%` in
+ * `/issues/%` makes `decodeURIComponent` throw, and the route has to answer
+ * with the JSON error envelope rather than let a URIError leave the handler.
+ */
+function decodeSegment(raw: string | undefined): string | undefined {
+	try {
+		return decodeURIComponent(raw ?? "");
+	} catch {
+		return undefined;
+	}
+}
+
+function badIssueId(raw: string | undefined): Response {
+	return errorJson(
+		INVALID_ISSUE_ID_CODE,
+		`issue id is not a valid percent-encoded segment: ${raw ?? ""}`,
+		400,
+	);
 }
 
 function capabilityOff(surface: string): Response {
@@ -114,7 +136,8 @@ export function createJiraTrackerHandler(
 
 		const issueMatch = ISSUE_PATH.exec(path);
 		if (request.method === "GET" && issueMatch !== null) {
-			const key = decodeURIComponent(issueMatch[1] ?? "");
+			const key = decodeSegment(issueMatch[1]);
+			if (key === undefined) return badIssueId(issueMatch[1]);
 			try {
 				return json(await readIssue(client, config, key));
 			} catch (err) {
@@ -133,7 +156,8 @@ export function createJiraTrackerHandler(
 
 		const closeMatch = CLOSE_PATH.exec(path);
 		if (request.method === "POST" && closeMatch !== null) {
-			const key = decodeURIComponent(closeMatch[1] ?? "");
+			const key = decodeSegment(closeMatch[1]);
+			if (key === undefined) return badIssueId(closeMatch[1]);
 			try {
 				return json(await closeIssue(client, config, key));
 			} catch (err) {

--- a/extensions/tracker-jira/src/server.ts
+++ b/extensions/tracker-jira/src/server.ts
@@ -1,0 +1,182 @@
+/**
+ * The warren-tracker/v1 HTTP surface.
+ *
+ * Base contract only. The three optional surfaces answer 404
+ * `capability_not_supported`, matching the reference server: warren never
+ * calls a surface whose capability was not declared, so the route exists
+ * to give a misconfigured caller a readable answer rather than a bare
+ * "no route".
+ *
+ * Every response is JSON with the protocol's error envelope on any
+ * non-2xx, and the handler is separated from `Bun.serve` so tests drive
+ * it directly with a `Request`.
+ */
+
+import type { JiraTrackerConfig } from "./config.ts";
+import { JiraClient } from "./jira/client.ts";
+import {
+	CAPABILITY_NOT_SUPPORTED_CODE,
+	type CapabilitiesResponse,
+	type RemoteIssueStatusesResponse,
+	type RemoteTrackerCapabilities,
+	TRACKER_PROTOCOL_VERSION,
+	type TrackerErrorResponse,
+} from "./protocol.ts";
+import { closeIssue, readIssue, readStatuses, TrackerOperationError } from "./operations.ts";
+
+/**
+ * What this tracker can do, per the issue that asked for it. Jira has no
+ * plan object warren can walk, so a plan-run over Jira issues uses
+ * `POST /plan-runs` with an explicit ordered `issues: [...]` list, which
+ * the base contract is enough to drive. Metadata would need a Jira custom
+ * field per warren key and scheduled issues would need a due-date
+ * convention; neither is guessable, so neither is declared.
+ */
+export const JIRA_CAPABILITIES: RemoteTrackerCapabilities = {
+	supportsPlans: false,
+	supportsMetadata: false,
+	supportsScheduledIssues: false,
+	isGitNative: false,
+};
+
+const ISSUE_PATH = /^\/issues\/([^/]+)$/;
+const CLOSE_PATH = /^\/issues\/([^/]+)\/close$/;
+const METADATA_PATH = /^\/issues\/([^/]+)\/metadata$/;
+const PLAN_PATH = /^\/plans\/([^/]+)$/;
+
+function json(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json", ...headers },
+	});
+}
+
+function errorJson(
+	code: string,
+	message: string,
+	status: number,
+	headers: Record<string, string> = {},
+): Response {
+	const body: TrackerErrorResponse = { error: { code, message } };
+	return json(body, status, headers);
+}
+
+function capabilityOff(surface: string): Response {
+	return errorJson(
+		CAPABILITY_NOT_SUPPORTED_CODE,
+		`capability not supported: ${surface}`,
+		404,
+	);
+}
+
+function operationFailure(err: unknown): Response {
+	const failure =
+		err instanceof TrackerOperationError
+			? err
+			: new TrackerOperationError(
+					"internal_error",
+					err instanceof Error ? err.message : String(err),
+					500,
+				);
+	const headers: Record<string, string> =
+		failure.retryAfter === null ? {} : { "retry-after": failure.retryAfter };
+	return errorJson(failure.code, failure.message, failure.status, headers);
+}
+
+export interface JiraTrackerServerOptions {
+	readonly config: JiraTrackerConfig;
+	/** Override the Jira transport. Tests pass recorded payloads through it. */
+	readonly fetchImpl?: typeof fetch;
+}
+
+export function createJiraTrackerHandler(
+	options: JiraTrackerServerOptions,
+): (request: Request) => Promise<Response> {
+	const { config } = options;
+	const client = new JiraClient(config, options.fetchImpl ?? fetch);
+
+	return async (request: Request): Promise<Response> => {
+		const path = new URL(request.url).pathname;
+
+		if (config.bearerToken !== undefined) {
+			if (request.headers.get("authorization") !== `Bearer ${config.bearerToken}`) {
+				return errorJson("unauthorized", "missing or invalid bearer token", 401);
+			}
+		}
+
+		if (request.method === "GET" && path === "/capabilities") {
+			const body: CapabilitiesResponse = {
+				protocolVersion: TRACKER_PROTOCOL_VERSION,
+				capabilities: JIRA_CAPABILITIES,
+			};
+			return json(body);
+		}
+
+		const issueMatch = ISSUE_PATH.exec(path);
+		if (request.method === "GET" && issueMatch !== null) {
+			const key = decodeURIComponent(issueMatch[1] ?? "");
+			try {
+				return json(await readIssue(client, config, key));
+			} catch (err) {
+				return operationFailure(err);
+			}
+		}
+
+		if (request.method === "GET" && path === "/issue-statuses") {
+			try {
+				const body: RemoteIssueStatusesResponse = { statuses: await readStatuses(client) };
+				return json(body);
+			} catch (err) {
+				return operationFailure(err);
+			}
+		}
+
+		const closeMatch = CLOSE_PATH.exec(path);
+		if (request.method === "POST" && closeMatch !== null) {
+			const key = decodeURIComponent(closeMatch[1] ?? "");
+			try {
+				return json(await closeIssue(client, config, key));
+			} catch (err) {
+				return operationFailure(err);
+			}
+		}
+
+		if (request.method === "GET" && (path === "/plans" || PLAN_PATH.test(path))) {
+			return capabilityOff("plans");
+		}
+		if (request.method === "POST" && METADATA_PATH.test(path)) {
+			return capabilityOff("metadata");
+		}
+		if (request.method === "GET" && path === "/scheduled-issues") {
+			return capabilityOff("scheduled-issues");
+		}
+
+		return errorJson("not_found", `no route: ${request.method} ${path}`, 404);
+	};
+}
+
+export interface RunningJiraTracker {
+	readonly port: number;
+	readonly url: string;
+	stop(): Promise<void>;
+}
+
+export async function startJiraTracker(
+	options: JiraTrackerServerOptions & { readonly hostname?: string },
+): Promise<RunningJiraTracker> {
+	const handler = createJiraTrackerHandler(options);
+	const server = Bun.serve({
+		port: options.config.port,
+		hostname: options.hostname ?? "0.0.0.0",
+		fetch: handler,
+	});
+	const boundPort: number | undefined = server.port;
+	if (boundPort === undefined) throw new Error("Bun.serve did not report a bound port");
+	return {
+		port: boundPort,
+		url: `http://127.0.0.1:${boundPort}`,
+		stop: async () => {
+			server.stop(true);
+		},
+	};
+}

--- a/extensions/tracker-jira/tsconfig.json
+++ b/extensions/tracker-jira/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"allowImportingTsExtensions": true,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"types": ["bun-types"]
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION
Closes #1029.

## Summary

`extensions/tracker-jira/` serves warren-tracker/v1 against the Jira Cloud REST v3 API, out of process, holding its own credential. No core commit: the `IssueTracker` seam and the `RemoteTracker` bridge already carry it.

Capabilities are the shape the issue asked for, `supportsPlans` / `supportsMetadata` / `supportsScheduledIssues` / `isGitNative` all false, which is what Jira maps onto without inventing anything.

## The suite ran, and what it made me change

Nothing, on the protocol surface. It passed unchanged in both auth modes:

```
$ bun run dev-server --port 8792
$ cd ../tracker-conformance && bun run check http://127.0.0.1:8792
warren-tracker/v1 conformance: 7 case groups against http://127.0.0.1:8792
PASS, exit 0

$ bun run dev-server --port 8793 --bearer s3cret
$ bun run check http://127.0.0.1:8793
  FAIL capabilities/negotiation: GET /capabilities -> 401, want 2xx
$ bun run check http://127.0.0.1:8793 --bearer s3cret
warren-tracker/v1 conformance: 7 case groups against http://127.0.0.1:8793
PASS, exit 0
```

That is the real handler, the real client and the real mapping. Only the transport underneath is fake.

The feedback you asked for is not "it passed" though, it is where the protocol left a decision to me. Four, in rough order of how long each took:

**1. A tracker with no close verb.** Jira has only workflow transitions, and a workflow usually offers none out of a terminal status, so idempotent close cannot be expressed directly. What it forced is a good shape: close reads the issue first and returns there when Jira already considers it done, so closing twice is 200 both times and nothing is transitioned. Worth saying out loud that a protocol which had modeled close as "set status to X" would have been unimplementable here. The rule as written is the right rule.

**2. The retry contract is documented from warren's side only.** `issue-tracker.md` §5 says warren retries 429 and 5xx and does not retry other 4xx. A server author has to read that and infer "so a permanent refusal must be a 4xx". That inference is how `no_close_transition` became a 409 rather than a 502. Stating it as a rule *for servers* would save the next author the derivation.

**3. Nothing says what a server should do when its own upstream rejects it.** The protocol covers the bearer warren presents and documents 401 for that. It says nothing about the other credential. The naive answer, passing Jira's 401 straight through, tells warren its own bearer was refused and sends an operator to the wrong secret. I map it to `502 upstream_unauthorized`. This one deserves a line in the protocol, because the naive answer is actively misleading rather than merely underspecified.

**4. `issue_not_found` is the only reserved code.** A good minimum, but every other failure is a per-server invention, so two trackers will spell the same thing differently. Not urgent while warren maps everything else onto one `TrackerError`, and worth remembering before that stops being true.

No missing warren surface. The vocabulary plus one endpoint set was the whole contract, same finding the conformance package reported.

## The Jira mapping, and the one decision per row

| warren-tracker/v1 | Jira | note |
|---|---|---|
| `GET /capabilities` | nothing | answered locally, so a boot probe and a container healthcheck cost no Jira call |
| `GET /issues/{key}` | `GET /rest/api/3/issue/{key}` | `status` is Jira's raw name, never normalized here |
| `GET /issue-statuses` | `GET /rest/api/3/search/jql` over `JIRA_JQL` | every page, with a backstop that throws rather than truncating |
| `POST /issues/{key}/close` | read, then transition | see above |

`description` is an ADF tree on v3 and is flattened to text; a plain string passes through, which is what v2 and some proxies return. `blockedBy` reads the **inward** side of a link, which is the blocker; the outward side is the issue this one blocks and is deliberately not reported.

The pagination backstop throwing instead of truncating is deliberate. A silently short `/issue-statuses` map reads to warren as issues that vanished.

## What is not verified

**No call has ever reached a real Jira.** `src/fake-jira.ts` is transcribed from Atlassian's documented v3 response shapes, so it is a statement of what this tracker *expects* Jira to return, not evidence of what it does return. I have no instance to point it at, and I would rather mark that than let a green suite read as a live integration.

The blast radius is narrow and I named it in the README: the ADF shape of `description`, the `issuelinks` inward description on a site whose admin renamed the link type (there is a `JIRA_BLOCKED_BY_INWARD` knob for exactly that), and the `nextPageToken` pagination of `/search/jql`. A first live run either confirms those three or corrects them.

**Jira Server and Data Center are out of scope.** Their search endpoint is offset-paginated `/rest/api/2/search` and their auth is a PAT as a bearer. Shipping an untested second path would be a guess wearing a feature's clothes, so the README names the two functions that would change instead.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes, root and the extension's own config
- [x] `bun test extensions/tracker-jira`: 49 tests across 3 files
- [x] the conformance suite, both auth modes, output above
- [x] `bun run check:all`: 11 of 12 gates green, see below

The container was built and run, since CI's `docker-build` only builds the root image:

```
$ docker build -t warren-ext-tracker-jira .          # succeeds

$ docker run --rm warren-ext-tracker-jira
tracker-jira: JIRA_BASE_URL is required              # exit 2

$ docker run -d -p 8794:8080 -e JIRA_BASE_URL=https://unreachable.atlassian.invalid \
    -e JIRA_EMAIL=... -e JIRA_API_TOKEN=... -e "JIRA_JQL=project = WAR" warren-ext-tracker-jira
$ docker logs
tracker-jira listening on 8080 (site https://unreachable.atlassian.invalid, auth basic, jql project = WAR)

$ curl /capabilities
{"protocolVersion":"warren-tracker/v1","capabilities":{...all false}}

$ curl /issues/WAR-1
502 {"error":{"code":"upstream_unreachable","message":"jira unreachable: ..."}}
```

The boot line names the site, the auth mode and the query, which is the trio that goes wrong in practice, and never the credential.

`check:coverage` is the twelfth gate. It fails on this machine, which is Windows, and it fails the same way on unmodified `main`:

```
$ comm -3 <failures on this branch> <failures on main>
  (empty)          # 104 distinct tests either way
```

They are POSIX assumptions: `/data/projects` fallbacks, `chmod 0600` round-trips, sqlite file paths, and the macOS seatbelt profile. Coverage itself moved up rather than down: functions 93.42% against a 90.91% floor, lines 96.07% against 93.37%.

## One thing I did not touch

`issue-tracker.md` §8 says warren-tracker/v1 is experimental until a foreign implementation survives the suite unchanged. This is a candidate for that, but whether it counts is your call and not something a PR should assert about itself, so the doc is unchanged. The AGENTS.md extension count is the only core file this touches.
