### PR TITLE
refactor(forge): stop the git credential from assuming GitHub

### DIFF
--- a/src/forge/credentials.test.ts
+++ b/src/forge/credentials.test.ts
@@ -47,6 +47,22 @@ describe("mintGitCredential", () => {
 		}
 	});
 
+	test("keeps a self-hosted forge port in the host it rewrites against", async () => {
+		// git treats host and host:port as different remotes, so an insteadOf
+		// rule that drops the port names a URL that never appears.
+		const forge = new GitHubForge({ token: "tok" });
+		forge.parseRepoRef = (url: string) =>
+			url.includes("acme.internal") ? { forge: "github", key: "x/y" } : null;
+		for (const url of [
+			"https://git.acme.internal:8443/x/y.git",
+			"ssh://git@git.acme.internal:2222/x/y.git",
+		]) {
+			expect((await mintGitCredential(forge, url))?.host, url).toBe(
+				url.startsWith("https") ? "git.acme.internal:8443" : "git.acme.internal:2222",
+			);
+		}
+	});
+
 	test("throws GitCredentialMintError on a non-no_credential mint failure", async () => {
 		const forge = new GitHubForge({ token: "tok" });
 		forge.gitCredential = () =>

--- a/src/forge/credentials.test.ts
+++ b/src/forge/credentials.test.ts
@@ -1,27 +1,50 @@
 import { describe, expect, test } from "bun:test";
-import { GitCredentialMintError, mintGitCredentialSecret } from "./credentials.ts";
+import { GitCredentialMintError, mintGitCredential } from "./credentials.ts";
 import { FakeForge } from "./fake/fake-forge.ts";
 import { GitHubForge } from "./github/provider.ts";
 
-describe("mintGitCredentialSecret", () => {
+describe("mintGitCredential", () => {
 	test("returns undefined for a URL the forge does not own", async () => {
 		const forge = new GitHubForge({ token: "tok" });
-		expect(await mintGitCredentialSecret(forge, "https://gitlab.com/x/y.git")).toBeUndefined();
+		expect(await mintGitCredential(forge, "https://gitlab.com/x/y.git")).toBeUndefined();
 	});
 
 	test("mints the static secret for an owned URL under PAT mode", async () => {
 		const forge = new GitHubForge({ token: "tok" });
-		expect(await mintGitCredentialSecret(forge, "https://github.com/x/y.git")).toBe("tok");
+		expect(await mintGitCredential(forge, "https://github.com/x/y.git")).toEqual({
+			username: "x-access-token",
+			secret: "tok",
+			host: "github.com",
+		});
 	});
 
 	test("maps no_credential (empty token) to anonymous git", async () => {
 		const forge = new GitHubForge({ token: "" });
-		expect(await mintGitCredentialSecret(forge, "https://github.com/x/y.git")).toBeUndefined();
+		expect(await mintGitCredential(forge, "https://github.com/x/y.git")).toBeUndefined();
 	});
 
-	test("mints the FakeForge credential for a fake URL", async () => {
+	test("mints the FakeForge credential, with no host to rewrite against", async () => {
+		// FakeForge OWNS fake://repo, but its authority is the repo name rather
+		// than a git host, so there is no https remote an insteadOf rule could
+		// name. The credential still exists for the consumers that do not need
+		// one; only the rewrite renders nothing (warren-1b6f).
 		const forge = new FakeForge();
-		expect(await mintGitCredentialSecret(forge, "fake://repo")).toBe("fake-credential");
+		expect(await mintGitCredential(forge, "fake://repo")).toEqual({
+			username: "fake",
+			secret: "fake-credential",
+			host: "",
+		});
+	});
+
+	test("reads the host off the clone URL, in each spelling warren accepts", async () => {
+		const forge = new GitHubForge({ token: "tok" });
+		for (const url of [
+			"https://github.com/x/y.git",
+			"ssh://git@github.com/x/y.git",
+			"git@github.com:x/y.git",
+		]) {
+			expect((await mintGitCredential(forge, url))?.host, url).toBe("github.com");
+		}
 	});
 
 	test("throws GitCredentialMintError on a non-no_credential mint failure", async () => {
@@ -31,8 +54,8 @@ describe("mintGitCredentialSecret", () => {
 				ok: false,
 				error: { kind: "network", detail: "boom" },
 			});
-		await expect(
-			mintGitCredentialSecret(forge, "https://github.com/x/y.git"),
-		).rejects.toBeInstanceOf(GitCredentialMintError);
+		await expect(mintGitCredential(forge, "https://github.com/x/y.git")).rejects.toBeInstanceOf(
+			GitCredentialMintError,
+		);
 	});
 });

--- a/src/forge/credentials.ts
+++ b/src/forge/credentials.ts
@@ -102,6 +102,9 @@ function remoteHost(cloneUrl: string): string | null {
 	if (parsed.protocol !== "https:" && parsed.protocol !== "http:" && parsed.protocol !== "ssh:") {
 		return null;
 	}
-	const host = parsed.hostname.toLowerCase();
+	// `host`, not `hostname`: a self-hosted forge on a non-default port is a
+	// different remote to git, and an `insteadOf` rule without the port would
+	// never match the URL it is supposed to rewrite.
+	const host = parsed.host.toLowerCase();
 	return host === "" ? null : host;
 }

--- a/src/forge/credentials.ts
+++ b/src/forge/credentials.ts
@@ -4,13 +4,19 @@
  *
  * The HTTP handlers that fan a git credential into a domain call
  * (`addProject`, `refreshProject`, `spawnRun`, `createPlanRun`) mint HERE,
- * immediately before the call that spawns git, and pass only the minted
- * secret down the existing `token` / `githubToken` params. Those params
- * feed `githubCredentialGitEnv` (src/workspace/git/credential-env.ts),
- * which renders the per-spawn `GIT_CONFIG_*` env — the process lifetime of
- * one git child is the credential's whole lifetime. Under PAT mode the
- * mint is a static read (free); under App mode this same call site is the
- * re-mint point.
+ * immediately before the call that spawns git, and pass the minted
+ * {@link GitSpawnCredential} down the `gitCredential` params. Those params
+ * feed `gitCredentialGitEnv` (src/workspace/git/credential-env.ts), which
+ * renders the per-spawn `GIT_CONFIG_*` env, and the lifetime of one
+ * git child is the credential's whole lifetime. Under PAT mode the mint is
+ * a static read (free); under App mode this same call site is the re-mint
+ * point.
+ *
+ * The mint returns the USERNAME and the HOST beside the secret
+ * (warren-1b6f). Both used to be literals inside the env helper
+ * (`x-access-token`, `github.com`), which made the rewrite a GitHub-only
+ * rule: the username is the forge's own answer (`GitCredential.username`)
+ * and the host belongs to the clone URL the forge was asked about.
  *
  * Callers pass the boot-resolved `Forge` (`ServerDeps.forge`, resolved once
  * by `resolveForge` in `src/server/main/index.ts`) — never a per-request
@@ -18,6 +24,7 @@
  */
 
 import { WarrenError } from "../core/errors.ts";
+import type { GitSpawnCredential } from "../workspace/git/credential-env.ts";
 import type { Forge } from "./contract.ts";
 
 /**
@@ -32,23 +39,24 @@ export class GitCredentialMintError extends WarrenError {
 }
 
 /**
- * Mint the secret for ONE git network op against `cloneUrl`.
+ * Mint the credential for ONE git network op against `cloneUrl`.
  *
- * Returns `undefined` — anonymous git — in exactly the two cases the old
- * `AutoOpenPrConfig.gitToken` fan-out produced no credential:
+ * Returns `undefined`, meaning anonymous git, in three cases:
  *
  *   - the forge does not own the URL (`parseRepoRef` → null), matching the
  *     old behavior where the github.com-scoped `insteadOf` prefix never
  *     matched a foreign host;
  *   - the forge reports `no_credential` (e.g. `GITHUB_TOKEN` unset under
- *     PAT mode), matching the old undefined/empty-token passthrough.
+ *     PAT mode), matching the old undefined/empty-token passthrough;
+ *   - the forge minted an empty secret or an empty username, neither of
+ *     which can authenticate anything.
  *
  * Any other mint failure throws `GitCredentialMintError`.
  */
-export async function mintGitCredentialSecret(
+export async function mintGitCredential(
 	forge: Forge,
 	cloneUrl: string,
-): Promise<string | undefined> {
+): Promise<GitSpawnCredential | undefined> {
 	const ref = forge.parseRepoRef(cloneUrl);
 	if (ref === null) return undefined;
 	const result = await forge.gitCredential(ref);
@@ -62,5 +70,38 @@ export async function mintGitCredentialSecret(
 			},
 		);
 	}
-	return result.value.secret === "" ? undefined : result.value.secret;
+	const { username, secret } = result.value;
+	if (secret === "" || username === "") return undefined;
+	// An empty host means no https remote to rewrite against, which is
+	// FakeForge's `fake://owner/name` shape. The credential still exists and
+	// still reaches the consumers that do not need a host (the in-pod
+	// credential endpoint, `authenticatedCloneUrl`); only the `insteadOf`
+	// rewrite renders nothing, exactly as the github.com-scoped rule did
+	// against a foreign remote.
+	return { username, secret, host: remoteHost(cloneUrl) ?? "" };
+}
+
+/**
+ * The host an https rewrite would target, read off the clone URL rather
+ * than out of `RepoRef`, which is provider-private and the domain never
+ * destructures it (forge-contract.md §0). Handles the https, ssh and
+ * scp-style spellings warren accepts. Returns null for anything else,
+ * including a scheme with no authority such as FakeForge's
+ * `fake://owner/name`, where an https rewrite would name nothing real.
+ */
+function remoteHost(cloneUrl: string): string | null {
+	const trimmed = cloneUrl.trim();
+	const scp = /^[^@\s/]+@([^:\s/]+):/.exec(trimmed);
+	if (scp !== null) return (scp[1] as string).toLowerCase();
+	let parsed: URL;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:" && parsed.protocol !== "ssh:") {
+		return null;
+	}
+	const host = parsed.hostname.toLowerCase();
+	return host === "" ? null : host;
 }

--- a/src/forge/registry.test.ts
+++ b/src/forge/registry.test.ts
@@ -236,3 +236,20 @@ describe("resolveForge app arm (warren-f8df)", () => {
 		).not.toThrow();
 	});
 });
+
+describe("the github arm's static secret", () => {
+	test("reads WARREN_GIT_TOKEN before GITHUB_TOKEN", async () => {
+		const forge = resolveForge({}, { WARREN_GIT_TOKEN: "neutral", GITHUB_TOKEN: "legacy" });
+		const ref = forge.parseRepoRef("https://github.com/x/y.git");
+		expect(ref).not.toBeNull();
+		const cred = await forge.gitCredential(ref as NonNullable<typeof ref>);
+		expect(cred.ok && cred.value.secret).toBe("neutral");
+	});
+
+	test("still falls back to GITHUB_TOKEN, so an existing deployment is untouched", async () => {
+		const forge = resolveForge({}, { GITHUB_TOKEN: "legacy" });
+		const ref = forge.parseRepoRef("https://github.com/x/y.git");
+		const cred = await forge.gitCredential(ref as NonNullable<typeof ref>);
+		expect(cred.ok && cred.value.secret).toBe("legacy");
+	});
+});

--- a/src/forge/registry.test.ts
+++ b/src/forge/registry.test.ts
@@ -246,6 +246,15 @@ describe("the github arm's static secret", () => {
 		expect(cred.ok && cred.value.secret).toBe("neutral");
 	});
 
+	test("treats an empty or blank neutral token as unset, not as a choice", async () => {
+		for (const blank of ["", "   "]) {
+			const forge = resolveForge({}, { WARREN_GIT_TOKEN: blank, GITHUB_TOKEN: "legacy" });
+			const ref = forge.parseRepoRef("https://github.com/x/y.git");
+			const cred = await forge.gitCredential(ref as NonNullable<typeof ref>);
+			expect(cred.ok && cred.value.secret, JSON.stringify(blank)).toBe("legacy");
+		}
+	});
+
 	test("still falls back to GITHUB_TOKEN, so an existing deployment is untouched", async () => {
 		const forge = resolveForge({}, { GITHUB_TOKEN: "legacy" });
 		const ref = forge.parseRepoRef("https://github.com/x/y.git");

--- a/src/forge/registry.ts
+++ b/src/forge/registry.ts
@@ -10,7 +10,10 @@
  *
  * Selection rules (§1.1):
  *   - `WARREN_FORGE` unset (or blank) → `github` (the default forge).
- *   - `github` → `GitHubForge` over the static `GITHUB_TOKEN` secret.
+ *   - `github` → `GitHubForge` over the static secret, read from
+ *     `WARREN_GIT_TOKEN` and then `GITHUB_TOKEN` (warren-1b6f: the same
+ *     order the K8s pod path already reads, so one variable names the git
+ *     credential whatever the forge is).
  *   - `app`    → `GitHubAppForge` (warren-f8df) over the
  *     `WARREN_GITHUB_APP_ID` / `WARREN_GITHUB_APP_INSTALLATION_ID` /
  *     `WARREN_GITHUB_APP_PRIVATE_KEY` triple; a missing or unparseable
@@ -60,9 +63,10 @@ export type ForgeEnv = Readonly<Record<string, string | undefined>>;
 export interface ForgeDeps {
 	/**
 	 * Lazy static-secret factory for the `github` arm. Optional — when
-	 * omitted the selector reads `GITHUB_TOKEN` from the same env the
-	 * selection came from. A test injects a throwing factory here to prove
-	 * the `fake` arm never touches the github arm's inputs.
+	 * omitted the selector reads `WARREN_GIT_TOKEN`, then `GITHUB_TOKEN`,
+	 * from the same env the selection came from. A test injects a throwing
+	 * factory here to prove the `fake` arm never touches the github arm's
+	 * inputs.
 	 */
 	readonly githubToken?: () => string;
 	/**
@@ -124,7 +128,10 @@ export function resolveForge(deps: ForgeDeps = {}, env: ForgeEnv = process.env):
 	const kind = resolveForgeKind(env);
 	switch (kind) {
 		case "github": {
-			const tokenFactory = deps.githubToken ?? (() => env.GITHUB_TOKEN ?? "");
+			// warren-1b6f: the forge-neutral name wins, and GITHUB_TOKEN stays as
+			// the fallback, matching `src/runtime/k8s/git-tokens.ts`.
+			const tokenFactory =
+				deps.githubToken ?? (() => env.WARREN_GIT_TOKEN ?? env.GITHUB_TOKEN ?? "");
 			return new GitHubForge({
 				token: tokenFactory(),
 				...(deps.githubFetch !== undefined ? { fetch: deps.githubFetch } : {}),

--- a/src/forge/registry.ts
+++ b/src/forge/registry.ts
@@ -146,7 +146,8 @@ export function resolveForge(deps: ForgeDeps = {}, env: ForgeEnv = process.env):
 		case "github": {
 			// warren-1b6f: the forge-neutral name wins, and GITHUB_TOKEN stays as
 			// the fallback, matching `src/runtime/k8s/git-tokens.ts`.
-			const tokenFactory = deps.githubToken ?? (() => firstToken(env.WARREN_GIT_TOKEN, env.GITHUB_TOKEN));
+			const tokenFactory =
+				deps.githubToken ?? (() => firstToken(env.WARREN_GIT_TOKEN, env.GITHUB_TOKEN));
 			return new GitHubForge({
 				token: tokenFactory(),
 				...(deps.githubFetch !== undefined ? { fetch: deps.githubFetch } : {}),

--- a/src/forge/registry.ts
+++ b/src/forge/registry.ts
@@ -124,14 +124,29 @@ export function resolveForgeKind(env: ForgeEnv = process.env): ForgeKind {
  * `WARREN_FORGE` (see module doc) and constructs the chosen forge from
  * `deps`.
  */
+/**
+ * The first env token that carries something, trimmed.
+ *
+ * An operator who exports `WARREN_GIT_TOKEN=""` has not chosen a neutral
+ * token, so an empty or blank value must not shadow a valid `GITHUB_TOKEN`
+ * behind it. Same rule as `normalizeToken` in
+ * `src/runtime/k8s/git-tokens.ts`, which the comment below claims parity with.
+ */
+function firstToken(...raw: readonly (string | undefined)[]): string {
+	for (const value of raw) {
+		const trimmed = value?.trim();
+		if (trimmed !== undefined && trimmed !== "") return trimmed;
+	}
+	return "";
+}
+
 export function resolveForge(deps: ForgeDeps = {}, env: ForgeEnv = process.env): Forge {
 	const kind = resolveForgeKind(env);
 	switch (kind) {
 		case "github": {
 			// warren-1b6f: the forge-neutral name wins, and GITHUB_TOKEN stays as
 			// the fallback, matching `src/runtime/k8s/git-tokens.ts`.
-			const tokenFactory =
-				deps.githubToken ?? (() => env.WARREN_GIT_TOKEN ?? env.GITHUB_TOKEN ?? "");
+			const tokenFactory = deps.githubToken ?? (() => firstToken(env.WARREN_GIT_TOKEN, env.GITHUB_TOKEN));
 			return new GitHubForge({
 				token: tokenFactory(),
 				...(deps.githubFetch !== undefined ? { fetch: deps.githubFetch } : {}),

--- a/src/observability/log-redact.test.ts
+++ b/src/observability/log-redact.test.ts
@@ -26,6 +26,17 @@ describe("LOG_REDACT_PATHS", () => {
 		expect(LOG_REDACT_PATHS).toContain("*.token");
 		expect(LOG_REDACT_PATHS).toContain("headers.authorization");
 	});
+
+	test("covers the minted git credential under both of its spellings", () => {
+		// warren-1b6f renamed the field carrying the per-spawn secret. A rename
+		// that misses this list turns a logged intent into a leak, so both the
+		// new field and the in-pod wire's older `gitToken` stay listed, along
+		// with the env var the github arm now reads first.
+		expect(LOG_REDACT_PATHS).toContain("gitCredential");
+		expect(LOG_REDACT_PATHS).toContain("*.gitCredential");
+		expect(LOG_REDACT_PATHS).toContain("gitToken");
+		expect(LOG_REDACT_PATHS).toContain("WARREN_GIT_TOKEN");
+	});
 });
 
 describe("LOG_REDACT_OPTIONS applied to pino", () => {

--- a/src/observability/log-redact.ts
+++ b/src/observability/log-redact.ts
@@ -43,6 +43,8 @@ export const SECRET_FIELDS = [
 	"secret",
 	"apiKey",
 	"GITHUB_TOKEN",
+	// warren-1b6f: the forge-neutral spelling the github arm now reads first.
+	"WARREN_GIT_TOKEN",
 	"BURROW_API_TOKEN",
 	"WARREN_BURROW_TOKEN",
 	// warren-9bbc: snake_case JSON keys an agent transcript or an OAuth /
@@ -59,15 +61,18 @@ export const SECRET_FIELDS = [
 	"clientSecret",
 	"private_key",
 	"privateKey",
-	// warren-6c4c: the per-spawn git-credential env (githubCredentialGitEnv,
+	// warren-6c4c: the per-spawn git-credential env (gitCredentialGitEnv,
 	// forge-contract.md §4) embeds the minted secret inline in
 	// GIT_CONFIG_KEY_0's `url.https://x-access-token:<secret>@…` value — list
 	// the names so a logged SpawnOptions.env can never leak one.
 	"GIT_CONFIG_KEY_0",
 	"GIT_CONFIG_VALUE_0",
 	// warren-4e1c: the per-spawn minted push credential rides
-	// `FinalizeIntent.gitToken` / `WorkspaceSalvageInput.gitToken` — list the
-	// field name so a logged intent/salvage object can never leak one.
+	// `FinalizeIntent.gitCredential` / `WorkspaceSalvageInput.gitCredential`:
+	// list the field name so a logged intent/salvage object can never leak
+	// one. `gitToken` stays listed: the in-pod finalize wire still carries the
+	// bare secret under that name (warren-1b6f).
+	"gitCredential",
 	"gitToken",
 	// warren-f8df: the GitHub App forge (src/forge/github-app/) — the cached
 	// `ghs_` installation token, the env var holding the App's PEM, and any

--- a/src/plan-runs/close-child-seed.test.ts
+++ b/src/plan-runs/close-child-seed.test.ts
@@ -118,7 +118,7 @@ describe("closeMergedChildSeed", () => {
 			issueTracker,
 			spawn,
 			gitBinary: "git",
-			githubToken: "ghp_secret",
+			gitCredential: { username: "x-access-token", secret: "ghp_secret", host: "github.com" },
 		});
 
 		const credKey = "url.https://x-access-token:ghp_secret@github.com/.insteadOf";

--- a/src/plan-runs/close-child-seed.ts
+++ b/src/plan-runs/close-child-seed.ts
@@ -36,7 +36,8 @@ import {
 } from "../bot-identity.ts";
 import type { SpawnFn } from "../projects/index.ts";
 import type { IssueTracker } from "../tracker/contract.ts";
-import { githubCredentialGitEnv } from "../workspace/git/credential-env.ts";
+import type { GitSpawnCredential } from "../workspace/git/credential-env.ts";
+import { gitCredentialGitEnv } from "../workspace/git/credential-env.ts";
 
 export interface CloseMergedChildSeedInput {
 	/** Project clone whose origin carries the seed queue (coordination project). */
@@ -54,11 +55,11 @@ export interface CloseMergedChildSeedInput {
 	readonly gitBinary: string;
 	/**
 	 * Raw `GITHUB_TOKEN` for the fetch + push against a private origin,
-	 * applied per-spawn via `githubCredentialGitEnv` (needed on the K8s
+	 * applied per-spawn via `gitCredentialGitEnv` (needed on the K8s
 	 * control plane, where no supervisor-installed global insteadOf rule
 	 * exists). Absent/empty → anonymous git, the old behavior.
 	 */
-	readonly githubToken?: string;
+	readonly gitCredential?: GitSpawnCredential;
 }
 
 export type CloseMergedChildSeedResult =
@@ -132,7 +133,7 @@ export async function closeMergedChildSeed(
 
 	const scrub = gitRepoContextScrubEnv();
 	// Credential env for the network-touching calls only (fetch + push).
-	const cred = githubCredentialGitEnv(input.githubToken);
+	const cred = gitCredentialGitEnv(input.gitCredential);
 
 	// Best-effort fetch so the worktree reflects the just-merged default branch.
 	await runGit(input, ["fetch", "--prune", "origin"], input.projectPath, { ...scrub, ...cred });

--- a/src/plan-runs/create.ts
+++ b/src/plan-runs/create.ts
@@ -39,6 +39,7 @@ import type { ProjectsConfig } from "../projects/config.ts";
 import { refreshProject } from "../projects/index.ts";
 import type { IssueTracker, PlanCapableTracker, TrackerContext } from "../tracker/contract.ts";
 import type { WarrenConfigCache } from "../warren-config/index.ts";
+import type { GitSpawnCredential } from "../workspace/git/credential-env.ts";
 import { PlanHasNoOpenChildrenError, ProjectLacksTrackerError } from "./errors.ts";
 
 export const PLAN_RUN_ACCEPTED_PLAN_STATUSES: readonly PlanStatus[] = [
@@ -83,8 +84,8 @@ export interface CreatePlanRunOrchestrationInput {
 	/** Git spawn seam. When wired, the host clone is refreshed before the plan walk (warren-6d60). */
 	readonly spawn?: SpawnFn;
 	readonly projectsConfig: ProjectsConfig;
-	/** Private-repo credential for the host-side refresh fetch (minted per-spawn via `mintGitCredentialSecret`). */
-	readonly gitToken?: string;
+	/** Private-repo credential for the host-side refresh fetch (minted per-spawn via `mintGitCredential`). */
+	readonly gitCredential?: GitSpawnCredential;
 	readonly warrenConfigs?: WarrenConfigCache;
 	/** Test seam — defaults to the live `refreshProject`. */
 	readonly refreshProjectFn?: typeof refreshProject;
@@ -113,7 +114,7 @@ async function refreshDispatchProject(
 		repo: input.repos.projects,
 		config: input.projectsConfig,
 		id: project.id,
-		token: input.gitToken,
+		gitCredential: input.gitCredential,
 		spawn: input.spawn,
 		...(input.ref !== undefined ? { ref: input.ref } : {}),
 		...(input.now !== undefined ? { now: input.now } : {}),

--- a/src/plan-runs/dispatch.ts
+++ b/src/plan-runs/dispatch.ts
@@ -22,6 +22,8 @@
  */
 
 import type { Repos } from "../db/repos/index.ts";
+import type { Forge } from "../forge/contract.ts";
+import { mintGitCredential } from "../forge/credentials.ts";
 import type { SpawnFn } from "../projects/clone.ts";
 import type { ProjectsConfig } from "../projects/config.ts";
 import { spawnRun } from "../runs/index.ts";
@@ -45,8 +47,12 @@ export interface CreatePlanRunSpawnInput {
 	readonly warrenConfigs: WarrenConfigCache;
 	readonly projectsConfig: ProjectsConfig;
 	readonly projectSpawn: SpawnFn;
-	/** Raw `GITHUB_TOKEN` for the pre-dispatch refresh fetch — see `SpawnRunInput.githubToken`. */
-	readonly githubToken?: string;
+	/**
+	 * Boot-resolved forge. The pre-dispatch refresh fetch mints its credential
+	 * HERE, per dispatch (forge-contract.md §4), instead of the boot-captured
+	 * `GITHUB_TOKEN` this used to hold across the coordinator's whole lifetime.
+	 */
+	readonly forge?: Forge;
 	readonly seedsCli: SeedsCliDeps;
 	/** Boot-resolved IssueTracker (warren-5819) — threading seam for the child spawn. */
 	readonly issueTracker?: IssueTracker;
@@ -61,6 +67,8 @@ export function createPlanRunSpawn(input: CreatePlanRunSpawnInput): CoordinatorS
 	return async ({ planRun, child, prompt }) => {
 		const project = await input.repos.projects.require(planRun.projectId);
 		const ref = planRun.ref ?? project.defaultBranch;
+		const gitCredential =
+			input.forge === undefined ? undefined : await mintGitCredential(input.forge, project.gitUrl);
 		const result = await spawnRunFn({
 			repos: input.repos,
 			runtimeProvider: input.runtimeProvider,
@@ -85,7 +93,7 @@ export function createPlanRunSpawn(input: CreatePlanRunSpawnInput): CoordinatorS
 			},
 			projectsConfig: input.projectsConfig,
 			projectSpawn: input.projectSpawn,
-			githubToken: input.githubToken,
+			gitCredential,
 			warrenConfigs: input.warrenConfigs,
 			seedsCli: input.seedsCli,
 			...(input.issueTracker !== undefined ? { issueTracker: input.issueTracker } : {}),

--- a/src/projects/clone.test.ts
+++ b/src/projects/clone.test.ts
@@ -240,7 +240,7 @@ describe("cloneProjectRepo", () => {
 			gitUrl: "https://github.com/x/private.git",
 			owner: "x",
 			name: "private",
-			token: "ghp_secret",
+			gitCredential: { username: "x-access-token", secret: "ghp_secret", host: "github.com" },
 			spawn,
 			exists: fs.exists,
 			mkdirp: fs.mkdirp,

--- a/src/projects/clone.ts
+++ b/src/projects/clone.ts
@@ -24,7 +24,8 @@ import { existsSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { formatError } from "../core/errors.ts";
-import { githubCredentialGitEnv } from "../workspace/git/credential-env.ts";
+import type { GitSpawnCredential } from "../workspace/git/credential-env.ts";
+import { gitCredentialGitEnv } from "../workspace/git/credential-env.ts";
 import type { ProjectsConfig } from "./config.ts";
 import { ProjectUnavailableError } from "./errors.ts";
 
@@ -123,13 +124,13 @@ export interface CloneProjectInput {
 	/**
 	 * GitHub token for private-repo access (`GITHUB_TOKEN` at the HTTP
 	 * boundary). Applied as a process-scoped `insteadOf` rewrite via
-	 * `githubCredentialGitEnv` on the network-touching git spawns (clone,
+	 * `gitCredentialGitEnv` on the network-touching git spawns (clone,
 	 * `remote set-head`) — never in argv, never persisted to the clone's
 	 * config. Absent/empty → anonymous clone, exactly the old behavior.
 	 * The supervisor's global rule covers the local topology; this covers
 	 * `warren serve` running bare (K8s pod), where no global rule exists.
 	 */
-	readonly token?: string;
+	readonly gitCredential?: GitSpawnCredential;
 	readonly spawn: SpawnFn;
 	readonly timeoutMs?: number;
 	/** Filesystem probes — overrideable for tests. */
@@ -162,7 +163,7 @@ export async function cloneProjectRepo(input: CloneProjectInput): Promise<CloneP
 
 	// No token → no `env` key at all, so anonymous public-repo clones spawn
 	// exactly as before (plain inheritance, nothing for tests to see).
-	const credEnv = githubCredentialGitEnv(input.token);
+	const credEnv = gitCredentialGitEnv(input.gitCredential);
 	const netEnv = Object.keys(credEnv).length > 0 ? { env: credEnv } : {};
 
 	const cloneCmd = [config.gitBinary, "clone", gitUrl, localPath];

--- a/src/projects/manage.ts
+++ b/src/projects/manage.ts
@@ -38,6 +38,7 @@ import type { ProjectRow } from "../db/schema.ts";
 import type { Forge } from "../forge/contract.ts";
 import type { BridgeLogger } from "../runs/stream/index.ts";
 import type { WarrenConfigCache } from "../warren-config/index.ts";
+import type { GitSpawnCredential } from "../workspace/git/credential-env.ts";
 import {
 	type CloneProjectResult,
 	cloneProjectRepo,
@@ -83,7 +84,7 @@ export interface AddProjectInput {
 	 * `cloneProjectRepo` — see `CloneProjectInput.token`. Absent/empty →
 	 * anonymous clone.
 	 */
-	readonly token?: string;
+	readonly gitCredential?: GitSpawnCredential;
 	readonly spawn: SpawnFn;
 	readonly timeoutMs?: number;
 	readonly now?: () => Date;
@@ -134,7 +135,7 @@ export async function addProject(input: AddProjectInput): Promise<ProjectRow> {
 		owner: parsed.owner,
 		name: parsed.name,
 		defaultBranch: input.defaultBranch,
-		token: input.token,
+		gitCredential: input.gitCredential,
 		spawn: input.spawn,
 		timeoutMs: input.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
 	});
@@ -169,7 +170,7 @@ export interface RefreshProjectInput {
 	 * GitHub token for private-repo fetches (`GITHUB_TOKEN`), forwarded to
 	 * `refreshProjectClone` — see `RefreshProjectCloneInput.token`.
 	 */
-	readonly token?: string;
+	readonly gitCredential?: GitSpawnCredential;
 	readonly spawn: SpawnFn;
 	readonly timeoutMs?: number;
 	readonly now?: () => Date;
@@ -230,7 +231,7 @@ export async function refreshProject(input: RefreshProjectInput): Promise<Refres
 		localPath: row.localPath,
 		ref,
 		...(input.fetchCommit !== undefined ? { fetchCommit: input.fetchCommit } : {}),
-		token: input.token,
+		gitCredential: input.gitCredential,
 		spawn: input.spawn,
 		timeoutMs: input.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
 		armHooks,

--- a/src/projects/refresh.test.ts
+++ b/src/projects/refresh.test.ts
@@ -103,7 +103,7 @@ describe("refreshProjectClone", () => {
 			config: CFG,
 			localPath: "/data/projects/x/y",
 			ref: "main",
-			token: "ghp_secret",
+			gitCredential: { username: "x-access-token", secret: "ghp_secret", host: "github.com" },
 			spawn,
 			exists: () => true,
 		});

--- a/src/projects/refresh.ts
+++ b/src/projects/refresh.ts
@@ -24,7 +24,8 @@
  */
 
 import { existsSync } from "node:fs";
-import { githubCredentialGitEnv } from "../workspace/git/credential-env.ts";
+import type { GitSpawnCredential } from "../workspace/git/credential-env.ts";
+import { gitCredentialGitEnv } from "../workspace/git/credential-env.ts";
 import { detectProjectFeatures, type ProjectFeatureFlags } from "./capabilities.ts";
 import type { SpawnFn, SpawnOptions, SpawnResult } from "./clone.ts";
 import type { ProjectsConfig } from "./config.ts";
@@ -64,11 +65,11 @@ export interface RefreshProjectCloneInput {
 	/**
 	 * GitHub token for private-repo access (`GITHUB_TOKEN` at the HTTP
 	 * boundary). Applied to the `git fetch` spawn as a process-scoped
-	 * `insteadOf` rewrite (`githubCredentialGitEnv`) so a bare `warren
+	 * `insteadOf` rewrite (`gitCredentialGitEnv`) so a bare `warren
 	 * serve` (K8s pod, no supervisor-installed global rule) can refresh a
 	 * private clone. Absent/empty → anonymous fetch, the old behavior.
 	 */
-	readonly token?: string;
+	readonly gitCredential?: GitSpawnCredential;
 	readonly spawn: SpawnFn;
 	readonly timeoutMs?: number;
 	readonly exists?: (path: string) => boolean;
@@ -121,7 +122,7 @@ export async function refreshProjectClone(
 	}
 
 	// No token → no `env` key, plain inheritance (see CloneProjectInput.token).
-	const credEnv = githubCredentialGitEnv(input.token);
+	const credEnv = gitCredentialGitEnv(input.gitCredential);
 	const netEnv: Pick<SpawnOptions, "env"> = Object.keys(credEnv).length > 0 ? { env: credEnv } : {};
 	// warren-232d: fetch-only mode for baseCommit dispatches. The shared host
 	// clone's HEAD is never moved — the workspace is cut at the pinned SHA

--- a/src/runs/reap/clone-apply.test.ts
+++ b/src/runs/reap/clone-apply.test.ts
@@ -292,7 +292,7 @@ describe("pushCloneDeltasToOrigin (warren-486c durability + warren-4e1c credenti
 		// Minted from the forge (FakeForge's static secret), per-spawn — never held.
 		expect(push?.env?.GIT_CONFIG_COUNT).toBe("1");
 		expect(push?.env?.GIT_CONFIG_KEY_0).toBe(
-			"url.https://x-access-token:fake-credential@github.com/.insteadOf",
+			"url.https://fake:fake-credential@github.com/.insteadOf",
 		);
 		expect(push?.env?.GIT_CONFIG_VALUE_0).toBe("https://github.com/");
 		// The repo-context scrub still rides alongside the credential.

--- a/src/runs/reap/clone-apply.ts
+++ b/src/runs/reap/clone-apply.ts
@@ -42,9 +42,9 @@ import {
 	warrenCommitIdentityArgs,
 	warrenCommitIdentityEnv,
 } from "../../bot-identity.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import type { FinalizeResult } from "../../runtime/contract.ts";
-import { githubCredentialGitEnv } from "../../workspace/git/credential-env.ts";
+import { gitCredentialGitEnv } from "../../workspace/git/credential-env.ts";
 import { isCommitSha } from "../base-commit.ts";
 import { hasAutoPlanRunFrontmatter } from "./auto-plan-run.ts";
 import type { ReapPipelineContext, ReapPipelineState } from "./pipeline.ts";
@@ -210,12 +210,12 @@ export async function pushCloneDeltasToOrigin(
 		// suppressed auto-dispatch, exactly like a rejected push.
 		const secret =
 			ctx.input.forge !== undefined
-				? await mintGitCredentialSecret(ctx.input.forge, ctx.project.gitUrl)
+				? await mintGitCredential(ctx.input.forge, ctx.project.gitUrl)
 				: undefined;
 		await ctx.exec.run("git", ["push", "origin", `HEAD:${ref}`], {
 			cwd: ctx.project.localPath,
 			timeoutMs: PUSH_TIMEOUT_MS,
-			env: { ...gitRepoContextScrubEnv(), ...githubCredentialGitEnv(secret) },
+			env: { ...gitRepoContextScrubEnv(), ...gitCredentialGitEnv(secret) },
 		});
 		await ctx.emit("reap.clone_deltas_pushed", { ref });
 		return true;

--- a/src/runs/reap/finalize-intent.ts
+++ b/src/runs/reap/finalize-intent.ts
@@ -5,8 +5,9 @@
  * per-spawn minted push credential.
  */
 
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import type { FinalizeIntent, FinalizeResult, RunHandle } from "../../runtime/contract.ts";
+import type { GitSpawnCredential } from "../../workspace/git/credential-env.ts";
 import type { ReapPipelineContext } from "./pipeline.ts";
 import { seededArtifactResetPaths } from "./seed-reset.ts";
 
@@ -25,10 +26,10 @@ export async function runProviderFinalize(ctx: ReapPipelineContext): Promise<Fin
 	// A mint failure is recorded and degrades to an anonymous push, which fails
 	// closed as a `branch_push` stage failure on a private repo — rather than
 	// skipping the merges wholesale.
-	let gitToken: string | undefined;
+	let gitCredential: GitSpawnCredential | undefined;
 	if (ctx.input.forge !== undefined) {
 		try {
-			gitToken = await mintGitCredentialSecret(ctx.input.forge, ctx.project.gitUrl);
+			gitCredential = await mintGitCredential(ctx.input.forge, ctx.project.gitUrl);
 		} catch (err) {
 			await ctx.fail("branch_push", err);
 		}
@@ -36,7 +37,7 @@ export async function runProviderFinalize(ctx: ReapPipelineContext): Promise<Fin
 	const intent: FinalizeIntent = {
 		branch: ctx.branch ?? "",
 		push: true,
-		...(gitToken !== undefined ? { gitToken } : {}),
+		...(gitCredential !== undefined ? { gitCredential } : {}),
 		// Opaque artifact keys the domain asks the provider to merge (warren-df3e);
 		// the returned `FinalizeResult.artifacts` is keyed the same way.
 		artifacts: ["mulch", "seeds", "plans"],

--- a/src/runs/reap/outcome-facts.ts
+++ b/src/runs/reap/outcome-facts.ts
@@ -17,8 +17,9 @@
  */
 
 import type { Forge } from "../../forge/contract.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import { authenticatedCloneUrl } from "../../workspace/git/clone-url.ts";
+import type { GitSpawnCredential } from "../../workspace/git/credential-env.ts";
 import type { BoundBridgeLogger } from "../stream/index.ts";
 import type { ReapExec } from "./types.ts";
 
@@ -115,22 +116,22 @@ async function measureDiffStats(input: RecordOutcomeFactsInput): Promise<DiffSta
 	// and read the range there (warren-ab66 posture). Requires the push to
 	// have landed and a forge credential for the fetch.
 	if (!input.branchPushed || input.branch === null || input.forge === undefined) return null;
-	const token = await mintGitCredentialSecret(input.forge, input.project.gitUrl).catch(() => {
+	const gitCredential = await mintGitCredential(input.forge, input.project.gitUrl).catch(() => {
 		return undefined;
 	});
-	if (token === undefined) return null;
-	return numstatFromClone(input, token);
+	if (gitCredential === undefined) return null;
+	return numstatFromClone(input, gitCredential);
 }
 
 /** Fetch `branch` into the clone under a private temp ref, read numstat, delete the ref. */
 async function numstatFromClone(
 	input: RecordOutcomeFactsInput,
-	token: string,
+	gitCredential: GitSpawnCredential,
 ): Promise<DiffStats | null> {
 	const { branch, baseBranch, runId, exec, project } = input;
 	if (branch === null || baseBranch === null) return null;
 	const tempRef = `${FETCH_REF_PREFIX}${runId}`;
-	const url = authenticatedCloneUrl(project.gitUrl, token);
+	const url = authenticatedCloneUrl(project.gitUrl, gitCredential.secret);
 	try {
 		await exec.run("git", ["fetch", "--no-tags", "--force", url, `${branch}:${tempRef}`], {
 			cwd: project.localPath,

--- a/src/runs/reap/outcome-facts.ts
+++ b/src/runs/reap/outcome-facts.ts
@@ -131,7 +131,7 @@ async function numstatFromClone(
 	const { branch, baseBranch, runId, exec, project } = input;
 	if (branch === null || baseBranch === null) return null;
 	const tempRef = `${FETCH_REF_PREFIX}${runId}`;
-	const url = authenticatedCloneUrl(project.gitUrl, gitCredential.secret);
+	const url = authenticatedCloneUrl(project.gitUrl, gitCredential);
 	try {
 		await exec.run("git", ["fetch", "--no-tags", "--force", url, `${branch}:${tempRef}`], {
 			cwd: project.localPath,

--- a/src/runs/reap/pr-context.ts
+++ b/src/runs/reap/pr-context.ts
@@ -156,7 +156,7 @@ async function collectFromClone(
 	cfg: CloneFetchConfig,
 ): Promise<CommitStats> {
 	const tempRef = `${CLONE_FETCH_REF_PREFIX}${cfg.runId}`;
-	const url = authenticatedCloneUrl(cfg.gitUrl, cfg.gitCredential.secret);
+	const url = authenticatedCloneUrl(cfg.gitUrl, cfg.gitCredential);
 	try {
 		// Fetch only the run branch into a namespaced temp ref (never a local
 		// branch); `--force` lets a re-reap overwrite a stale ref.

--- a/src/runs/reap/pr-context.ts
+++ b/src/runs/reap/pr-context.ts
@@ -13,6 +13,7 @@
 
 import type { IssueTracker, TrackerContext } from "../../tracker/contract.ts";
 import { authenticatedCloneUrl } from "../../workspace/git/clone-url.ts";
+import type { GitSpawnCredential } from "../../workspace/git/credential-env.ts";
 import type { PrCommit, PrSeed } from "../pr.ts";
 import type { ReapExec } from "./types.ts";
 
@@ -36,11 +37,11 @@ export interface CloneFetchConfig {
 	readonly gitUrl: string;
 	/**
 	 * Per-fetch git credential secret, minted from the forge immediately before
-	 * the fetch (`mintGitCredentialSecret`, warren-45e6 — credentials are
+	 * the fetch (`mintGitCredential`, warren-45e6: credentials are
 	 * minted, never held; forge-contract.md §4). Injected as the clone URL's
 	 * userinfo by `authenticatedCloneUrl`.
 	 */
-	readonly token: string;
+	readonly gitCredential: GitSpawnCredential;
 }
 
 export interface GatherPrContextInput {
@@ -155,7 +156,7 @@ async function collectFromClone(
 	cfg: CloneFetchConfig,
 ): Promise<CommitStats> {
 	const tempRef = `${CLONE_FETCH_REF_PREFIX}${cfg.runId}`;
-	const url = authenticatedCloneUrl(cfg.gitUrl, cfg.token);
+	const url = authenticatedCloneUrl(cfg.gitUrl, cfg.gitCredential.secret);
 	try {
 		// Fetch only the run branch into a namespaced temp ref (never a local
 		// branch); `--force` lets a re-reap overwrite a stale ref.

--- a/src/runs/reap/pr-open.context.test.ts
+++ b/src/runs/reap/pr-open.context.test.ts
@@ -90,7 +90,12 @@ describe("gatherPrContext K8s clone fetch (warren-ab66)", () => {
 			baseBranch: "main",
 			prompt: "no seed here",
 			exec: realExec,
-			cloneFetch: { runBranch: "run-1", runId: "run-abc", gitUrl: origin, token: "" },
+			cloneFetch: {
+				runBranch: "run-1",
+				runId: "run-abc",
+				gitUrl: origin,
+				gitCredential: { username: "x-access-token", secret: "", host: "github.com" },
+			},
 		});
 		expect(ctx.commits.map((c) => c.subject)).toEqual(["feat: add a", "feat: add b"]);
 		for (const c of ctx.commits) expect(c.sha).toMatch(/^[0-9a-f]{40}$/);
@@ -113,7 +118,7 @@ describe("gatherPrContext K8s clone fetch (warren-ab66)", () => {
 				runBranch: "run-1",
 				runId: "run-def",
 				gitUrl: join(root, "does-not-exist"),
-				token: "",
+				gitCredential: { username: "x-access-token", secret: "", host: "github.com" },
 			},
 			emit: async (kind, payload) => {
 				emitted.push({ kind, payload });
@@ -150,7 +155,12 @@ describe("gatherPrContext K8s clone fetch (warren-ab66)", () => {
 			prompt: "no seed here",
 			exec: realExec,
 			// Present but must be ignored because workspacePath !== null.
-			cloneFetch: { runBranch: "run-1", runId: "run-ghi", gitUrl: origin, token: "" },
+			cloneFetch: {
+				runBranch: "run-1",
+				runId: "run-ghi",
+				gitUrl: origin,
+				gitCredential: { username: "x-access-token", secret: "", host: "github.com" },
+			},
 		});
 		expect(ctx.commits.map((c) => c.subject)).toEqual(["feat: add a", "feat: add b"]);
 		expect(ctx.diffStat).toContain("a.ts");
@@ -183,7 +193,12 @@ describe("gatherPrContext K8s clone fetch (warren-ab66)", () => {
 			baseBranch: "main",
 			prompt: "no seed here",
 			exec: realExec,
-			cloneFetch: { runBranch: "run-1", runId: "run-body", gitUrl: origin, token: "" },
+			cloneFetch: {
+				runBranch: "run-1",
+				runId: "run-body",
+				gitUrl: origin,
+				gitCredential: { username: "x-access-token", secret: "", host: "github.com" },
+			},
 		});
 		expect(ctx.finalCommitBody).toBe(
 			"Rationale: the seam was already there.\n\nHandoff: watch the retry path.",
@@ -198,7 +213,12 @@ describe("gatherPrContext K8s clone fetch (warren-ab66)", () => {
 			baseBranch: "main",
 			prompt: "no seed here",
 			exec: realExec,
-			cloneFetch: { runBranch: "run-1", runId: "run-nobody", gitUrl: origin, token: "" },
+			cloneFetch: {
+				runBranch: "run-1",
+				runId: "run-nobody",
+				gitUrl: origin,
+				gitCredential: { username: "x-access-token", secret: "", host: "github.com" },
+			},
 		});
 		expect(ctx.finalCommitBody).toBeNull();
 	});

--- a/src/runs/reap/pr-open.ts
+++ b/src/runs/reap/pr-open.ts
@@ -1,6 +1,6 @@
 import { CI_FIXER_TRIGGER } from "../../ci-fixer/poller.ts";
 import type { Forge, ForgeErrorKind, PullRequestRef, RepoRef } from "../../forge/contract.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import type { IssueTracker } from "../../tracker/contract.ts";
 import { type AutoOpenPrConfig, type BuildPrContentInput, buildPrContent } from "../pr.ts";
 import type { PrTemplateOverrides } from "../pr-template.ts";
@@ -218,13 +218,13 @@ async function resolveCloneFetchConfig(
 	input: RunPrOpenInput,
 ): Promise<CloneFetchConfig | undefined> {
 	if (input.workspacePath !== null) return undefined;
-	const secret = await mintGitCredentialSecret(input.forge, input.project.gitUrl);
-	if (secret === undefined) return undefined;
+	const gitCredential = await mintGitCredential(input.forge, input.project.gitUrl);
+	if (gitCredential === undefined) return undefined;
 	return {
 		runBranch: input.branch,
 		runId: input.run.id,
 		gitUrl: input.project.gitUrl,
-		token: secret,
+		gitCredential,
 	};
 }
 

--- a/src/runs/reap/run.k8s.test.ts
+++ b/src/runs/reap/run.k8s.test.ts
@@ -163,7 +163,11 @@ describe("reapRun under a K8s-style RuntimeProvider", () => {
 		expect(result.state).toBe("succeeded");
 		// Minted from the forge (FakeForge's static secret) immediately before
 		// the finalize call — never read off a config object.
-		expect(fake.calls.lastIntent?.gitToken).toBe("fake-credential");
+		expect(fake.calls.lastIntent?.gitCredential).toEqual({
+			username: "fake",
+			secret: "fake-credential",
+			host: "github.com",
+		});
 	});
 
 	test("no forge on the reap input leaves the finalize intent credential-free", async () => {
@@ -181,7 +185,7 @@ describe("reapRun under a K8s-style RuntimeProvider", () => {
 			exec: e.exec,
 		});
 
-		expect(fake.calls.lastIntent && "gitToken" in fake.calls.lastIntent).toBe(false);
+		expect(fake.calls.lastIntent && "gitCredential" in fake.calls.lastIntent).toBe(false);
 	});
 
 	test("applies finalize mirror deltas to the project clone (leg 2)", async () => {

--- a/src/runs/reap/run.salvage.test.ts
+++ b/src/runs/reap/run.salvage.test.ts
@@ -90,7 +90,7 @@ describe("reapRun salvage-before-destroy (warren-cd3b)", () => {
 		expect(pushes.length).toBeGreaterThanOrEqual(2);
 		for (const push of pushes) {
 			expect(push.env?.GIT_CONFIG_KEY_0).toBe(
-				"url.https://x-access-token:fake-credential@github.com/.insteadOf",
+				"url.https://fake:fake-credential@github.com/.insteadOf",
 			);
 			expect(push.env?.GIT_CONFIG_VALUE_0).toBe("https://github.com/");
 		}

--- a/src/runs/reap/run.ts
+++ b/src/runs/reap/run.ts
@@ -1,6 +1,7 @@
 import type { EventRow, RunFailureReason, RunTerminalState } from "../../db/schema.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import type { RunHandle, RuntimeProvider, WorkspaceInfo } from "../../runtime/contract.ts";
+import type { GitSpawnCredential } from "../../workspace/git/credential-env.ts";
 import { lifecycleBus } from "../lifecycle-bus.ts";
 import { isInfraLostRunFailure } from "../retry/infra-lost-retry.ts";
 import { bindBridgeLogger } from "../stream/index.ts";
@@ -278,10 +279,10 @@ export async function reapRun(input: ReapRunInput): Promise<ReapRunResult> {
 		// salvage spawn (forge-contract.md §4 — minted, never held). A mint
 		// failure is recorded and degrades to an anonymous push (which fails
 		// closed on a private repo) rather than skipping the salvage.
-		let gitToken: string | undefined;
+		let gitCredential: GitSpawnCredential | undefined;
 		if (input.forge !== undefined && project !== null) {
 			try {
-				gitToken = await mintGitCredentialSecret(input.forge, project.gitUrl);
+				gitCredential = await mintGitCredential(input.forge, project.gitUrl);
 			} catch (err) {
 				await fail("branch_push", err);
 			}
@@ -291,7 +292,7 @@ export async function reapRun(input: ReapRunInput): Promise<ReapRunResult> {
 			workspacePath,
 			baseBranch,
 			...(input.salvageDir !== undefined ? { salvageDir: input.salvageDir } : {}),
-			...(gitToken !== undefined ? { gitToken } : {}),
+			...(gitCredential !== undefined ? { gitCredential } : {}),
 			exec,
 			fs,
 		});

--- a/src/runs/reap/salvage.test.ts
+++ b/src/runs/reap/salvage.test.ts
@@ -56,7 +56,11 @@ describe("salvageWorkspace (warren-cd3b)", () => {
 				return { stdout: "", stderr: "" };
 			},
 		};
-		const out = await salvageWorkspace({ ...input, exec, gitToken: "ghp_rescue" });
+		const out = await salvageWorkspace({
+			...input,
+			exec,
+			gitCredential: { username: "x-access-token", secret: "ghp_rescue", host: "github.com" },
+		});
 		expect(out.rescueRef).toBe("warren/rescue/run_x");
 		expect(envs[0]?.GIT_CONFIG_COUNT).toBe("1");
 		expect(envs[0]?.GIT_CONFIG_KEY_0).toBe(

--- a/src/runs/reap/salvage.ts
+++ b/src/runs/reap/salvage.ts
@@ -25,7 +25,8 @@
  */
 
 import { rescueBranchFor, salvageBundlePath } from "../../runtime/salvage.ts";
-import { githubCredentialGitEnv } from "../../workspace/git/credential-env.ts";
+import type { GitSpawnCredential } from "../../workspace/git/credential-env.ts";
+import { gitCredentialGitEnv } from "../../workspace/git/credential-env.ts";
 import type { ReapExec, ReapFs } from "./types.ts";
 
 export interface WorkspaceSalvageInput {
@@ -38,11 +39,11 @@ export interface WorkspaceSalvageInput {
 	/**
 	 * Per-spawn minted git credential for the rescue-ref push (warren-4e1c,
 	 * forge-contract.md §4 — minted by the caller immediately before this
-	 * call via `mintGitCredentialSecret`, never held on a config object).
+	 * call via `mintGitCredential`, never held on a config object).
 	 * Undefined ⇒ anonymous push, the pre-forge behavior for a forge that owns
 	 * no credential for the URL.
 	 */
-	readonly gitToken?: string;
+	readonly gitCredential?: GitSpawnCredential;
 	readonly exec: ReapExec;
 	readonly fs: ReapFs;
 }
@@ -78,7 +79,7 @@ export async function salvageWorkspace(
 		await input.exec.run("git", ["push", "origin", `HEAD:refs/heads/${branch}`], {
 			cwd: input.workspacePath,
 			timeoutMs: 60_000,
-			env: githubCredentialGitEnv(input.gitToken),
+			env: gitCredentialGitEnv(input.gitCredential),
 		});
 		rescueRef = branch;
 	} catch (err) {

--- a/src/runs/retry/infra-lost-retry.ts
+++ b/src/runs/retry/infra-lost-retry.ts
@@ -38,12 +38,15 @@
 
 import type { Repos } from "../../db/repos/index.ts";
 import type { RunFailureReason, RunRow } from "../../db/schema.ts";
+import type { Forge } from "../../forge/contract.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import type { SpawnFn as ProjectSpawnFn } from "../../projects/clone.ts";
 import type { ProjectsConfig } from "../../projects/config.ts";
 import type { RuntimeProvider } from "../../runtime/contract.ts";
 import type { SeedsCliDeps } from "../../seeds-cli/index.ts";
 import type { IssueTracker } from "../../tracker/contract.ts";
 import type { WarrenConfigCache } from "../../warren-config/index.ts";
+import type { GitSpawnCredential } from "../../workspace/git/credential-env.ts";
 import { resolveCostCapUsd } from "../cost-cap.ts";
 import type { RunEventBroker } from "../events.ts";
 import { spawnRun } from "../spawn/dispatch.ts";
@@ -152,12 +155,14 @@ type RetrySpawnDraft = {
  * cognitive-complexity ceiling where conditional spreads would not.
  */
 function buildRetrySpawnInput(
+	gitCredential: GitSpawnCredential | undefined,
 	input: CreateInfraLostRetryHookInput,
 	run: RunRow,
 	projectId: string,
 	decision: InfraLostRetryDecision,
 ): SpawnRunInput {
 	const draft: RetrySpawnDraft = {
+		...(gitCredential !== undefined ? { gitCredential } : {}),
 		repos: input.repos,
 		runtimeProvider: input.runtimeProvider,
 		agentName: run.agentName,
@@ -181,7 +186,6 @@ function buildRetrySpawnInput(
 	if (input.warrenConfigs !== undefined) draft.warrenConfigs = input.warrenConfigs;
 	if (input.seedsCli !== undefined) draft.seedsCli = input.seedsCli;
 	if (input.issueTracker !== undefined) draft.issueTracker = input.issueTracker;
-	if (input.githubToken !== undefined) draft.githubToken = input.githubToken;
 	if (input.runBranchPrefixDefault !== undefined) {
 		draft.runBranchPrefixDefault = input.runBranchPrefixDefault;
 	}
@@ -206,8 +210,12 @@ export interface CreateInfraLostRetryHookInput {
 	readonly seedsCli?: SeedsCliDeps;
 	/** Boot-resolved IssueTracker (warren-5819) — threading seam for the retry spawn. */
 	readonly issueTracker?: IssueTracker;
-	/** Raw `GITHUB_TOKEN` for the pre-dispatch refresh fetch. */
-	readonly githubToken?: string;
+	/**
+	 * Boot-resolved forge. The retry's pre-dispatch refresh fetch mints its
+	 * credential HERE, per dispatch (forge-contract.md §4), rather than
+	 * holding a boot-read `GITHUB_TOKEN` across the process lifetime.
+	 */
+	readonly forge?: Forge;
 	readonly runBranchPrefixDefault?: string;
 	/** Live tail fan-out for the linkage events; omit in tests. */
 	readonly broker?: RunEventBroker;
@@ -258,7 +266,14 @@ export function createInfraLostRetryHook(input: CreateInfraLostRetryHookInput): 
 		const projectId = run.projectId;
 		if (projectId === null) return;
 		try {
-			const result = await spawnRunFn(buildRetrySpawnInput(input, run, projectId, decision));
+			const project = await input.repos.projects.get(projectId);
+			const gitCredential =
+				input.forge !== undefined && project !== null
+					? await mintGitCredential(input.forge, project.gitUrl)
+					: undefined;
+			const result = await spawnRunFn(
+				buildRetrySpawnInput(gitCredential, input, run, projectId, decision),
+			);
 			input.bridges.start(result.run.id, result.sandboxRun.id, result.sandbox.id, run.mode);
 			// Linkage in both directions so an operator tailing either run can
 			// follow the chain (warren-4af7).

--- a/src/runs/retry/provider-retry.ts
+++ b/src/runs/retry/provider-retry.ts
@@ -43,7 +43,7 @@
 import type { Repos } from "../../db/repos/index.ts";
 import type { EventRow } from "../../db/schema.ts";
 import type { Forge } from "../../forge/contract.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import type { SpawnFn as ProjectSpawnFn } from "../../projects/clone.ts";
 import type { ProjectsConfig } from "../../projects/config.ts";
 import type { RuntimeProvider } from "../../runtime/contract.ts";
@@ -295,9 +295,9 @@ async function dispatchProviderRetry(
 	const emit = makeRunEventEmitter(input, now);
 	try {
 		const project = await input.repos.projects.get(run.projectId);
-		const gitSecret =
+		const gitCredential =
 			input.forge !== undefined && project !== null
-				? await mintGitCredentialSecret(input.forge, project.gitUrl)
+				? await mintGitCredential(input.forge, project.gitUrl)
 				: undefined;
 		const spawnRunFn = input.spawnRunFn ?? spawnRun;
 		const result = await spawnRunFn({
@@ -325,7 +325,7 @@ async function dispatchProviderRetry(
 			retryOf: run.id,
 			projectsConfig: input.projectsConfig,
 			projectSpawn: input.projectSpawn,
-			githubToken: gitSecret,
+			gitCredential,
 			...(input.warrenConfigs !== undefined ? { warrenConfigs: input.warrenConfigs } : {}),
 			...(input.runBranchPrefixDefault !== undefined
 				? { runBranchPrefixDefault: input.runBranchPrefixDefault }

--- a/src/runs/spawn/dispatch.ts
+++ b/src/runs/spawn/dispatch.ts
@@ -105,7 +105,7 @@ async function dispatchRun(input: SpawnRunInput): Promise<SpawnRunResult> {
 						: baseRef !== undefined
 							? { ref: baseRef }
 							: {}),
-					token: input.githubToken,
+					gitCredential: input.gitCredential,
 					spawn: input.projectSpawn,
 					...(input.now !== undefined ? { now: input.now } : {}),
 					...(input.warrenConfigs !== undefined ? { warrenConfigs: input.warrenConfigs } : {}),

--- a/src/runs/spawn/types.ts
+++ b/src/runs/spawn/types.ts
@@ -14,6 +14,7 @@ import type { AgentDefinition } from "../../registry/schema.ts";
 import type { RuntimeProvider } from "../../runtime/contract.ts";
 import type { SeedsCliDeps } from "../../seeds-cli/index.ts";
 import type { WarrenConfigCache } from "../../warren-config/index.ts";
+import type { GitSpawnCredential } from "../../workspace/git/credential-env.ts";
 import type { MigrationHealFn } from "./migration-preflight.ts";
 
 /**
@@ -127,10 +128,10 @@ export interface SpawnRunInput {
 	/**
 	 * GitHub credential for the pre-dispatch refresh's `git fetch`
 	 * against a private repo (minted per-spawn via
-	 * `mintGitCredentialSecret`, forwarded to `refreshProject`).
+	 * `mintGitCredential`, forwarded to `refreshProject`).
 	 * Absent → anonymous.
 	 */
-	readonly githubToken?: string;
+	readonly gitCredential?: GitSpawnCredential;
 	/** Branch, tag, or SHA to refresh to. Defaults to the project's tracked default branch. */
 	readonly ref?: string;
 	/**

--- a/src/runtime/contract.ts
+++ b/src/runtime/contract.ts
@@ -13,6 +13,7 @@ import type {
 	InboxState,
 	RunState,
 } from "../core/wire.ts";
+import type { GitSpawnCredential } from "../workspace/git/credential-env.ts";
 import type { ArtifactDelta } from "./finalize-deltas.ts";
 import type { FinalizeStage } from "./finalize-stages.ts";
 
@@ -321,11 +322,10 @@ export interface FinalizeIntent {
 	resetSeededPaths?: ReadonlyArray<{ path: string; contents: string }>;
 	/**
 	 * Per-spawn minted git credential for `branch_push` (warren-4e1c, forge
-	 * contract §4 — minted via `mintGitCredentialSecret` immediately before
+	 * contract §4: minted via `mintGitCredential` immediately before
 	 * `finalize`, never held on a config object). LocalProvider splices it into
-	 * the push's `GIT_CONFIG_*` env; K8s prefers it over the env-derived token.
-	 * Undefined ⇒ anonymous push. */
-	gitToken?: string;
+	 * the push's `GIT_CONFIG_*` env, K8s prefers it, undefined pushes anonymously. */
+	gitCredential?: GitSpawnCredential;
 }
 
 /**

--- a/src/runtime/k8s/finalize-collect.ts
+++ b/src/runtime/k8s/finalize-collect.ts
@@ -14,7 +14,7 @@
 
 import { join } from "node:path";
 import { parseDirtyPaths, repairBaseTrackingRef } from "../../runs/reap/util.ts";
-import { authenticatedCloneUrl } from "../../workspace/git/clone-url.ts";
+import { authenticatedCloneUrl, bareTokenCredential } from "../../workspace/git/clone-url.ts";
 import type {
 	ArtifactDelta,
 	ArtifactDeltaFile,
@@ -313,7 +313,7 @@ export async function authenticateOrigin(
 	const res = await git(["remote", "get-url", "origin"], { cwd: workspacePath });
 	if (res.exitCode !== 0) return async () => {};
 	const origin = res.stdout.trim();
-	const authed = authenticatedCloneUrl(origin, token);
+	const authed = authenticatedCloneUrl(origin, bareTokenCredential(token));
 	if (authed === origin) return async () => {};
 	const set = await git(["remote", "set-url", "origin", authed], { cwd: workspacePath });
 	if (set.exitCode !== 0) return async () => {};

--- a/src/runtime/k8s/git-tokens.ts
+++ b/src/runtime/k8s/git-tokens.ts
@@ -38,7 +38,7 @@ function normalizeToken(raw: string | undefined): string | undefined {
  * mint seam is wired (PAT mode without a forge handle keeps the static
  * Secret ref), when the domain already pinned `WARREN_GIT_TOKEN` on the
  * spec, or when the mint yields anonymous git (foreign host / no_credential
- * — see `mintGitCredentialSecret`). A genuine App-mode mint failure THROWS
+ * (see `mintGitCredential`). A genuine App-mode mint failure THROWS
  * (`GitCredentialMintError`) so the dispatch fails loud instead of cloning
  * with a credential the run will outlive.
  */

--- a/src/runtime/k8s/provider.finalize.test.ts
+++ b/src/runtime/k8s/provider.finalize.test.ts
@@ -78,7 +78,10 @@ describe("K8sProvider.finalize — wiring", () => {
 			finalizeCoordinator: coordinator,
 			finalizeSetTimer: inertTimer,
 		});
-		const p = provider.finalize(handle, { ...intent(), gitToken: "minted_per_spawn" });
+		const p = provider.finalize(handle, {
+			...intent(),
+			gitCredential: { username: "x-access-token", secret: "minted_per_spawn", host: "github.com" },
+		});
 		await Promise.resolve();
 		const parked = coordinator.peekIntent(handle.runId);
 		expect(parked?.gitToken).toBe("minted_per_spawn");
@@ -145,7 +148,10 @@ describe("K8sProvider.finalize — wiring", () => {
 			finalizeCoordinator: coordinator,
 			finalizeSetTimer: inertTimer,
 		});
-		const p = provider.finalize(handle, { ...intent(), gitToken: "ghs_minted" });
+		const p = provider.finalize(handle, {
+			...intent(),
+			gitCredential: { username: "x-access-token", secret: "ghs_minted", host: "github.com" },
+		});
 		await Promise.resolve();
 		const parked = coordinator.peekIntent(handle.runId);
 		expect(parked?.gitToken).toBe("ghs_minted");

--- a/src/runtime/k8s/provider.ts
+++ b/src/runtime/k8s/provider.ts
@@ -153,7 +153,7 @@ export interface K8sProviderDeps {
 	 * OPTIONAL git-credential mint seam (forge-contract.md §4.1, warren-c9ac).
 	 * `create()` mints the window-1 init-container clone credential at pod-spec
 	 * time so a short-lived App-mode token is fresh for the clone. Boot wires
-	 * this to `mintGitCredentialSecret` over the resolved forge; absent, the pod
+	 * this to `mintGitCredential` over the resolved forge; absent, the pod
 	 * spec keeps the static `warren-git-token` Secret ref (PAT-mode posture).
 	 */
 	readonly mintGitCredential?: (gitUrl: string) => Promise<string | undefined>;
@@ -469,13 +469,13 @@ export class K8sProvider implements RuntimeProvider {
 	 * The short-lived git push credential rides the intent (fetched over the
 	 * authenticated callback AFTER the agent exits), NOT the agent container's
 	 * static env — a compromised agent never holds the push token (blast-radius
-	 * minimization). warren-4e1c: the domain-minted `intent.gitToken` wins; absent,
+	 * minimization). warren-4e1c: the domain-minted `intent.gitCredential?.secret` wins; absent,
 	 * the static env fallback is gated on `allowStaticPushTokenFallback` (OFF under
 	 * App mode — warren-c9ac, `./git-tokens.ts`). */
 	finalize(handle: RunHandle, intent: FinalizeIntent): Promise<FinalizeResult> {
 		const env = this.deps.serverEnv ?? process.env;
 		const gitToken = resolveK8sPushToken({
-			intentToken: intent.gitToken,
+			intentToken: intent.gitCredential?.secret,
 			env,
 			allowStaticEnv: this.deps.allowStaticPushTokenFallback ?? true,
 		});

--- a/src/runtime/k8s/workspace-init.ts
+++ b/src/runtime/k8s/workspace-init.ts
@@ -65,7 +65,7 @@ import {
 } from "node:fs/promises";
 import { dirname, isAbsolute, join, normalize } from "node:path";
 import { WorkspaceMaterializationError } from "../../workspace/errors.ts";
-import { authenticatedCloneUrl } from "../../workspace/git/clone-url.ts";
+import { authenticatedCloneUrl, bareTokenCredential } from "../../workspace/git/clone-url.ts";
 import { runGit } from "../../workspace/git/exec.ts";
 import { parseSeedManifest } from "./seed-configmap.ts";
 
@@ -262,7 +262,7 @@ async function materializeViaCache(
 ): Promise<boolean> {
 	if (cfg.repoCacheDir === undefined) return false;
 	const mirrorPath = mirrorPathFor(cfg.repoCacheDir, cfg.repoUrl);
-	const authUrl = authenticatedCloneUrl(cfg.repoUrl, cfg.token);
+	const authUrl = authenticatedCloneUrl(cfg.repoUrl, bareTokenCredential(cfg.token));
 	try {
 		await ensureMirror(git, fs, cfg, mirrorPath, authUrl, log);
 		// Local clone from the mirror path — no network, no credentials.
@@ -290,7 +290,7 @@ async function directClone(
 	cfg: InitEnv,
 	log: (m: string) => void,
 ): Promise<void> {
-	const cloneUrl = authenticatedCloneUrl(cfg.repoUrl, cfg.token);
+	const cloneUrl = authenticatedCloneUrl(cfg.repoUrl, bareTokenCredential(cfg.token));
 	log(`workspace-init: cloning ${cfg.repoUrl} (${cfg.baseBranch}) into ${cfg.workspacePath}`);
 	await cloneBaseAndCarve(git, cfg, cloneUrl);
 	// Strip the embedded token so it never persists in the workspace .git/config.

--- a/src/runtime/local/finalize.test.ts
+++ b/src/runtime/local/finalize.test.ts
@@ -210,7 +210,12 @@ describe("finalize — stage trail + push reporting", () => {
 		const fs = fakeFs(fullSeed());
 		const exec = fakeExec({ revListCount: "3" });
 		const p = provider({ fs, exec, seedsPlansBody: "" });
-		const result = await p.finalize(HANDLE, intent({ gitToken: "ghp_pushsecret" }));
+		const result = await p.finalize(
+			HANDLE,
+			intent({
+				gitCredential: { username: "x-access-token", secret: "ghp_pushsecret", host: "github.com" },
+			}),
+		);
 		expect(result.pushed).toBe(true);
 		const push = exec.calls.find((c) => c.cmd === "git" && c.args[0] === "push");
 		expect(push?.env?.GIT_CONFIG_COUNT).toBe("1");

--- a/src/runtime/local/finalize.ts
+++ b/src/runtime/local/finalize.ts
@@ -42,7 +42,7 @@ import {
 	repairBaseTrackingRef,
 	workspaceDirtyPaths,
 } from "../../runs/reap/util.ts";
-import { githubCredentialGitEnv } from "../../workspace/git/credential-env.ts";
+import { gitCredentialGitEnv } from "../../workspace/git/credential-env.ts";
 import type {
 	ArtifactDelta,
 	ArtifactDeltaFile,
@@ -425,7 +425,7 @@ async function finalizePush(
 		await exec.run("git", ["push", "origin", refspec], {
 			cwd: workspacePath,
 			timeoutMs: 60_000,
-			env: githubCredentialGitEnv(intent.gitToken),
+			env: gitCredentialGitEnv(intent.gitCredential),
 		});
 		trail.ok("branch_push");
 	} catch (err) {

--- a/src/runtime/registry.ts
+++ b/src/runtime/registry.ts
@@ -129,7 +129,7 @@ export interface RuntimeProviderDeps {
 	/**
 	 * OPTIONAL git-credential mint seam for the K8s token windows
 	 * (forge-contract.md §4.1, warren-c9ac) — only consulted for
-	 * `WARREN_RUNTIME=k8s`. Boot wires it to `mintGitCredentialSecret` over the
+	 * `WARREN_RUNTIME=k8s`. Boot wires it to `mintGitCredential` over the
 	 * resolved forge so `create()` mints the init-container clone credential at
 	 * pod-spec time (window 1).
 	 */

--- a/src/server/handlers/alerts.ts
+++ b/src/server/handlers/alerts.ts
@@ -22,7 +22,7 @@
 
 import { ValidationError } from "../../core/errors.ts";
 import type { EventsRepo } from "../../db/repos/events.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import {
 	buildHealPrompt,
 	checkHealerRole,
@@ -188,7 +188,7 @@ async function dispatchHealer(
 	// warren-6c4c: mint the spawn's clone-refresh credential per-spawn through
 	// the boot forge (forge-contract.md §4); no config object holds a token.
 	const project = await deps.repos.projects.require(candidate.projectId);
-	const gitSecret = await mintGitCredentialSecret(deps.forge, project.gitUrl);
+	const gitSecret = await mintGitCredential(deps.forge, project.gitUrl);
 	const result = await spawnRun({
 		repos: deps.repos,
 		// warren-245d: dispatch through the resolved runtime provider so the
@@ -204,7 +204,7 @@ async function dispatchHealer(
 		metadata: { healFingerprint: alert.fingerprint, alertSource: alert.source },
 		projectsConfig: deps.projectsConfig,
 		projectSpawn: deps.spawn ?? defaultSpawn,
-		...(gitSecret !== undefined ? { githubToken: gitSecret } : {}),
+		...(gitSecret !== undefined ? { gitCredential: gitSecret } : {}),
 		...(deps.warrenConfigs !== undefined ? { warrenConfigs: deps.warrenConfigs } : {}),
 		...(deps.runBranchPrefixDefault !== undefined
 			? { runBranchPrefixDefault: deps.runBranchPrefixDefault }

--- a/src/server/handlers/plan-runs.ts
+++ b/src/server/handlers/plan-runs.ts
@@ -18,7 +18,7 @@ import {
 	PLAN_RUN_STATE_FILTERS,
 	type PlanRunStateFilter,
 } from "../../core/wire.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import {
 	buildDefaultPlanRunEmit,
 	cancelPlanRun,
@@ -88,7 +88,7 @@ export function createPlanRunHandler(deps: ServerDeps): RouteHandler {
 		// through the boot forge (forge-contract.md §4); no config object
 		// holds a token.
 		const project = await deps.repos.projects.require(projectId);
-		const gitSecret = await mintGitCredentialSecret(deps.forge, project.gitUrl);
+		const gitSecret = await mintGitCredential(deps.forge, project.gitUrl);
 		const result = await createPlanRun({
 			projectId,
 			...(planId !== undefined ? { planId } : {}),
@@ -104,7 +104,7 @@ export function createPlanRunHandler(deps: ServerDeps): RouteHandler {
 			issueTracker: deps.issueTracker,
 			projectsConfig: deps.projectsConfig,
 			...(deps.spawn !== undefined ? { spawn: deps.spawn } : {}),
-			...(gitSecret !== undefined ? { gitToken: gitSecret } : {}),
+			...(gitSecret !== undefined ? { gitCredential: gitSecret } : {}),
 			...(deps.warrenConfigs !== undefined ? { warrenConfigs: deps.warrenConfigs } : {}),
 			...(deps.refreshProjectFn !== undefined ? { refreshProjectFn: deps.refreshProjectFn } : {}),
 			...(deps.now !== undefined ? { now: deps.now } : {}),

--- a/src/server/handlers/projects.ts
+++ b/src/server/handlers/projects.ts
@@ -7,7 +7,7 @@
 
 import { NotFoundError, ValidationError } from "../../core/errors.ts";
 import type { TrackerContext } from "../../core/wire.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import { ProjectLacksTrackerError } from "../../plan-runs/errors.ts";
 import { computeReadyPlans, type ReadyPlanInput } from "../../plan-runs/index.ts";
 import type { ProjectRow } from "../../projects/index.ts";
@@ -117,7 +117,7 @@ export function createProjectHandler(deps: ServerDeps): RouteHandler {
 		// warren-6c4c: mint the private-repo credential for the host-side clone
 		// per-spawn through the boot forge (forge-contract.md §4); no config
 		// object holds a token.
-		const gitSecret = await mintGitCredentialSecret(deps.forge, gitUrl);
+		const gitSecret = await mintGitCredential(deps.forge, gitUrl);
 		const project = await addProject({
 			repo: deps.repos.projects,
 			config: deps.projectsConfig,
@@ -125,7 +125,7 @@ export function createProjectHandler(deps: ServerDeps): RouteHandler {
 			forge: deps.forge,
 			...(deps.publicAllowlist !== undefined ? { publicAllowlist: deps.publicAllowlist } : {}),
 			...(defaultBranch !== undefined ? { defaultBranch } : {}),
-			...(gitSecret !== undefined ? { token: gitSecret } : {}),
+			...(gitSecret !== undefined ? { gitCredential: gitSecret } : {}),
 			spawn: defaultSpawn,
 		});
 		return jsonResponse(201, project);
@@ -350,7 +350,7 @@ export function runProjectTriggerHandler(deps: ServerDeps): RouteHandler {
 		// warren-6c4c: mint per git spawn (forge-contract.md §4) — once for the
 		// refresh fetch below, again for spawnRun's internal clone refresh —
 		// — no config object holds a token. Static under PAT.
-		const refreshSecret = await mintGitCredentialSecret(deps.forge, required.gitUrl);
+		const refreshSecret = await mintGitCredential(deps.forge, required.gitUrl);
 
 		// Refresh the clone BEFORE reading the trigger entry. The cached
 		// config snapshot predates spawnRun's internal refresh, so without
@@ -365,7 +365,7 @@ export function runProjectTriggerHandler(deps: ServerDeps): RouteHandler {
 			repo: deps.repos.projects,
 			config: deps.projectsConfig,
 			id: required.id,
-			...(refreshSecret !== undefined ? { token: refreshSecret } : {}),
+			...(refreshSecret !== undefined ? { gitCredential: refreshSecret } : {}),
 			spawn: deps.spawn ?? defaultSpawn,
 			...(deps.now !== undefined ? { now: deps.now } : {}),
 			...(deps.warrenConfigs !== undefined ? { warrenConfigs: deps.warrenConfigs } : {}),
@@ -391,7 +391,7 @@ export function runProjectTriggerHandler(deps: ServerDeps): RouteHandler {
 		const prompt = resolveCronPrompt(trigger, loaded.defaults);
 		const now = deps.now?.() ?? new Date();
 
-		const spawnSecret = await mintGitCredentialSecret(deps.forge, required.gitUrl);
+		const spawnSecret = await mintGitCredential(deps.forge, required.gitUrl);
 		const result = await spawnRun({
 			repos: deps.repos,
 			// warren-245d: dispatch through the resolved runtime provider so the
@@ -418,7 +418,7 @@ export function runProjectTriggerHandler(deps: ServerDeps): RouteHandler {
 			...(deps.now !== undefined ? { now: deps.now } : {}),
 			projectsConfig: deps.projectsConfig,
 			projectSpawn: deps.spawn ?? defaultSpawn,
-			...(spawnSecret !== undefined ? { githubToken: spawnSecret } : {}),
+			...(spawnSecret !== undefined ? { gitCredential: spawnSecret } : {}),
 			...(deps.warrenConfigs !== undefined ? { warrenConfigs: deps.warrenConfigs } : {}),
 			...(deps.runBranchPrefixDefault !== undefined
 				? { runBranchPrefixDefault: deps.runBranchPrefixDefault }
@@ -473,13 +473,13 @@ export function refreshProjectHandler(deps: ServerDeps): RouteHandler {
 		// the boot forge (forge-contract.md §4). The project row is loaded for
 		// its gitUrl; refreshProject re-requires it internally.
 		const project = await deps.repos.projects.require(id);
-		const gitSecret = await mintGitCredentialSecret(deps.forge, project.gitUrl);
+		const gitSecret = await mintGitCredential(deps.forge, project.gitUrl);
 		const result = await refreshProject({
 			repo: deps.repos.projects,
 			config: deps.projectsConfig,
 			id,
 			...(ref !== undefined ? { ref } : {}),
-			...(gitSecret !== undefined ? { token: gitSecret } : {}),
+			...(gitSecret !== undefined ? { gitCredential: gitSecret } : {}),
 			spawn: deps.spawn ?? defaultSpawn,
 			...(deps.now !== undefined ? { now: deps.now } : {}),
 			...(deps.warrenConfigs !== undefined ? { warrenConfigs: deps.warrenConfigs } : {}),

--- a/src/server/handlers/runs.git-credential.test.ts
+++ b/src/server/handlers/runs.git-credential.test.ts
@@ -2,7 +2,7 @@
  * HTTP coverage for `POST /runs/:id/git-credential` (warren-c9ac,
  * forge-contract.md §4.1 window 3): the in-pod harness re-mints a push
  * credential over the authenticated callback when no reap intent parked one.
- * The handler resolves run → project → `mintGitCredentialSecret(deps.forge)`;
+ * The handler resolves run → project → `mintGitCredential(deps.forge)`;
  * FakeForge (depsFor's default) mints `fake-credential`.
  */
 

--- a/src/server/handlers/runs/dispatch.ts
+++ b/src/server/handlers/runs/dispatch.ts
@@ -1,9 +1,10 @@
 import { ValidationError } from "../../../core/errors.ts";
-import { mintGitCredentialSecret } from "../../../forge/credentials.ts";
+import { mintGitCredential } from "../../../forge/credentials.ts";
 import { readProviderFrontmatter } from "../../../registry/schema.ts";
 import { validateBaseCommit, validateDispatchRef } from "../../../runs/base-commit.ts";
 import { readMaxCostUsd } from "../../../runs/cost-cap.ts";
 import { spawnRun } from "../../../runs/index.ts";
+import type { GitSpawnCredential } from "../../../workspace/git/credential-env.ts";
 import type { IdempotentDispatch } from "../../idempotency.ts";
 import { jsonResponse } from "../../response.ts";
 import type { RouteHandler, ServerDeps } from "../../types.ts";
@@ -38,13 +39,13 @@ interface CloneDefaults {
  * the boot forge (forge-contract.md §4); no config object holds a token.
  * Extracted so `createRunHandler`'s complexity budget stays intact.
  */
-async function mintSpawnGithubToken(
+async function mintSpawnGitCredential(
 	deps: ServerDeps,
 	projectId: string,
-): Promise<{ githubToken?: string }> {
+): Promise<{ gitCredential?: GitSpawnCredential }> {
 	const project = await deps.repos.projects.require(projectId);
-	const secret = await mintGitCredentialSecret(deps.forge, project.gitUrl);
-	return secret !== undefined ? { githubToken: secret } : {};
+	const secret = await mintGitCredential(deps.forge, project.gitUrl);
+	return secret !== undefined ? { gitCredential: secret } : {};
 }
 
 async function resolveCloneDefaults(
@@ -176,7 +177,7 @@ async function buildHttpSpawnOptions(
 		mode: "batch",
 		projectsConfig: deps.projectsConfig,
 		projectSpawn: deps.spawn ?? defaultSpawn,
-		...(await mintSpawnGithubToken(deps, projectId)),
+		...(await mintSpawnGitCredential(deps, projectId)),
 		// warren-b27c: shape-checked, not cast.
 		metadata: optionalObject(body, "metadata"),
 		now: deps.now,

--- a/src/server/handlers/runs/git-credential.ts
+++ b/src/server/handlers/runs/git-credential.ts
@@ -9,7 +9,7 @@
  * it). The resolved design routes this window through the same authenticated
  * callback channel the intent poll already uses: the pod asks warren, warren
  * mints a FRESH credential off the boot-resolved forge
- * (`mintGitCredentialSecret`, §4 — minted, never held), and returns it in the
+ * (`mintGitCredential`, §4: minted, never held), and returns it in the
  * response body. Under App mode this is the ONLY credential path the salvage
  * window can rely on; the pod-side static env is a last resort for PAT mode.
  *
@@ -27,7 +27,7 @@
  */
 
 import { NotFoundError } from "../../../core/errors.ts";
-import { mintGitCredentialSecret } from "../../../forge/credentials.ts";
+import { mintGitCredential } from "../../../forge/credentials.ts";
 import { jsonResponse } from "../../response.ts";
 import type { RouteHandler, ServerDeps } from "../../types.ts";
 import { requireParam } from "../index.ts";
@@ -41,7 +41,10 @@ export function postRunGitCredentialHandler(deps: ServerDeps): RouteHandler {
 		if (project === null) {
 			throw new NotFoundError(`project ${run.projectId} for run ${id}`);
 		}
-		const gitToken = await mintGitCredentialSecret(deps.forge, project.gitUrl);
-		return jsonResponse(200, { gitToken: gitToken ?? null });
+		const gitCredential = await mintGitCredential(deps.forge, project.gitUrl);
+		// The in-pod wire carries the bare secret (the pod injects it into the
+		// origin URL rather than rendering an insteadOf rule), so the credential
+		// flattens here. warren-1b6f left that half of the wire alone.
+		return jsonResponse(200, { gitToken: gitCredential?.secret ?? null });
 	};
 }

--- a/src/server/main/index.ts
+++ b/src/server/main/index.ts
@@ -255,6 +255,7 @@ export async function bootServer(opts: BootServerOptions = {}): Promise<WarrenSe
 		warrenConfigs,
 		seedsCli,
 		issueTracker,
+		forge,
 		env,
 		logger,
 		projectSpawn: defaultSpawn,

--- a/src/server/main/plan-run-wiring.ts
+++ b/src/server/main/plan-run-wiring.ts
@@ -12,7 +12,7 @@
 
 import type { Repos } from "../../db/repos/index.ts";
 import type { Forge } from "../../forge/contract.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import {
 	bootPlanRunCoordinator,
 	type CoordinatorCloseChildSeedFn,
@@ -154,7 +154,7 @@ function createCloseChildSeed(deps: CloseChildSeedDeps): CoordinatorCloseChildSe
 			// immediately before the git spawns (forge-contract.md §4 — minted,
 			// never held) instead of reading a boot-captured env.GITHUB_TOKEN.
 			// Undefined → anonymous git, the old no-token behavior.
-			const gitSecret = await mintGitCredentialSecret(forge, project.gitUrl);
+			const gitSecret = await mintGitCredential(forge, project.gitUrl);
 			const result = await closeMergedChildSeed({
 				projectPath: project.localPath,
 				defaultBranch: project.defaultBranch,
@@ -165,7 +165,7 @@ function createCloseChildSeed(deps: CloseChildSeedDeps): CoordinatorCloseChildSe
 				gitBinary: projectsConfig.gitBinary,
 				// Minted per close so the fetch/push work against private repos
 				// on the K8s control plane (no supervisor insteadOf rule there).
-				githubToken: gitSecret,
+				gitCredential: gitSecret,
 			});
 			logger.info(
 				{ planRunId: planRun.id, seq: child.seq, seedId: child.seedId, outcome: result.kind },
@@ -268,9 +268,7 @@ export function bootPlanRunCoordinatorWiring(input: PlanRunWiringInput): PlanRun
 			warrenConfigs,
 			projectsConfig,
 			projectSpawn,
-			// Raw token for the pre-dispatch refresh fetch (private repos on
-			// the K8s control plane) — see SpawnRunInput.githubToken.
-			githubToken: env.GITHUB_TOKEN,
+			forge,
 			seedsCli,
 			...(issueTracker !== undefined ? { issueTracker } : {}),
 			...(runBranchPrefixDefault !== undefined ? { runBranchPrefixDefault } : {}),

--- a/src/server/main/retry-wiring.ts
+++ b/src/server/main/retry-wiring.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Repos } from "../../db/repos/index.ts";
+import type { Forge } from "../../forge/contract.ts";
 import type { SpawnFn } from "../../projects/clone.ts";
 import type { ProjectsConfig } from "../../projects/config.ts";
 import { createInfraLostRetryHook, type InfraLostRetryHook } from "../../runs/index.ts";
@@ -37,6 +38,8 @@ export interface InfraLostRetryWiringInput {
 	readonly seedsCli: SeedsCliDeps;
 	/** Boot-resolved IssueTracker (warren-5819) — forwarded to the retry hook. */
 	readonly issueTracker?: IssueTracker;
+	/** Boot-resolved forge, so the retry mints its refresh credential per dispatch. */
+	readonly forge?: Forge;
 	readonly env: EnvLike;
 	readonly runBranchPrefixDefault?: string;
 	readonly logger: Logger;
@@ -64,7 +67,7 @@ export function wireInfraLostRetry(input: InfraLostRetryWiringInput): InfraLostR
 			warrenConfigs: input.warrenConfigs,
 			seedsCli: input.seedsCli,
 			...(input.issueTracker !== undefined ? { issueTracker: input.issueTracker } : {}),
-			...(input.env.GITHUB_TOKEN !== undefined ? { githubToken: input.env.GITHUB_TOKEN } : {}),
+			...(input.forge !== undefined ? { forge: input.forge } : {}),
 			...(input.runBranchPrefixDefault !== undefined
 				? { runBranchPrefixDefault: input.runBranchPrefixDefault }
 				: {}),

--- a/src/server/main/runtime-wiring.ts
+++ b/src/server/main/runtime-wiring.ts
@@ -38,7 +38,7 @@ import {
 	Watch,
 } from "@kubernetes/client-node";
 import type { Forge } from "../../forge/contract.ts";
-import { mintGitCredentialSecret } from "../../forge/credentials.ts";
+import { mintGitCredential } from "../../forge/credentials.ts";
 import type { RuntimeProvider } from "../../runtime/contract.ts";
 import type { AdmissionCounterSink } from "../../runtime/k8s/admission.ts";
 import {
@@ -267,7 +267,11 @@ function k8sForgeTokenWindows(forge: Forge | undefined): {
 } {
 	if (forge === undefined) return {};
 	return {
-		k8sMintGitCredential: (gitUrl) => mintGitCredentialSecret(forge, gitUrl),
+		// The in-pod finalize wire (v1) still carries a bare secret, so the
+		// credential is flattened at this ONE boundary. Its username and host
+		// stay GitHub's literals inside the pod, which is the remaining half of
+		// warren-1b6f and needs a wire-version decision to close.
+		k8sMintGitCredential: async (gitUrl) => (await mintGitCredential(forge, gitUrl))?.secret,
 		k8sAllowStaticPushTokenFallback: forge.capabilities.credentialLifetime === "static",
 	};
 }

--- a/src/server/scheduler.ts
+++ b/src/server/scheduler.ts
@@ -23,7 +23,7 @@
 
 import type { Repos } from "../db/repos/index.ts";
 import type { Forge } from "../forge/contract.ts";
-import { mintGitCredentialSecret } from "../forge/credentials.ts";
+import { mintGitCredential } from "../forge/credentials.ts";
 import type { SpawnFn } from "../projects/clone.ts";
 import type { ProjectsConfig } from "../projects/config.ts";
 import { spawnRun } from "../runs/index.ts";
@@ -44,6 +44,7 @@ import {
 	type TriggerSchedulerConfig,
 } from "../triggers/index.ts";
 import type { WarrenConfigCache } from "../warren-config/index.ts";
+import type { GitSpawnCredential } from "../workspace/git/credential-env.ts";
 import type { BridgeRegistry } from "./types.ts";
 
 export interface BootSchedulerInput {
@@ -75,7 +76,7 @@ export interface BootSchedulerInput {
 	 *   - the CI-fixer poller reads check runs / log tails through it, and
 	 *     its capability flags drive the §5 degradations;
 	 *   - the self-heal re-clone and the scheduled-dispatch refresh mint
-	 *     their git credential PER SPAWN via `mintGitCredentialSecret`
+	 *     their git credential PER SPAWN via `mintGitCredential`
 	 *     (forge-contract.md §4 — credentials are minted, never held), so a
 	 *     short-lived App credential never has to outlive a tick loop.
 	 */
@@ -131,19 +132,19 @@ export function bootScheduler(input: BootSchedulerInput): SchedulerHandle {
 		tracker: projectHealTracker,
 		config: input.projectsConfig,
 		spawn: input.projectSpawn,
-		mintToken: (project) => mintGitCredentialSecret(input.forge, project.gitUrl),
+		mintCredential: (project) => mintGitCredential(input.forge, project.gitUrl),
 		...(input.logger !== undefined ? { logger: input.logger } : {}),
 		...(input.cloneExists !== undefined ? { exists: input.cloneExists } : {}),
 		...(input.now !== undefined ? { now: input.now } : {}),
 	});
 
-	const mintProjectGitSecret = async (projectId: string): Promise<string | undefined> => {
+	const mintProjectGitSecret = async (
+		projectId: string,
+	): Promise<GitSpawnCredential | undefined> => {
 		// §4 per-spawn mint: credential is minted immediately before the spawn,
 		// never captured at boot. Unowned URL / `no_credential` → undefined.
 		const project = await input.repos.projects.get(projectId);
-		return project !== null
-			? await mintGitCredentialSecret(input.forge, project.gitUrl)
-			: undefined;
+		return project !== null ? await mintGitCredential(input.forge, project.gitUrl) : undefined;
 	};
 
 	const spawnDispatch: DispatchSpawnFn = async (
@@ -166,7 +167,7 @@ export function bootScheduler(input: BootSchedulerInput): SchedulerHandle {
 			...(args.maxCostUsd !== undefined ? { maxCostUsdOverride: args.maxCostUsd } : {}),
 			projectsConfig: input.projectsConfig,
 			projectSpawn: input.projectSpawn,
-			githubToken: gitSecret,
+			gitCredential: gitSecret,
 			warrenConfigs: input.warrenConfigs,
 			seedsCli: seedsDeps,
 			...trackerOption,
@@ -207,7 +208,7 @@ export function bootScheduler(input: BootSchedulerInput): SchedulerHandle {
 			targetBranch: args.targetBranch,
 			projectsConfig: input.projectsConfig,
 			projectSpawn: input.projectSpawn,
-			githubToken: gitSecret,
+			gitCredential: gitSecret,
 			warrenConfigs: input.warrenConfigs,
 			seedsCli: seedsDeps,
 			...trackerOption,

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -169,7 +169,7 @@ export interface ServerDeps {
 	 * Boot-resolved forge (`resolveForge` in `src/forge/registry.ts`, honoring
 	 * `WARREN_FORGE`), resolved ONCE in `bootServer` (warren-6c4c) and threaded
 	 * here exactly like `runtimeProvider`. REQUIRED. Handlers mint per-spawn git
-	 * credentials through it (`mintGitCredentialSecret`); the handle must never
+	 * credentials through it (`mintGitCredential`); the handle must never
 	 * appear in a public projection.
 	 */
 	readonly forge: Forge;

--- a/src/triggers/project-heal.test.ts
+++ b/src/triggers/project-heal.test.ts
@@ -89,7 +89,7 @@ describe("recloneMissingProject", () => {
 			}),
 			config: CONFIG,
 			spawn: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
-			token: "ghs_secret",
+			gitCredential: { username: "x-access-token", secret: "ghs_secret", host: "github.com" },
 			clone: async (input) => {
 				calls.push({ ...input, spawn: undefined });
 				return { localPath: input.config.root, defaultBranch: input.defaultBranch ?? "" };
@@ -101,7 +101,7 @@ describe("recloneMissingProject", () => {
 			name: "widget",
 			gitUrl: "https://github.com/acme/widget.git",
 			defaultBranch: "trunk",
-			token: "ghs_secret",
+			gitCredential: { username: "x-access-token", secret: "ghs_secret", host: "github.com" },
 		});
 	});
 });

--- a/src/triggers/project-heal.ts
+++ b/src/triggers/project-heal.ts
@@ -34,6 +34,7 @@ import type { ProjectRow } from "../db/schema.ts";
 import { cloneProjectRepo, type SpawnFn } from "../projects/clone.ts";
 import type { ProjectsConfig } from "../projects/config.ts";
 import { parseGitHubUrl } from "../projects/url.ts";
+import type { GitSpawnCredential } from "../workspace/git/credential-env.ts";
 
 /** Default gap between repeated notices for the same unresolved condition. */
 export const NOTICE_INTERVAL_MS = 3_600_000;
@@ -103,7 +104,7 @@ export interface RecloneMissingProjectInput {
 	readonly config: ProjectsConfig;
 	readonly spawn: SpawnFn;
 	/** `GITHUB_TOKEN` for private-repo access — see `CloneProjectInput.token`. */
-	readonly token?: string;
+	readonly gitCredential?: GitSpawnCredential;
 	readonly timeoutMs?: number;
 	/** Injected cloner; defaults to the live `cloneProjectRepo`. */
 	readonly clone?: typeof cloneProjectRepo;
@@ -126,7 +127,7 @@ export async function recloneMissingProject(input: RecloneMissingProjectInput): 
 		owner: parsed.owner,
 		name: parsed.name,
 		defaultBranch: input.project.defaultBranch,
-		token: input.token,
+		gitCredential: input.gitCredential,
 		spawn: input.spawn,
 		...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
 	});
@@ -158,9 +159,9 @@ export interface ProjectCloneHealerInput {
 	 * Per-reclone credential mint (warren-0b49, forge-contract.md §4 —
 	 * credentials are minted, never held). Invoked immediately before the
 	 * re-clone spawns git; the boot wiring resolves it from the boot-resolved
-	 * forge via `mintGitCredentialSecret`. Absent → anonymous git.
+	 * forge via `mintGitCredential`. Absent → anonymous git.
 	 */
-	readonly mintToken?: (project: ProjectRow) => Promise<string | undefined>;
+	readonly mintCredential?: (project: ProjectRow) => Promise<GitSpawnCredential | undefined>;
 	readonly timeoutMs?: number;
 	readonly logger?: HealLogger;
 	/** Filesystem probe — overrideable for tests. */
@@ -230,7 +231,8 @@ async function attemptReclone(
 	recloneFn: typeof recloneMissingProject,
 	project: ProjectRow,
 ): Promise<void> {
-	const token = input.mintToken !== undefined ? await input.mintToken(project) : undefined;
+	const token =
+		input.mintCredential !== undefined ? await input.mintCredential(project) : undefined;
 	await recloneFn({
 		project,
 		config: input.config,

--- a/src/workspace/git/clone-url.test.ts
+++ b/src/workspace/git/clone-url.test.ts
@@ -1,24 +1,77 @@
 import { describe, expect, test } from "bun:test";
-import { authenticatedCloneUrl } from "./clone-url.ts";
+import {
+	authenticatedCloneUrl,
+	bareTokenCredential,
+	DEFAULT_GIT_USERNAME,
+} from "./clone-url.ts";
+
+const github = { username: "x-access-token", secret: "tok" };
 
 describe("authenticatedCloneUrl", () => {
-	test("injects x-access-token for https URLs", () => {
-		expect(authenticatedCloneUrl("https://github.com/o/r.git", "tok")).toBe(
+	test("injects the credential's own username for https URLs", () => {
+		expect(authenticatedCloneUrl("https://github.com/o/r.git", github)).toBe(
 			"https://x-access-token:tok@github.com/o/r.git",
 		);
 	});
 
-	test("leaves the URL alone without a token", () => {
+	test("uses the username the forge minted, not a GitHub literal", () => {
+		expect(
+			authenticatedCloneUrl("https://gitlab.com/o/r.git", { username: "oauth2", secret: "glpat" }),
+		).toBe("https://oauth2:glpat@gitlab.com/o/r.git");
+		expect(
+			authenticatedCloneUrl("https://bitbucket.org/o/r.git", {
+				username: "x-token-auth",
+				secret: "bb",
+			}),
+		).toBe("https://x-token-auth:bb@bitbucket.org/o/r.git");
+	});
+
+	test("keeps a self-hosted forge's port in the authority", () => {
+		expect(
+			authenticatedCloneUrl("https://git.acme.internal:8443/o/r.git", {
+				username: "oauth2",
+				secret: "glpat",
+			}),
+		).toBe("https://oauth2:glpat@git.acme.internal:8443/o/r.git");
+	});
+
+	test("leaves the URL alone without a credential", () => {
 		expect(authenticatedCloneUrl("https://github.com/o/r.git")).toBe("https://github.com/o/r.git");
 	});
 
+	test("leaves the URL alone when the secret is empty", () => {
+		expect(authenticatedCloneUrl("https://github.com/o/r.git", { username: "oauth2", secret: "" })).toBe(
+			"https://github.com/o/r.git",
+		);
+	});
+
+	test("falls back to the default username when the forge named none", () => {
+		expect(authenticatedCloneUrl("https://github.com/o/r.git", { username: "", secret: "tok" })).toBe(
+			`https://${DEFAULT_GIT_USERNAME}:tok@github.com/o/r.git`,
+		);
+	});
+
 	test("does not touch ssh URLs", () => {
-		expect(authenticatedCloneUrl("git@github.com:o/r.git", "tok")).toBe("git@github.com:o/r.git");
+		expect(authenticatedCloneUrl("git@github.com:o/r.git", github)).toBe("git@github.com:o/r.git");
 	});
 
 	test("does not double-inject when the authority already has userinfo", () => {
-		expect(authenticatedCloneUrl("https://user:pw@github.com/o/r.git", "tok")).toBe(
+		expect(authenticatedCloneUrl("https://user:pw@github.com/o/r.git", github)).toBe(
 			"https://user:pw@github.com/o/r.git",
 		);
+	});
+});
+
+describe("bareTokenCredential", () => {
+	test("names the GitHub scheme for a token that arrived without a username", () => {
+		expect(bareTokenCredential("pod-tok")).toEqual({
+			username: DEFAULT_GIT_USERNAME,
+			secret: "pod-tok",
+		});
+	});
+
+	test("is undefined for no token, so the URL stays anonymous", () => {
+		expect(bareTokenCredential(undefined)).toBeUndefined();
+		expect(bareTokenCredential("")).toBeUndefined();
 	});
 });

--- a/src/workspace/git/clone-url.test.ts
+++ b/src/workspace/git/clone-url.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-	authenticatedCloneUrl,
-	bareTokenCredential,
-	DEFAULT_GIT_USERNAME,
-} from "./clone-url.ts";
+import { authenticatedCloneUrl, bareTokenCredential, DEFAULT_GIT_USERNAME } from "./clone-url.ts";
 
 const github = { username: "x-access-token", secret: "tok" };
 
@@ -40,15 +36,15 @@ describe("authenticatedCloneUrl", () => {
 	});
 
 	test("leaves the URL alone when the secret is empty", () => {
-		expect(authenticatedCloneUrl("https://github.com/o/r.git", { username: "oauth2", secret: "" })).toBe(
-			"https://github.com/o/r.git",
-		);
+		expect(
+			authenticatedCloneUrl("https://github.com/o/r.git", { username: "oauth2", secret: "" }),
+		).toBe("https://github.com/o/r.git");
 	});
 
 	test("falls back to the default username when the forge named none", () => {
-		expect(authenticatedCloneUrl("https://github.com/o/r.git", { username: "", secret: "tok" })).toBe(
-			`https://${DEFAULT_GIT_USERNAME}:tok@github.com/o/r.git`,
-		);
+		expect(
+			authenticatedCloneUrl("https://github.com/o/r.git", { username: "", secret: "tok" }),
+		).toBe(`https://${DEFAULT_GIT_USERNAME}:tok@github.com/o/r.git`);
 	});
 
 	test("does not touch ssh URLs", () => {

--- a/src/workspace/git/clone-url.ts
+++ b/src/workspace/git/clone-url.ts
@@ -5,22 +5,65 @@
  * is not k8s-specific — the reap path (`src/runs/reap/pr-open.ts`,
  * `finalize-collect.ts`) also authenticates clone/fetch URLs — so hosting it in
  * an init-container module created a k8s↔reap coupling. It now lives beside the
- * other neutral `src/workspace/git/` primitives. Behavior is unchanged.
+ * other neutral `src/workspace/git/` primitives.
  */
 
 /**
- * Inject a git token into an https clone URL as `x-access-token:<token>@host`
- * (GitHub's app-token scheme, matching the supervisor's `insteadOf` credential).
- * Left untouched for ssh/other schemes or a URL that already carries credentials,
- * and when no token is supplied (public repos clone anonymously). Pure.
+ * The username to use when the caller holds a token and nothing else.
+ *
+ * This is GitHub's App-token scheme. It is the right answer only where the
+ * token genuinely arrives without a forge beside it, which today is the
+ * in-pod finalize path: the pod reads `WARREN_GIT_TOKEN` or the credential
+ * endpoint, and neither carries a username. Everywhere a `GitCloneCredential`
+ * exists, pass it, because the forge is the one that knows (`oauth2` for
+ * GitLab, `x-access-token` for a GitHub App).
  */
-export function authenticatedCloneUrl(repoUrl: string, token?: string): string {
-	if (token === undefined || token === "") return repoUrl;
+export const DEFAULT_GIT_USERNAME = "x-access-token";
+
+/**
+ * The half of a minted git credential a clone URL can carry. Structurally a
+ * `GitSpawnCredential` (src/workspace/git/credential-env.ts) minus the host,
+ * so a caller passes the minted credential straight through.
+ */
+export interface GitCloneCredential {
+	readonly username: string;
+	readonly secret: string;
+}
+
+/**
+ * Inject a git credential into an https clone URL as `<username>:<secret>@host`.
+ *
+ * The username comes from the credential rather than from a literal here: a
+ * GitHub App mints `x-access-token`, GitLab wants `oauth2`, and hardcoding
+ * either makes the other fail to authenticate (warren-1b6f). Taking the whole
+ * credential rather than a bare secret is deliberate, so a caller cannot drop
+ * the username by passing `.secret` alone.
+ *
+ * Left untouched for ssh/other schemes or a URL that already carries
+ * credentials, and when no credential is supplied (public repos clone
+ * anonymously). Pure.
+ */
+export function authenticatedCloneUrl(repoUrl: string, credential?: GitCloneCredential): string {
+	if (credential === undefined || credential.secret === "") return repoUrl;
+	const username = credential.username === "" ? DEFAULT_GIT_USERNAME : credential.username;
 	const prefix = "https://";
 	if (!repoUrl.startsWith(prefix)) return repoUrl;
 	const rest = repoUrl.slice(prefix.length);
 	// `@` before the first `/` means the authority already has userinfo.
 	const authority = rest.split("/", 1)[0] ?? "";
 	if (authority.includes("@")) return repoUrl;
-	return `${prefix}x-access-token:${token}@${rest}`;
+	return `${prefix}${username}:${credential.secret}@${rest}`;
+}
+
+/**
+ * Wrap a bare token as a credential, for the paths that only ever have one.
+ *
+ * The init and finalize containers read a token out of env or the in-pod
+ * credential endpoint, and no username arrives with it. This is where that
+ * gap is filled, named and in one place, rather than inside the URL helper
+ * where every caller would inherit it silently.
+ */
+export function bareTokenCredential(token: string | undefined): GitCloneCredential | undefined {
+	if (token === undefined || token === "") return undefined;
+	return { username: DEFAULT_GIT_USERNAME, secret: token };
 }

--- a/src/workspace/git/credential-env.test.ts
+++ b/src/workspace/git/credential-env.test.ts
@@ -1,20 +1,36 @@
 import { describe, expect, test } from "bun:test";
-import { githubCredentialGitEnv } from "./credential-env.ts";
+import { gitCredentialGitEnv } from "./credential-env.ts";
 
-describe("githubCredentialGitEnv", () => {
-	test("renders the x-access-token insteadOf rule as GIT_CONFIG_* vars", () => {
-		expect(githubCredentialGitEnv("tok")).toEqual({
+describe("gitCredentialGitEnv", () => {
+	test("renders the insteadOf rule as GIT_CONFIG_* vars", () => {
+		expect(
+			gitCredentialGitEnv({ username: "x-access-token", secret: "tok", host: "github.com" }),
+		).toEqual({
 			GIT_CONFIG_COUNT: "1",
 			GIT_CONFIG_KEY_0: "url.https://x-access-token:tok@github.com/.insteadOf",
 			GIT_CONFIG_VALUE_0: "https://github.com/",
 		});
 	});
 
-	test("undefined token → empty overrides (public repos clone anonymously)", () => {
-		expect(githubCredentialGitEnv(undefined)).toEqual({});
+	test("takes the username and the host from the credential, not from a literal", () => {
+		// warren-1b6f: both used to be hardcoded here, which made the rewrite a
+		// rule only github.com could match.
+		expect(
+			gitCredentialGitEnv({ username: "oauth2", secret: "glpat-x", host: "gitlab.example.com" }),
+		).toEqual({
+			GIT_CONFIG_COUNT: "1",
+			GIT_CONFIG_KEY_0: "url.https://oauth2:glpat-x@gitlab.example.com/.insteadOf",
+			GIT_CONFIG_VALUE_0: "https://gitlab.example.com/",
+		});
 	});
 
-	test("empty token → empty overrides", () => {
-		expect(githubCredentialGitEnv("")).toEqual({});
+	test("no credential means empty overrides, so a public repo clones anonymously", () => {
+		expect(gitCredentialGitEnv(undefined)).toEqual({});
+	});
+
+	test("a credential missing any of its three parts renders nothing", () => {
+		expect(gitCredentialGitEnv({ username: "oauth2", secret: "", host: "h" })).toEqual({});
+		expect(gitCredentialGitEnv({ username: "", secret: "s", host: "h" })).toEqual({});
+		expect(gitCredentialGitEnv({ username: "oauth2", secret: "s", host: "" })).toEqual({});
 	});
 });

--- a/src/workspace/git/credential-env.ts
+++ b/src/workspace/git/credential-env.ts
@@ -1,5 +1,5 @@
 /**
- * GitHub-credential git env — the per-spawn replacement for the supervisor's
+ * Per-spawn git credential env, the replacement for the supervisor's
  * deleted global `insteadOf` rule (warren-5497; the old module was
  * `src/supervisor/git-credentials.ts`).
  *
@@ -8,8 +8,8 @@
  * only the local topology boots through the supervisor, and a global rule has
  * no refresh point for expiring App tokens. Under `WARREN_RUNTIME=k8s` the
  * control-plane pod runs `warren serve` directly, so host-side `git clone` /
- * `fetch` / `push` against a private github.com repo died on git's interactive
- * username prompt (exit 128, "could not read Username for 'https://github.com'").
+ * `fetch` / `push` against a private repo died on git's interactive
+ * username prompt (exit 128, "could not read Username for 'https://...'").
  *
  * This helper renders the rewrite as `GIT_CONFIG_{COUNT,KEY_0,VALUE_0}`
  * env vars (git ≥2.31), merged into a single spawn's environment via the
@@ -22,20 +22,45 @@
  *   - `insteadOf` rewrites on the wire only, so the clone's stored
  *     `origin` URL stays clean.
  *
- * Harmless on non-github.com remotes (prefix never matches).
+ * The username and the host used to be the literals `x-access-token` and
+ * `github.com` (warren-1b6f). Both are provider facts, not warren facts:
+ * a GitHub App wants `x-access-token`, GitLab wants `oauth2`, and a
+ * self-hosted forge answers on its own host. They now arrive on
+ * {@link GitSpawnCredential}, minted beside the forge that knows them
+ * (`src/forge/credentials.ts`). Harmless on a remote the credential does
+ * not name, because the prefix never matches.
  */
 
 /**
- * Env overrides that let a spawned git authenticate to github.com over
- * https with `token` (GitHub's `x-access-token` app-token scheme). Empty /
- * undefined token → `{}`, so call sites can splice unconditionally and
+ * What ONE git network spawn needs to authenticate. Minted per operation
+ * and never held (forge-contract.md §4).
+ */
+export interface GitSpawnCredential {
+	/**
+	 * Provider-chosen. A GitHub App mints `x-access-token`, GitLab wants
+	 * `oauth2`. No domain code names either string.
+	 */
+	readonly username: string;
+	readonly secret: string;
+	/** The remote host the rewrite targets, e.g. `github.com`. */
+	readonly host: string;
+}
+
+/**
+ * Env overrides that let a spawned git authenticate to `credential.host`
+ * over https. An absent credential, or one missing any of its three
+ * parts, yields `{}`, so call sites can splice unconditionally and
  * public-repo behavior is untouched. Pure.
  */
-export function githubCredentialGitEnv(token: string | undefined): Record<string, string> {
-	if (token === undefined || token === "") return {};
+export function gitCredentialGitEnv(
+	credential: GitSpawnCredential | undefined,
+): Record<string, string> {
+	if (credential === undefined) return {};
+	const { username, secret, host } = credential;
+	if (username === "" || secret === "" || host === "") return {};
 	return {
 		GIT_CONFIG_COUNT: "1",
-		GIT_CONFIG_KEY_0: `url.https://x-access-token:${token}@github.com/.insteadOf`,
-		GIT_CONFIG_VALUE_0: "https://github.com/",
+		GIT_CONFIG_KEY_0: `url.https://${username}:${secret}@${host}/.insteadOf`,
+		GIT_CONFIG_VALUE_0: `https://${host}/`,
 	};
 }


### PR DESCRIPTION
The pre-work of #1028 (`warren-1b6f`), items 1 and 3. It does not close the issue: the GitLab provider itself is the other half, and this is the part that has to land first for it to authenticate anything.

## Summary

- `gitCredentialGitEnv` takes a `GitSpawnCredential` (`username`, `secret`, `host`) instead of a bare token. The literals `x-access-token` and `github.com` are gone from it.
- `mintGitCredential` (was `mintGitCredentialSecret`) returns that credential. The ~20 sites that threaded a secret string thread the object, and `githubToken` / `gitToken` / `token` on those inputs become `gitCredential`.
- The plan-run child dispatch and the infra-lost retry stop holding a boot-read `GITHUB_TOKEN` and mint per dispatch off the boot forge, like every other spawn site.
- The `github` registry arm reads `WARREN_GIT_TOKEN` before `GITHUB_TOKEN`, the order `src/runtime/k8s/git-tokens.ts` already used.

## The one design decision

The issue says to route the username and host through `GitCredential.username` and `RepoRef`. The username does come from the forge. The host does not come from `RepoRef`: §0 says nothing outside a provider destructures a ref, and `RepoRef.key` is where the host would have to be read from.

So the host is read off the clone URL, in `credentials.ts`, which already holds both the URL and the forge. That is the same layout-only derivation `parseForgeOwnedUrl` already does next door, and it never cracks the ref.

Two consequences worth naming:

**FakeForge gets a credential with an empty host.** `fake://owner/name` has an authority that is the repo name, not a git host, so there is nothing an https rewrite could target. The credential still exists for the consumers that do not need a host (the in-pod credential endpoint, `authenticatedCloneUrl`), and only the rewrite renders nothing. That matches what actually happened before: the github.com-scoped rule was emitted against a `fake://` remote and never matched.

**The username is now FakeForge's own.** Three tests asserted `x-access-token:fake-credential` in the rendered env. They assert `fake:fake-credential` now, which is the point of the change.

## Two things this deliberately leaves alone

**The in-pod finalize wire.** `InPodFinalizeIntent.gitToken` still carries a bare secret, and the pod still injects it with GitHub's literals. Making it forge-neutral means bumping `IN_POD_FINALIZE_WIRE_VERSION` and deciding what a lagging agent image does with a v2 intent. That is your call, not a first-PR call, so the credential flattens to `.secret` at exactly two boundaries, both commented: `k8sForgeTokenWindows` in `runtime-wiring.ts` and the `POST /runs/:id/git-credential` handler.

**`src/projects/url.ts`.** Item 2 of the pre-work. Its `host !== "github.com"` check is a URL-parsing concern rather than a credential one, and folding it behind `forge.parseRepoRef` changes what `addProject` accepts and what its errors say. Separate PR, and I will open it against this branch if you want it.

## A near-miss worth reporting

`SECRET_FIELDS` in `log-redact.ts` listed `gitToken`. Renaming the field to `gitCredential` silently took the minted secret out of the redaction list, so a logged `FinalizeIntent` would have carried it through in the clear.

Nothing caught that: it is a string list, not a type. Both spellings are listed now, plus `WARREN_GIT_TOKEN`, and there is a test that names the hazard so the next rename fails loudly.

Related: `tsc` did not catch the four handler sites still passing `{ token: secret }` and `{ githubToken: secret }` either. Excess-property checking does not apply through a conditional spread, so `...(x !== undefined ? { token: x } : {})` type-checks against an input that has no `token`. Four sites were silently dropping the credential until the tests caught it.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun test`: the failing set is byte-identical to `main`
- [x] `bun run check:all`: 11 of 12 gates green

`check:coverage` is the twelfth. It fails on this machine, which is Windows, and fails the same way on unmodified `main`:

```
$ comm -3 <failures on this branch> <failures on main>
  (empty)          # 104 distinct tests either way
```

They are POSIX assumptions: `/data/projects` fallbacks, `chmod 0600` round-trips, sqlite file paths, and the macOS seatbelt profile.

`src/runtime/contract.ts` sat at exactly its frozen 510-line budget, so the new import cost a line. I reflowed the `gitCredential` doc block rather than raising the number.

New coverage, beyond the sites that only changed type:

- `gitCredentialGitEnv` renders a non-GitHub credential, and renders nothing when any of the three parts is empty
- `mintGitCredential` reads the host out of all three URL spellings warren accepts, and returns an empty host for `fake://`
- the `github` arm prefers `WARREN_GIT_TOKEN` and still falls back to `GITHUB_TOKEN`, so an existing deployment is untouched
- the redaction list covers both field spellings

I did not exercise a real K8s finalize or a real App-mode mint.
