### PR TITLE
projects: WARREN_GIT_TIMEOUT_MS override for host-clone git timeouts

### DIFF
--- a/src/projects/add-project.test.ts
+++ b/src/projects/add-project.test.ts
@@ -61,6 +61,28 @@ describe("addProject", () => {
 		expect(row.defaultBranch).toBe("trunk");
 	});
 
+	// warren-4fe1: found registering openclaw (~2.9GB) — the handler never
+	// passes timeoutMs, so the config-level operator override
+	// (WARREN_GIT_TIMEOUT_MS) must reach the cloner through the fallback chain.
+	test("falls back to config.gitTimeoutMs when the caller passes no timeoutMs", async () => {
+		let received: number | undefined;
+		await addProject({
+			repo,
+			config: { ...CFG, gitTimeoutMs: 900_000 },
+			gitUrl: "https://github.com/x/big.git",
+			spawn: NOOP_SPAWN,
+			clone: async (input) => {
+				received = input.timeoutMs;
+				return {
+					localPath: `${input.config.root}/${input.owner}/${input.name}`,
+					defaultBranch: "main",
+				};
+			},
+		});
+
+		expect(received).toBe(900_000);
+	});
+
 	test("persists hasSeeds=true after probe (warren-9990)", async () => {
 		const row = await addProject({
 			repo,

--- a/src/projects/config.test.ts
+++ b/src/projects/config.test.ts
@@ -56,10 +56,29 @@ describe("loadProjectsConfigFromEnv", () => {
 			loadProjectsConfigFromEnv({
 				WARREN_PROJECTS_DIR: "/srv/projects",
 				WARREN_GIT_BINARY: "/usr/local/bin/git",
+				WARREN_GIT_TIMEOUT_MS: "900000",
 			}),
 		).toEqual({
 			root: "/srv/projects",
 			gitBinary: "/usr/local/bin/git",
+			gitTimeoutMs: 900000,
 		});
+	});
+
+	// The first payer is openclaw (~2.9GB): a full registration clone cannot
+	// finish inside the 120s default, and the server offered no override.
+	test("omits gitTimeoutMs when WARREN_GIT_TIMEOUT_MS is unset or blank", () => {
+		expect(loadProjectsConfigFromEnv({})).not.toHaveProperty("gitTimeoutMs");
+		expect(loadProjectsConfigFromEnv({ WARREN_GIT_TIMEOUT_MS: "  " })).not.toHaveProperty(
+			"gitTimeoutMs",
+		);
+	});
+
+	test("rejects a non-positive or non-integer WARREN_GIT_TIMEOUT_MS", () => {
+		for (const bad of ["0", "-5", "abc", "1.5"]) {
+			expect(() => loadProjectsConfigFromEnv({ WARREN_GIT_TIMEOUT_MS: bad })).toThrow(
+				ValidationError,
+			);
+		}
 	});
 });

--- a/src/projects/config.ts
+++ b/src/projects/config.ts
@@ -12,6 +12,12 @@
  *   WARREN_DATA_DIR       the deploy's persistent volume — the projects root
  *                         derives from it (see below)
  *   WARREN_GIT_BINARY     git binary path — defaults to "git" (shared with canopy registry)
+ *   WARREN_GIT_TIMEOUT_MS host-clone git operation timeout in milliseconds —
+ *                         registration clones and refresh fetches. Unset falls
+ *                         back to DEFAULT_GIT_TIMEOUT_MS (120s). Large external
+ *                         repos (the first payer: openclaw at ~2.9GB) cannot
+ *                         finish a full clone in 120s, and the server offered
+ *                         no way to say so short of a code change.
  *
  * Why the projects root derives from `WARREN_DATA_DIR` (warren-5c42): the
  * README quickstart mounts ONE volume and points `WARREN_DATA_DIR` at it
@@ -43,6 +49,11 @@ export const DEFAULT_PROJECTS_DIR = join(DEFAULT_DATA_DIR, PROJECTS_SUBDIR);
 export interface ProjectsConfig {
 	readonly root: string;
 	readonly gitBinary: string;
+	/**
+	 * Operator override for host-clone git timeouts (WARREN_GIT_TIMEOUT_MS).
+	 * Absent → callers fall back to DEFAULT_GIT_TIMEOUT_MS.
+	 */
+	readonly gitTimeoutMs?: number;
 }
 
 export type EnvLike = Readonly<Record<string, string | undefined>>;
@@ -66,8 +77,22 @@ export function loadProjectsConfigFromEnv(env: EnvLike = process.env): ProjectsC
 		});
 	}
 
+	const rawTimeout = env.WARREN_GIT_TIMEOUT_MS?.trim();
+	let gitTimeoutMs: number | undefined;
+	if (rawTimeout !== undefined && rawTimeout !== "") {
+		const parsed = Number(rawTimeout);
+		if (!Number.isInteger(parsed) || parsed <= 0) {
+			throw new ValidationError(
+				`WARREN_GIT_TIMEOUT_MS must be a positive integer of milliseconds, got "${rawTimeout}"`,
+				{ recoveryHint: "unset it to fall back to the 120000ms default" },
+			);
+		}
+		gitTimeoutMs = parsed;
+	}
+
 	return {
 		root,
 		gitBinary: env.WARREN_GIT_BINARY ?? "git",
+		...(gitTimeoutMs !== undefined ? { gitTimeoutMs } : {}),
 	};
 }

--- a/src/projects/manage.ts
+++ b/src/projects/manage.ts
@@ -137,7 +137,7 @@ export async function addProject(input: AddProjectInput): Promise<ProjectRow> {
 		defaultBranch: input.defaultBranch,
 		gitCredential: input.gitCredential,
 		spawn: input.spawn,
-		timeoutMs: input.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
+		timeoutMs: input.timeoutMs ?? config.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
 	});
 
 	const detect = input.detectFeatures ?? detectProjectFeatures;
@@ -233,7 +233,7 @@ export async function refreshProject(input: RefreshProjectInput): Promise<Refres
 		...(input.fetchCommit !== undefined ? { fetchCommit: input.fetchCommit } : {}),
 		gitCredential: input.gitCredential,
 		spawn: input.spawn,
-		timeoutMs: input.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
+		timeoutMs: input.timeoutMs ?? config.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS,
 		armHooks,
 	});
 


### PR DESCRIPTION
POST /projects clones with a fixed 120s timeout and no operator override, so registering a large external repo dies at exit 143 / early EOF — hit on the first attempt to register the ~2.9GB `warren-run-bot/openclaw` fork on app.warren.run (warren-4fe1, OpenClaw campaign go-live).

- `WARREN_GIT_TIMEOUT_MS` parses into `ProjectsConfig.gitTimeoutMs` (positive integer; nonsense fails closed with a recovery hint)
- `addProject` and `refreshProject` fall back `input.timeoutMs ?? config.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS`
- unset env keeps today's 120s behavior byte-for-byte

Full `check:all` 12/12 in a clean worktree. Follow-up (filed in warren-4fe1): partial clone (`--filter=blob:none`) for big host clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLVwPhzSJstckKDNAfuECM