### PR TITLE
fix(ci): unnest quotes in negative smoke assertion

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -68,7 +68,7 @@ jobs:
               apt-get update -qq
               apt-get install -y -qq --no-install-recommends ca-certificates curl git >/dev/null
               useradd -m tester
-              su tester -c 'sh /install/install.sh 2>&1' > /tmp/out.txt 2>&1 || true
+              su tester -c "sh /install/install.sh" > /tmp/out.txt 2>&1 || true
               grep -q "unzip is required to install bun (Debian/Ubuntu: apt-get install -y unzip)" /tmp/out.txt
             '
 


### PR DESCRIPTION
One-line follow-up to #1108: the negative smoke assertion nested single quotes inside the outer `sh -c '...'`, so dash saw an ambiguous redirect and the step failed. Quote the inner `su -c` command with double quotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dqfx2fv2EHToaBV2xoa3G