### PR TITLE
fix(install): dependency preflight for bun bootstrap; smoke provisions unzip

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -45,7 +45,7 @@ jobs:
             sh -c '
               set -eu
               apt-get update -qq
-              apt-get install -y -qq --no-install-recommends ca-certificates curl git >/dev/null
+              apt-get install -y -qq --no-install-recommends ca-certificates curl git unzip >/dev/null
               export WARREN_INSTALL_TARBALL=/tmp/warren-cli.tgz
               sh /install/install.sh
               export PATH="$HOME/.bun/bin:$PATH"
@@ -53,6 +53,23 @@ jobs:
               # idempotent re-run upgrades in place
               sh /install/install.sh
               warren --version
+            '
+
+      - name: "Smoke: missing unzip produces a clear preflight error"
+        run: |
+          # Cheap negative assertion: without unzip (and not root, so the
+          # script's apt-get convenience path cannot kick in), the installer
+          # must die with the actionable message, not an opaque failure.
+          docker run --rm \
+            -v "$PWD/scripts:/install:ro" \
+            ubuntu:24.04 \
+            sh -c '
+              set -eu
+              apt-get update -qq
+              apt-get install -y -qq --no-install-recommends ca-certificates curl git >/dev/null
+              useradd -m tester
+              su tester -c 'sh /install/install.sh 2>&1' > /tmp/out.txt 2>&1 || true
+              grep -q "unzip is required to install bun (Debian/Ubuntu: apt-get install -y unzip)" /tmp/out.txt
             '
 
       - name: "Smoke: node:20-slim (npm present, no bun)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,6 +59,40 @@ ensure_bun() {
     log "found existing bun at $BUN_INSTALL/bin/bun"
     return
   fi
+  # Dependency preflight: bun's installer needs unzip (and we need curl to
+  # fetch it). A clean Debian/Ubuntu container lacks unzip, which used to
+  # surface as an opaque "unzip is required" halfway through the install.
+  # When we are root and apt-get exists, install the missing tools for the
+  # user; otherwise die with the exact fix for their platform.
+  missing=""
+  for tool in curl unzip; do
+    command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+  done
+  if [ -n "$missing" ]; then
+    if [ "$(id -u 2>/dev/null || echo nonroot)" = "0" ] && command -v apt-get >/dev/null 2>&1; then
+      log "installing missing prerequisites:$missing"
+      # shellcheck disable=SC2086
+      apt-get install -y $missing >/dev/null || die "apt-get install failed for:$missing"
+      for tool in curl unzip; do
+        command -v "$tool" >/dev/null 2>&1 || die "$tool is still missing after apt-get install"
+      done
+    else
+      for tool in $missing; do
+        case "$tool" in
+          curl)
+            case "$(uname -s)" in
+              Darwin) die "curl is required to install bun (curl ships with macOS — check your PATH)" ;;
+              *) die "curl is required to install bun (Debian/Ubuntu: apt-get install -y curl)" ;;
+            esac ;;
+          unzip)
+            case "$(uname -s)" in
+              Darwin) die "unzip is required to install bun (unzip ships with macOS)" ;;
+              *) die "unzip is required to install bun (Debian/Ubuntu: apt-get install -y unzip)" ;;
+            esac ;;
+        esac
+      done
+    fi
+  fi
   log "installing bun (user-local, $BUN_INSTALL)"
   # bun's official installer is a bash script (its shebang says so), and it
   # uses `set -o pipefail`, which dash rejects. Never pipe it into `sh` —


### PR DESCRIPTION
Second install-script hardening from the pl-26f3 smoke gate: bun's installer requires `unzip`, which a clean ubuntu container lacks — the smoke job failed with `error: unzip is required to install bun` after the pipefail fix (#1106) landed. Adds a preflight that names the missing tool and the exact install command per platform, and provisions unzip in the smoke container the same way the error message instructs a real user.

Cherry-picked from warren repair run run_kerk7zpr8zjt on the post-merge #1106 branch. Part of plan pl-26f3 follow-through (warren-5765).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dqfx2fv2EHToaBV2xoa3G