### PR TITLE
fix(acceptance): drop the retired POST /agents/refresh from scenarios 19, 24 and 35

### DIFF
--- a/scripts/acceptance/scenarios/19-warren-on-postgres.ts
+++ b/scripts/acceptance/scenarios/19-warren-on-postgres.ts
@@ -156,7 +156,14 @@ export const scenario: Scenario = {
 			// and exercises the dialect-aware ping path on pg.
 			await assertDbReachableOnPostgres(http);
 
-			await http.expectStatus("POST", "/agents/refresh", 200);
+			// The stub agent was seeded at boot via WARREN_SEED_AGENTS_FILE
+			// (warren-e376); POST /agents/refresh is deleted (pl-3a79). GET it
+			// to prove boot seeding landed before spawning against it.
+			await http.expectStatus(
+				"GET",
+				`/agents/${encodeURIComponent(ctx.fixtures.stubAgentName)}`,
+				200,
+			);
 			const project = await ensureProject(http, ctx.fixtures.sampleProjectGitUrl);
 
 			const created = await http.expectJson<CreateRunResponse>("POST", "/runs", 201, {

--- a/scripts/acceptance/scenarios/24-preview-node-runtime.ts
+++ b/scripts/acceptance/scenarios/24-preview-node-runtime.ts
@@ -171,7 +171,14 @@ async function runNodePreview(ctx: ScenarioCtx): Promise<void> {
 		ctx.logger.info(`scenario-24: warren ready at ${handle.warrenUrl}`);
 
 		const http = new WarrenHttp({ baseUrl: handle.warrenUrl, token: handle.token });
-		await http.expectStatus("POST", "/agents/refresh", 200);
+		// The stub agent was seeded at boot via WARREN_SEED_AGENTS_FILE
+		// (warren-e376); POST /agents/refresh is deleted (pl-3a79). GET it
+		// to prove boot seeding landed before spawning against it.
+		await http.expectStatus(
+			"GET",
+			`/agents/${encodeURIComponent(ctx.fixtures.stubAgentName)}`,
+			200,
+		);
 		const project = await ensureProject(http, sample.gitUrl);
 
 		const created = await http.expectJson<CreateRunResponse>("POST", "/runs", 201, {

--- a/scripts/acceptance/scenarios/35-ci-fixer-roundtrip.ts
+++ b/scripts/acceptance/scenarios/35-ci-fixer-roundtrip.ts
@@ -108,7 +108,14 @@ export const scenario: Scenario = {
 		const slug = parseRepoSlug(repoUrl);
 
 		const http = new WarrenHttp({ baseUrl: ctx.warrenUrl, token: ctx.token });
-		await http.expectStatus("POST", "/agents/refresh", 200);
+		// The stub agent was seeded at boot via WARREN_SEED_AGENTS_FILE
+		// (warren-e376); POST /agents/refresh is deleted (pl-3a79). GET it
+		// to prove boot seeding landed before spawning against it.
+		await http.expectStatus(
+			"GET",
+			`/agents/${encodeURIComponent(ctx.fixtures.stubAgentName)}`,
+			200,
+		);
 		const project = await http.expectJson<ProjectRow>("POST", "/projects", 201, {
 			body: { gitUrl: repoUrl },
 		});


### PR DESCRIPTION
Closes #1037.

## Summary

One line per scenario, in 19, 24 and 35. `await http.expectStatus("POST", "/agents/refresh", 200)` becomes the `GET /agents/<stubAgentName>` probe, which is what scenarios 05, 07, 09 and 10 already do.

The GET rather than the bare deletion, because the probe keeps what the retired POST was standing in for: proof that boot seeding through `WARREN_SEED_AGENTS_FILE` landed before the scenario spawns against that agent. The comment is copied verbatim from those four sites, so all seven now read identically.

## The route really is gone

Checked against the served table rather than taken from the issue:

```
$ bun -e 'import { API_ROUTE_POLICIES } from "./src/server/handlers/route-table.ts"; ...'
rotas /agents servidas hoje:
  GET /agents
  GET /agents/:name
POST /agents/refresh existe? false
```

A known path with the wrong method is 405 `method_not_allowed` (`src/server/errors.ts:196`, pinned by `src/server/server.test.ts:224`), which is the failure the issue reports.

After the change, no `expectStatus("POST", "/agents/refresh"` call remains anywhere under `scripts/`. The surviving matches for that string are all comments explaining the deletion.

## What I could not run, and why

The issue says it is fine to send this with only the static gates green, so this is that PR, and here is exactly how far I got.

I tried scenario 24 on this machine and the harness stops before the scenario:

```
$ bun run scripts/acceptance/run.ts --only 24
[acceptance] acceptance: mode=in-proc tmp=...
acceptance: harness boot failed:
Executable not found in $PATH: "cn"
    at buildCanopyRepo (scripts/acceptance/lib/fixtures.ts:243:8)
```

That is the canopy CLI the fixture builder shells to. Even with it installed, this is Windows: 24 guards on darwin at `24-preview-node-runtime.ts:126` and needs Linux with bubblewrap, 19 needs Postgres, and 35 needs `GITHUB_TOKEN` plus `WARREN_ACCEPT_CI_FIXER_REPO`.

So the reproduction in the issue is the maintainer's, not mine, and I am not claiming otherwise. What I verified myself is the static half above: the route is absent from the table, the router 405s a known path on the wrong method, and the call sites are gone.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun run check:ci-parity` passes
- [x] `bun run check:agents`, `check:size`, `check:debt`, `check:dups` pass
- [ ] the three scenarios actually run: not possible here, see above

`check:coverage` fails on this machine, which is Windows, and fails the same way on unmodified `main`: 104 distinct tests that assume POSIX. This PR touches three files under `scripts/acceptance/scenarios/`, none of which the unit suite executes.
