### PR TITLE
Auto-merge gate: accept a comma-separated AUTO_MERGE_BOT_LOGIN list (warren-7d31)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,10 +1,15 @@
 name: auto-merge
 
 # Enable GitHub's auto-merge on PRs authored by the repo owner — or by
-# the deployment's dedicated bot account, named by the repo variable
-# AUTO_MERGE_BOT_LOGIN (unset → owner-only; a variable rather than a
-# hardcoded login so forks/self-hosters name their own bot) — so they
-# merge as soon as the `ci` required check passes. Other authors' PRs
+# one of the deployment's dedicated bot accounts, named by the repo
+# variable AUTO_MERGE_BOT_LOGIN (unset → owner-only; a variable rather
+# than a hardcoded login so forks/self-hosters name their own bot) — so
+# they merge as soon as the `ci` required check passes. The variable
+# accepts a comma-separated list with no spaces (warren-7d31), because
+# a deployment can author run PRs under more than one identity: the
+# forge GitHub App (`<app-slug>[bot]`) when the App credential opens
+# the PR, and the machine account (e.g. `warren-run-bot`) when a
+# run-scoped token does. Other authors' PRs
 # still run CI but require a manual `gh pr merge` (or click). Squash is
 # the chosen merge method — keeps main history linear, drops the
 # burrow/run_xxx branch noise from agent-opened PRs.
@@ -32,7 +37,8 @@ jobs:
       !github.event.pull_request.draft &&
       (github.event.pull_request.user.login == github.repository_owner ||
        (vars.AUTO_MERGE_BOT_LOGIN != '' &&
-        github.event.pull_request.user.login == vars.AUTO_MERGE_BOT_LOGIN)) &&
+        contains(format(',{0},', vars.AUTO_MERGE_BOT_LOGIN),
+                 format(',{0},', github.event.pull_request.user.login)))) &&
       !contains(github.event.pull_request.labels.*.name, 'no-automerge')
     steps:
       # Pin to the PR head SHA, not the default `refs/pull/N/merge` ref.


### PR DESCRIPTION
## Summary
- Fixes warren-7d31: enable-auto-merge skipped every green run PR (#1093–#1096) because the `AUTO_MERGE_BOT_LOGIN` repo variable still named `warren-forge-bnnl24[bot]` while run PRs are now authored by `warren-run-bot`.
- Both identities are live paths — the forge App authors the PR when the App credential opens it, the machine account when a run-scoped token does — so the gate now accepts a **comma-separated list** (no spaces) via the sentinel-comma `contains()` pattern. A single login still works; unset/empty still means owner-only.
- The repo variable has already been flipped to `warren-run-bot` (single value, so it matches under the old exact-match gate too, fixing the skip immediately).

## After merge
Extend the variable to cover both identities:
```
gh variable set AUTO_MERGE_BOT_LOGIN -b "warren-run-bot,warren-forge-bnnl24[bot]"
```

## Note
This PR touches `.github/workflows/auto-merge.yml`, an Article IX protected path — it will (correctly) refuse to auto-merge itself and needs a human merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jybTV6kBczdcyTzY4E71o