### PR TITLE
test(cli): stop the doctor-remote test reading the developer's real client.json

### DIFF
--- a/src/cli/commands/doctor-remote.test.ts
+++ b/src/cli/commands/doctor-remote.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	type VersionResponse,
 	type WarrenClient,
@@ -8,6 +10,14 @@ import {
 } from "../../client/index.ts";
 import type { CliContext } from "../output.ts";
 import { remoteDoctorDeps, runRemoteDoctor } from "./doctor-remote.ts";
+
+// Point the config-file slot at a path that cannot exist, so a real
+// `~/.warren/client.json` on the dev machine (written by `warren login`)
+// never leaks into tests that exercise the built-in default. Same constant
+// and same hazard as `src/cli/client.test.ts`: `remoteDoctorDeps` runs the
+// real resolution chain, so without this the test fails on a corrupt file
+// that has nothing to do with the code under test (warren-3f76).
+const NO_CONFIG_FILE = { WARREN_CLIENT_CONFIG: join(tmpdir(), "warren-client-test-absent.json") };
 
 function captureContext(): { context: CliContext; out: string[]; err: string[] } {
 	const out: string[] = [];
@@ -91,7 +101,11 @@ describe("runRemoteDoctor", () => {
 
 	test("remoteDoctorDeps carries the slots the resolution picked (warren-8807)", () => {
 		const deps = remoteDoctorDeps(
-			{ WARREN_BASE_URL: "https://env.example.com", WARREN_API_TOKEN: "tok-env" },
+			{
+				...NO_CONFIG_FILE,
+				WARREN_BASE_URL: "https://env.example.com",
+				WARREN_API_TOKEN: "tok-env",
+			},
 			{},
 		);
 		expect(deps.client.config.baseUrl).toBe("https://env.example.com");


### PR DESCRIPTION
Closes #1033.

## Summary

`remoteDoctorDeps` runs the real resolution chain, so an env that names no `WARREN_CLIENT_CONFIG` falls through to `~/.warren/client.json`. The test at `:92` passes an env with only `WARREN_BASE_URL` and `WARREN_API_TOKEN`, so a corrupt or hand-edited file on the developer's machine fails it for a reason unrelated to the code under test.

`src/cli/client.test.ts` already solves this. The same `NO_CONFIG_FILE` constant and the same comment land here, spread into the env the test passes.

One test, nine lines. `remoteDoctorDeps` and the resolution chain are untouched, and the hint text has its own issue.

## Reproduced, then fixed

```
$ mkdir -p <scratch>/.warren && printf '{not json' > <scratch>/.warren/client.json

$ HOME=<scratch> bun test src/cli/commands/doctor-remote.test.ts     # before
  ValidationError: client config file <scratch>/.warren/client.json is not valid JSON
      at loadWarrenClientConfigFromFile (src/client/config-file.ts:48:4)
      at resolveClientConfigWithSources (src/cli/client.ts:140:19)
      at resolveWarrenClientWithSources (src/cli/client.ts:108:19)
      at <anonymous> (src/cli/commands/doctor-remote.test.ts:93:16)
  (fail) remoteDoctorDeps carries the slots the resolution picked (warren-8807)
  10 pass, 1 fail

$ HOME=<scratch> bun test src/cli/commands/doctor-remote.test.ts     # after
  11 pass, 0 fail

$ bun test src/cli/commands/doctor-remote.test.ts                    # clean HOME, after
  11 pass, 0 fail
```

That matches the reproduction in the issue exactly, including the counts. On this machine, which is Windows, the scratch HOME is set through `USERPROFILE`, which is what `os.homedir()` reads there.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun test src/cli/commands/doctor-remote.test.ts` passes with both a clean and a corrupt HOME
- [x] `bun run check:size`, `check:agents`, `check:debt`, `check:dups` pass

`check:coverage` fails on this machine, which is Windows, and fails the same way on unmodified `main`: 104 distinct tests that assume POSIX (`/data/projects` fallbacks, `chmod 0600` round-trips, sqlite file paths, the macOS seatbelt profile). This PR touches one test file in `src/cli/`, none of which is on that list.
