### PR TITLE
fix(cli): let the doctor failure paths read the credential source they already have

### DIFF
--- a/src/cli/auth-hints.test.ts
+++ b/src/cli/auth-hints.test.ts
@@ -17,6 +17,16 @@ describe("authFailureHint", () => {
 		expect(hint).toContain(".env");
 	});
 
+	test("tells the env arm to check the token, the way the flag arm does", () => {
+		// warren-4f1b: the env arm told only the stale-`.env` story and dropped
+		// the advice the flag arm still carried.
+		for (const source of ["flag", "env"] as const) {
+			expect(authFailureHint(source, {}), source).toContain(
+				"check it against the server's credential",
+			);
+		}
+	});
+
 	test("blames the config file and points back at warren login", () => {
 		const hint = authFailureHint("config-file", CONFIG_AT);
 		expect(hint).toContain("came from the client config file");
@@ -29,10 +39,15 @@ describe("authFailureHint", () => {
 		expect(authFailureHint(undefined, CONFIG_AT)).toContain(CONFIG_AT.WARREN_CLIENT_CONFIG);
 	});
 
-	test("names every slot when no source was resolved", () => {
+	test("reads an absent source as no token at all, not as a search to run", () => {
+		// warren-4f1b: absent means every slot is empty, which is an ordinary
+		// production state. Sending the operator to check three empty slots
+		// described a search they had already lost.
 		const hint = authFailureHint(undefined, CONFIG_AT);
+		expect(hint).toContain("no token is configured");
+		expect(hint).toContain("are all empty");
+		expect(hint).toContain("warren login");
 		expect(hint).toContain("WARREN_API_TOKEN");
 		expect(hint).toContain("--token");
-		expect(hint).toContain("warren login");
 	});
 });

--- a/src/cli/auth-hints.ts
+++ b/src/cli/auth-hints.ts
@@ -20,9 +20,12 @@ import type { EnvLike } from "./output.ts";
  * cannot see: Bun loads the file before the process starts, so a stale token
  * in the repo they happen to be standing in outranks what `warren login` saved.
  *
- * An absent source still names every slot. Both callers now resolve one for
- * real, so absent means "no token anywhere"; #1035 owns rewording that arm,
- * and lands it on both surfaces at once.
+ * An absent source means NO TOKEN AT ALL, which is a normal production
+ * state rather than an unresolved caller (warren-4f1b). `resolveClientConfig`
+ * picks the token from flag, env or config file with no default arm, so it
+ * omits the source exactly when all three are empty, and both callers
+ * resolve one for real. Sending that operator to check three empty slots
+ * described a search they had already lost; the answer is `warren login`.
  */
 export function authFailureHint(source: ClientConfigSource | undefined, env: EnvLike): string {
 	const configFile = clientConfigPath(env);
@@ -30,10 +33,10 @@ export function authFailureHint(source: ClientConfigSource | undefined, env: Env
 		case "flag":
 			return "the rejected token came from --token; check it against the server's credential";
 		case "env":
-			return `the rejected token came from WARREN_API_TOKEN in the environment; Bun auto-loads \`.env\` from the invoking cwd, so a stale token there outranks the one \`warren login\` saved in ${configFile}`;
+			return `the rejected token came from WARREN_API_TOKEN in the environment; check it against the server's credential. Bun auto-loads \`.env\` from the invoking cwd, so a stale token there outranks the one \`warren login\` saved in ${configFile}`;
 		case "config-file":
 			return `the rejected token came from the client config file (${configFile}); re-run \`warren login\` to replace it`;
 		default:
-			return `check WARREN_API_TOKEN / --token or the token \`warren login\` saved in the client config file (${configFile}) against the server's credential; if this only fails from inside a repo, a stale \`.env\` in your cwd (auto-loaded by Bun) may be overriding the config file`;
+			return `no token is configured in any slot: --token, WARREN_API_TOKEN, and the client config file (${configFile}) are all empty. Run \`warren login\` to save one, or pass --token`;
 	}
 }

--- a/src/cli/commands/doctor-remote.test.ts
+++ b/src/cli/commands/doctor-remote.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	type VersionResponse,
 	type WarrenClient,
@@ -24,6 +26,7 @@ function captureContext(): { context: CliContext; out: string[]; err: string[] }
 }
 
 interface MockClientInput {
+	readonly baseUrl?: string;
 	readonly probeError?: Error;
 	readonly whoamiError?: Error;
 	readonly version?: string;
@@ -33,7 +36,7 @@ interface MockClientInput {
 /** Mocked WarrenClient (warren-97a2): the client half of doctor never touches a DB. */
 function mockClient(input: MockClientInput = {}): WarrenClient {
 	return {
-		config: { baseUrl: "http://localhost:8080" },
+		config: { baseUrl: input.baseUrl ?? "http://localhost:8080" },
 		probe: async () => {
 			if (input.probeError !== undefined) throw input.probeError;
 		},
@@ -87,6 +90,50 @@ describe("runRemoteDoctor", () => {
 		expect(auth?.ok).toBe(false);
 		expect(auth?.hint).toContain("WARREN_API_TOKEN");
 		expect(auth?.hint).toContain("warren login");
+	});
+
+	test("the unreachable hint names the slot the base URL came from (warren-4f1b)", async () => {
+		const { context } = captureContext();
+		const configAt = join(tmpdir(), "warren-doctor-config.json");
+		const client = mockClient({
+			baseUrl: "https://stale.example.com",
+			probeError: new WarrenUnreachableError("connection refused"),
+		});
+		const result = await runRemoteDoctor(
+			{ ...context, env: { WARREN_CLIENT_CONFIG: configAt } },
+			{ client, baseUrlSource: "config-file" },
+			{},
+		);
+		const hint = result.checks[0]?.hint ?? "";
+		expect(hint).toContain("https://stale.example.com");
+		expect(hint).toContain("came from the client config file");
+		// The resolved path, not a hard-coded ~/.warren/client.json.
+		expect(hint).toContain(configAt);
+		// And no longer the two slots that did not supply it.
+		expect(hint).not.toContain("WARREN_BASE_URL");
+		expect(hint).not.toContain("--url");
+	});
+
+	test("the unreachable hint says so when no slot supplied a base URL (warren-4f1b)", async () => {
+		const { context } = captureContext();
+		const client = mockClient({ probeError: new WarrenUnreachableError("connection refused") });
+		const result = await runRemoteDoctor(context, { client, baseUrlSource: "default" }, {});
+		const hint = result.checks[0]?.hint ?? "";
+		expect(hint).toContain("built-in default");
+		expect(hint).toContain("WARREN_BASE_URL");
+	});
+
+	test("the auth line names the resolved config path, not the default (warren-4f1b)", async () => {
+		const { context } = captureContext();
+		const configAt = join(tmpdir(), "warren-doctor-config.json");
+		const result = await runRemoteDoctor(
+			{ ...context, env: { WARREN_CLIENT_CONFIG: configAt } },
+			{ client: mockClient({}), tokenSource: "config-file" },
+			{},
+		);
+		const auth = result.checks.find((c) => c.name === "auth_valid");
+		expect(auth?.message).toContain(configAt);
+		expect(auth?.message).not.toContain("~/.warren/client.json");
 	});
 
 	test("remoteDoctorDeps carries the slots the resolution picked (warren-8807)", () => {

--- a/src/cli/commands/doctor-remote.ts
+++ b/src/cli/commands/doctor-remote.ts
@@ -14,6 +14,7 @@
  * and 1 otherwise.
  */
 
+import { clientConfigPath } from "../../client/config-file.ts";
 import type { WarrenClient } from "../../client/index.ts";
 import { VERSION } from "../../index.ts";
 import { authFailureHint } from "../auth-hints.ts";
@@ -40,8 +41,10 @@ export interface RemoteDoctorDeps {
 	readonly cliVersion?: string;
 	/**
 	 * Which slot supplied the token, from `resolveWarrenClientWithSources`.
-	 * Absent means the caller did not resolve one, and the auth check falls
-	 * back to naming every slot.
+	 * Absent means NO TOKEN in any slot, which is an ordinary production
+	 * state: the resolution picks from flag, env and config file with no
+	 * default arm, so it omits the source exactly when all three are empty
+	 * (warren-4f1b).
 	 */
 	readonly tokenSource?: ClientConfigSource;
 	/** Which slot supplied the base URL. Absent leaves the line as the URL alone. */
@@ -88,7 +91,7 @@ export async function runRemoteDoctor(
 			name: "server_reachable",
 			ok: false,
 			message: formatError(err),
-			hint: "check WARREN_BASE_URL / --url and that `warren serve` is running",
+			hint: baseUrlFailureHint(deps.baseUrlSource, deps.client.config.baseUrl, context.env),
 		});
 		return finish(context, checks);
 	}
@@ -123,15 +126,47 @@ function baseUrlSourceLabel(source: ClientConfigSource | undefined): string | un
 	}
 }
 
+/**
+ * Where to look when the server did not answer. The fixed text named
+ * `WARREN_BASE_URL` and `--url` whatever the URL came from, so a stale URL
+ * in the config file sent the operator to two slots that had not supplied
+ * it (warren-4f1b). The slot is already resolved on the ok line; this is
+ * the path where it matters.
+ */
+function baseUrlFailureHint(
+	source: ClientConfigSource | undefined,
+	baseUrl: string,
+	env: EnvLike,
+): string {
+	const serving = "and that `warren serve` is running there";
+	switch (source) {
+		case "flag":
+			return `${baseUrl} came from --url; check it ${serving}`;
+		case "env":
+			return `${baseUrl} came from WARREN_BASE_URL in the environment; check it ${serving}`;
+		case "config-file":
+			return `${baseUrl} came from the client config file (${clientConfigPath(env)}); check it ${serving}, or re-run \`warren login\` to replace it`;
+		case "default":
+			return `${baseUrl} is the built-in default, because no slot supplied one; set WARREN_BASE_URL or pass --url, ${serving}`;
+		default:
+			return `check WARREN_BASE_URL / --url ${serving}`;
+	}
+}
+
 /** How the token slot reads in operator-facing output (warren-8807). */
-function tokenSourceLabel(source: ClientConfigSource | undefined): string | undefined {
+function tokenSourceLabel(
+	source: ClientConfigSource | undefined,
+	env: EnvLike,
+): string | undefined {
 	switch (source) {
 		case "flag":
 			return "--token";
 		case "env":
 			return "WARREN_API_TOKEN in the environment";
 		case "config-file":
-			return "the client config file (~/.warren/client.json, WARREN_CLIENT_CONFIG)";
+			// The path the resolution actually read, which honours
+			// WARREN_CLIENT_CONFIG rather than asserting the default (warren-4f1b).
+			return `the client config file (${clientConfigPath(env)})`;
 		default:
 			return undefined;
 	}
@@ -142,7 +177,7 @@ async function authCheck(
 	tokenSource: ClientConfigSource | undefined,
 	env: EnvLike,
 ): Promise<DoctorCheck> {
-	const label = tokenSourceLabel(tokenSource);
+	const label = tokenSourceLabel(tokenSource, env);
 	try {
 		const who = await client.whoami();
 		const admitted = `admitted as ${who.identity} (capabilities: ${who.capabilities.join(", ")})`;


### PR DESCRIPTION
Closes #1035.

## Summary

All four items. #1040 already moved `authFailureHint` into `src/cli/auth-hints.ts` and fixed the hard-coded path there, so items 2, 3 and 4 land in that file plus `tokenSourceLabel`, not at the line numbers in the issue.

| # | Was | Is |
|---|---|---|
| 1 | `server_reachable` failure hint was a fixed "check WARREN_BASE_URL / --url" | names the slot that supplied the URL, and says so when it is the built-in default |
| 2 | env-token 401 arm told only the stale-`.env` story | carries "check it against the server's credential", the way the flag arm still did |
| 3 | absent `tokenSource` sent the operator to check three slots | says no token is configured and points at `warren login` |
| 4 | `tokenSourceLabel` asserted `~/.warren/client.json` | prints the path `clientConfigPath` resolves |

## Item 3, and why absent really does mean empty

The issue is right that this is a normal production state, and it is worth writing down why rather than trusting it. `resolveClientConfigWithSources` picks the token with `firstNonEmpty` over flag, env and config file, with **no default arm**, unlike the base URL. So it omits `tokenSource` exactly when all three are empty. Both callers resolve for real: `remoteDoctorDeps` wires straight through, and `resolveCommandClient` sets it on the context whenever it exists.

So the old text described a search the operator had already lost. It listed three slots and asked them to look, when the answer was that there is nothing to find.

The doc comment on `RemoteDoctorDeps.tokenSource` said the absent case meant "the caller did not resolve one", a test-only state. That is now written as what it is.

## Both surfaces at once

`commandFailure` in `output.ts` reads the same `authFailureHint`, so items 2 and 3 land on the catch-tail of every other command with no second edit. That was the point of hoisting it in #1040.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun test src/cli/commands/doctor-remote.test.ts src/cli/auth-hints.test.ts`: 20 pass, up from 15
- [x] `bun run check:all`: 11 of 12 gates green

Every new assertion was checked against the old code rather than assumed. With the two source files stashed and the tests kept:

```
(fail) authFailureHint > tells the env arm to check the token, the way the flag arm does
(fail) authFailureHint > reads an absent source as no token at all, not as a search to run
(fail) runRemoteDoctor > the unreachable hint names the slot the base URL came from
(fail) runRemoteDoctor > the unreachable hint says so when no slot supplied a base URL
(fail) runRemoteDoctor > the auth line names the resolved config path, not the default
15 pass, 5 fail
```

`check:coverage` is the twelfth gate. It fails on this machine, which is Windows, and fails the same way on unmodified `main`: `comm -3` between the two failure sets is empty, 104 distinct tests either way. They are POSIX assumptions (`/data/projects` fallbacks, `chmod 0600` round-trips, sqlite file paths, the macOS seatbelt profile).

## One overlap to know about

#1049 (issue #1033) also touches `doctor-remote.test.ts`, and adds the same two `node:os` / `node:path` imports at the top. Whichever merges second wants a one-line import rebase. I branched both from `main` on purpose so neither blocks the other, and I will rebase whichever loses the race.

I did not exercise a real unreachable server or a real 401 against a live warren.
