### PR TITLE
fix(runs): keep the provider, model and cap when a run is retried

### DIFF
--- a/src/runs/retry/infra-lost-retry.test.ts
+++ b/src/runs/retry/infra-lost-retry.test.ts
@@ -60,6 +60,8 @@ interface Harness {
 		retryOf?: string;
 		costUsd?: number;
 		maxCostUsd?: number;
+		/** Extra frontmatter frozen onto the run, beside the cap. */
+		frontmatter?: Record<string, unknown>;
 		failureReason?: "sandbox_run_lost" | "crashed" | "provider_error";
 	}) => Promise<RunRow>;
 }
@@ -84,7 +86,10 @@ async function setup(): Promise<Harness> {
 				projectId: project.id,
 				prompt: over.prompt ?? "fix the thing",
 				renderedAgentJson: {
-					frontmatter: over.maxCostUsd !== undefined ? { maxCostUsd: over.maxCostUsd } : {},
+					frontmatter: {
+						...(over.maxCostUsd !== undefined ? { maxCostUsd: over.maxCostUsd } : {}),
+						...(over.frontmatter ?? {}),
+					},
 					sections: {},
 				},
 				trigger: "manual",
@@ -179,6 +184,30 @@ describe("infra-lost run auto-retry (warren-4af7)", () => {
 		const retryEvents = await h.repos.events.listByRun(retry.id);
 		const backlink = retryEvents.find((e) => e.kind === RUN_RETRY_OF_KIND);
 		expect(backlink?.payloadJson).toMatchObject({ retryOf: original.id });
+	});
+
+	test("carries the provider and model the failed run resolved (warren-0d80)", async () => {
+		const original = await h.run({
+			frontmatter: { provider: "openrouter", model: "moonshotai/kimi-k3" },
+		});
+		await hookFor(h)(original.id);
+		expect(h.spawnCalls[0]?.providerOverride).toBe("openrouter");
+		expect(h.spawnCalls[0]?.modelOverride).toBe("moonshotai/kimi-k3");
+	});
+
+	test("keeps the remaining budget as the cap, not the original's full one (warren-0d80)", async () => {
+		// The frozen frontmatter carries the FULL $5 cap. warren-4af7 says the
+		// retry gets what is left, so the inherited cap must not win here.
+		const original = await h.run({ maxCostUsd: 5, costUsd: 2 });
+		await hookFor(h)(original.id);
+		expect(h.spawnCalls[0]?.maxCostUsdOverride).toBe(3);
+	});
+
+	test("passes no provider or model for a run that declared none (warren-0d80)", async () => {
+		const original = await h.run({});
+		await hookFor(h)(original.id);
+		expect(h.spawnCalls[0]?.providerOverride).toBeUndefined();
+		expect(h.spawnCalls[0]?.modelOverride).toBeUndefined();
 	});
 
 	test("uncapped original → retry dispatches with no cap override", async () => {

--- a/src/runs/retry/infra-lost-retry.ts
+++ b/src/runs/retry/infra-lost-retry.ts
@@ -51,6 +51,7 @@ import type { SpawnRunInput } from "../spawn/types.ts";
 import type { BridgeLogger } from "../stream/index.ts";
 import { bindBridgeLogger } from "../stream/index.ts";
 import type { BridgeRegistry } from "../stream/types.ts";
+import { inheritedDispatchOverrides } from "./inherited-overrides.ts";
 
 /**
  * Failure causes that justify one automatic run-level re-dispatch. Today
@@ -175,6 +176,15 @@ function buildRetrySpawnInput(
 	if (run.ref !== null) draft.ref = run.ref;
 	if (run.baseCommit !== null) draft.baseCommit = run.baseCommit;
 	if (run.targetBranch !== null) draft.targetBranch = run.targetBranch;
+	// warren-0d80: provider and model come off the original's frozen
+	// frontmatter, so the retry runs on what the operator selected rather than
+	// on whatever the agent and project defaults resolve to now.
+	const inherited = inheritedDispatchOverrides(run.renderedAgentJson);
+	if (inherited.providerOverride !== undefined) draft.providerOverride = inherited.providerOverride;
+	if (inherited.modelOverride !== undefined) draft.modelOverride = inherited.modelOverride;
+	// The cap is deliberately NOT taken from `inherited`. warren-4af7 gives
+	// this retry the original cap MINUS what the first attempt spent, and the
+	// full frozen cap would hand it a fresh budget.
 	if (decision.remainingBudgetUsd !== null) draft.maxCostUsdOverride = decision.remainingBudgetUsd;
 	if (input.projectsConfig !== undefined) draft.projectsConfig = input.projectsConfig;
 	if (input.projectSpawn !== undefined) draft.projectSpawn = input.projectSpawn;

--- a/src/runs/retry/inherited-overrides.test.ts
+++ b/src/runs/retry/inherited-overrides.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { inheritedDispatchOverrides } from "./inherited-overrides.ts";
+
+describe("inheritedDispatchOverrides", () => {
+	test("reads the three override slots off the frozen frontmatter", () => {
+		expect(
+			inheritedDispatchOverrides({
+				frontmatter: { provider: "openrouter", model: "deepseek/deepseek-v4-pro", maxCostUsd: 4 },
+			}),
+		).toEqual({
+			providerOverride: "openrouter",
+			modelOverride: "deepseek/deepseek-v4-pro",
+			maxCostUsdOverride: 4,
+		});
+	});
+
+	test("fills only the slots the parent actually carried", () => {
+		expect(inheritedDispatchOverrides({ frontmatter: { model: "kimi-k3" } })).toEqual({
+			modelOverride: "kimi-k3",
+		});
+	});
+
+	test("yields nothing for a run whose frontmatter declared none of them", () => {
+		// A spread of `{}` leaves the retry resolving exactly as the original
+		// did, off the agent and the project defaults.
+		expect(inheritedDispatchOverrides({ frontmatter: {} })).toEqual({});
+		expect(inheritedDispatchOverrides({})).toEqual({});
+	});
+
+	test("narrows a rendered agent that is not the shape it should be", () => {
+		// The column is `unknown`, and a hand-built fixture or an older row
+		// can carry anything.
+		for (const rendered of [
+			null,
+			undefined,
+			"",
+			7,
+			[],
+			{ frontmatter: null },
+			{ frontmatter: 3 },
+		]) {
+			expect(inheritedDispatchOverrides(rendered), JSON.stringify(rendered)).toEqual({});
+		}
+	});
+
+	test("ignores an empty or non-string provider and model", () => {
+		expect(inheritedDispatchOverrides({ frontmatter: { provider: "", model: 42 } })).toEqual({});
+	});
+
+	test("defers to readMaxCostUsd on a cap that is not a plain number", () => {
+		// Measured, not assumed: the reader coerces a numeric string on purpose
+		// (the `cn --fm` trap its own module doc describes), and drops a
+		// negative, a zero and an unparseable one. The retry inherits whatever
+		// the original run's cap resolved to, including that coercion.
+		expect(inheritedDispatchOverrides({ frontmatter: { maxCostUsd: "4" } })).toEqual({
+			maxCostUsdOverride: 4,
+		});
+		for (const cap of [-1, 0, "abc", null]) {
+			expect(inheritedDispatchOverrides({ frontmatter: { maxCostUsd: cap } }), `${cap}`).toEqual(
+				{},
+			);
+		}
+	});
+});

--- a/src/runs/retry/inherited-overrides.ts
+++ b/src/runs/retry/inherited-overrides.ts
@@ -1,0 +1,53 @@
+/**
+ * The dispatch overrides a retry inherits from the run it replaces
+ * (warren-0d80).
+ *
+ * A run's EFFECTIVE provider, model and spend cap are folded onto its
+ * frozen `renderedAgentJson.frontmatter` at dispatch time, whichever tier
+ * supplied them: the agent's own frontmatter, the project defaults, or an
+ * explicit override on the request. Reading them back is the only way a
+ * retry can resolve the same three values, because `spawnRun` re-resolves
+ * from the agent and the project defaults when no override arrives, and
+ * those defaults may have moved since.
+ *
+ * Both retry modules read this. The HTTP clone path (`resolveCloneDefaults`
+ * in `src/server/handlers/runs/dispatch.ts`) already did the same thing by
+ * hand, which is where the shape comes from.
+ */
+
+import { readProviderFrontmatter } from "../../registry/schema.ts";
+import { readMaxCostUsd } from "../cost-cap.ts";
+
+/** Override slots on `SpawnRunInput`, filled only where the parent had one. */
+export interface InheritedDispatchOverrides {
+	readonly providerOverride?: string;
+	readonly modelOverride?: string;
+	readonly maxCostUsdOverride?: number;
+}
+
+/**
+ * Read the three override slots off a failed run's rendered agent. A run
+ * whose frontmatter carries none yields `{}`, so a spread of the result
+ * leaves the retry resolving exactly as the original did.
+ *
+ * `renderedAgentJson` is `unknown` on the row, and a hand-built fixture or
+ * an older row can carry anything, so the shape is narrowed rather than
+ * asserted.
+ */
+export function inheritedDispatchOverrides(renderedAgentJson: unknown): InheritedDispatchOverrides {
+	const frontmatter = readFrontmatter(renderedAgentJson);
+	const provider = readProviderFrontmatter(frontmatter);
+	const capUsd = readMaxCostUsd(frontmatter);
+	return {
+		...(provider.provider !== undefined ? { providerOverride: provider.provider } : {}),
+		...(provider.model !== undefined ? { modelOverride: provider.model } : {}),
+		...(capUsd !== null ? { maxCostUsdOverride: capUsd } : {}),
+	};
+}
+
+function readFrontmatter(renderedAgentJson: unknown): Readonly<Record<string, unknown>> {
+	if (renderedAgentJson === null || typeof renderedAgentJson !== "object") return {};
+	const { frontmatter } = renderedAgentJson as { frontmatter?: unknown };
+	if (frontmatter === null || typeof frontmatter !== "object") return {};
+	return frontmatter as Readonly<Record<string, unknown>>;
+}

--- a/src/runs/retry/provider-retry.test.ts
+++ b/src/runs/retry/provider-retry.test.ts
@@ -147,6 +147,8 @@ async function setup(
 		providerMessage?: string;
 		httpStatus?: number | null;
 		upstreamBody?: string | null;
+		/** Folded onto the failed run the way a real dispatch freezes it. */
+		frontmatter?: Record<string, unknown>;
 	} = {},
 ): Promise<Fixture> {
 	const db = await openDatabase({ path: ":memory:" });
@@ -162,7 +164,7 @@ async function setup(
 		agentName: "refactor-bot",
 		projectId: project.id,
 		prompt: "work the seed",
-		renderedAgentJson: {},
+		renderedAgentJson: opts.frontmatter !== undefined ? { frontmatter: opts.frontmatter } : {},
 		trigger: opts.trigger ?? "manual",
 		sandboxId: "bur_aaaaaaaaaaaa",
 		sandboxRunId: "run_zzzzzzzzzzzz",
@@ -324,6 +326,11 @@ describe("createProviderRetryLifecycleExtension", () => {
 		// retryOf back-link (warren-eaa6/warren-58ff): the successor row
 		// carries the original run's id so retry projections see it.
 		expect(call.retryOf).toBe(fixture.runId);
+		// A run that declared no provider, model or cap passes none, so the
+		// retry resolves off the agent and the project defaults as it did.
+		expect(call.providerOverride).toBeUndefined();
+		expect(call.modelOverride).toBeUndefined();
+		expect(call.maxCostUsdOverride).toBeUndefined();
 		expect(started).toEqual([spawn.newRunId]);
 
 		// The successor names its origin (also the single-retry bound marker).
@@ -337,6 +344,23 @@ describe("createProviderRetryLifecycleExtension", () => {
 		const oldEvents = await fixture.repos.events.listByRun(fixture.runId);
 		const dispatched = oldEvents.find((e) => e.kind === PROVIDER_RETRY_EVENTS.retryDispatched);
 		expect((dispatched?.payloadJson as { newRunId?: string }).newRunId).toBe(spawn.newRunId);
+	});
+
+	test("carries the provider, model and cap the failed run resolved (warren-0d80)", async () => {
+		// Observed 2026-08-20: a run dispatched on one model retried on the
+		// project default, because the overrides never reached spawnRun.
+		const fixture = await setup({
+			frontmatter: {
+				provider: "openrouter",
+				model: "deepseek/deepseek-v4-pro-0813",
+				maxCostUsd: 6,
+			},
+		});
+		const { spawn } = await fire(fixture);
+		const call = spawn.calls[0] as SpawnCall;
+		expect(call.providerOverride).toBe("openrouter");
+		expect(call.modelOverride).toBe("deepseek/deepseek-v4-pro-0813");
+		expect(call.maxCostUsdOverride).toBe(6);
 	});
 
 	test("retries a 5xx httpStatus even when the prose names no status code", async () => {

--- a/src/runs/retry/provider-retry.ts
+++ b/src/runs/retry/provider-retry.ts
@@ -55,6 +55,7 @@ import { type LifecycleExtension, WARREN_EXT_PROTOCOL } from "../lifecycle-bus.t
 import { spawnRun } from "../spawn/index.ts";
 import type { SpawnLogger } from "../spawn/types.ts";
 import type { BridgeRegistry } from "../stream/types.ts";
+import { inheritedDispatchOverrides } from "./inherited-overrides.ts";
 
 /** Event kinds this module stamps for lineage + observability. */
 export const PROVIDER_RETRY_EVENTS = {
@@ -289,6 +290,8 @@ async function dispatchProviderRetry(
 		readonly trigger: string;
 		readonly seedId: string | null;
 		readonly mode: "batch";
+		/** Frozen at the original dispatch; the retry's overrides are read back off it. */
+		readonly renderedAgentJson: unknown;
 	},
 	message: string,
 ): Promise<void> {
@@ -313,6 +316,11 @@ async function dispatchProviderRetry(
 			dispatchOrigin: "retry_provider",
 			...(run.seedId !== null ? { seedId: run.seedId } : {}),
 			mode: run.mode,
+			// warren-0d80: the provider, model and cap the original run actually
+			// resolved sit folded on its frozen frontmatter. Without them the
+			// retry re-resolves off the agent and the project defaults, so an
+			// operator-selected model silently swaps mid-lineage.
+			...inheritedDispatchOverrides(run.renderedAgentJson),
 			// Lineage on the row (warren-e96f `replicate` semantics): a fresh
 			// re-dispatch of the failed run's config off the project default
 			// branch, independent of whatever the failed run did. The event


### PR DESCRIPTION
Closes #1039.

## Summary

- `src/runs/retry/inherited-overrides.ts`: reads `providerOverride` / `modelOverride` / `maxCostUsdOverride` off a failed run's frozen `renderedAgentJson.frontmatter`, the same three slots `resolveCloneDefaults` already reads by hand on the HTTP clone path.
- `dispatchProviderRetry` spreads all three into `spawnRun`.
- `buildRetrySpawnInput` takes provider and model, and keeps its own cap.

The shared helper rather than two copies, as the issue suggested. `check:dups` stays green either way at this size, but the interesting reason is the next one.

## The cap is the one thing infra-lost must not inherit

This is the bit worth reviewing. `decideInfraLostRetry` already gives its retry the original cap **minus what the first attempt spent** (warren-4af7), and that remaining budget comes from the same frozen frontmatter. So spreading the helper wholesale there would replace a $3 remainder with the original $5 cap and hand a failed run a fresh budget.

The helper therefore returns the three slots separately, infra-lost picks two, and its existing cap line stays. There is a test that pins it:

```
keeps the remaining budget as the cap, not the original's full one (warren-0d80)
  original: maxCostUsd 5, costUsd 2  →  maxCostUsdOverride 3
```

The provider retry has no equivalent, because the failure it answers happens before the agent burns the budget it was given, so it inherits the cap verbatim.

## One thing I measured instead of assuming

I first wrote the helper's test asserting that `readMaxCostUsd` rejects a string cap. It does not:

```
"4"   -> 4
-1    -> null
0     -> null
"abc" -> null
```

It coerces a numeric string on purpose, the `cn --fm` trap its own module doc describes. The test now pins the real behaviour and says why, because a retry that silently dropped a cap the original honoured would be its own bug.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun test src/runs/retry`: 40 tests across 3 files, up from 30
- [x] `bun run check:all`: 11 of 12 gates green

The two integration assertions were checked against the old code rather than assumed. With both retry modules stashed and the tests kept:

```
(fail) infra-lost run auto-retry > carries the provider and model the failed run resolved
(fail) createProviderRetryLifecycleExtension > carries the provider, model and cap the failed run resolved
39 pass, 2 fail
```

`check:coverage` is the twelfth gate. It fails on this machine, which is Windows, and fails the same way on unmodified `main`: `comm -3` between the failure sets is empty, 104 distinct tests either way, all POSIX assumptions (`/data/projects` fallbacks, `chmod 0600` round-trips, sqlite file paths, the macOS seatbelt profile).

One run of the full suite also showed `article-ix-gate > a protected path hidden among many ordinary files is still caught` failing. It passes alone (14 pass, 15s: the suite spawns git), and a second full run came back at exactly the baseline 104. Load flake on this machine, not a finding.

## Overlap with #1045

Both touch `provider-retry.ts`. I test-merged rather than guessing:

```
$ git merge --no-ff feat/bounded-provider-retry
Auto-merging src/runs/retry/provider-retry.ts          # clean
Auto-merging src/runs/retry/provider-retry.test.ts
CONFLICT (content): Merge conflict in src/runs/retry/provider-retry.test.ts
```

**The source merges clean.** Only the test file conflicts, because #1045 splits the classifier tests out of it (that file was at 505 lines there) while this one adds tests to it. I deliberately did not repeat that split here, and folded the negative assertion into an existing test instead, so this PR sits at 499 lines and stays small.

Either can merge first. I will rebase whichever loses the race.

I did not exercise a real provider failure against a live cluster.
