### PR TITLE
fix(install): apt-get update before the prerequisite install

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -68,7 +68,7 @@ jobs:
               apt-get update -qq
               apt-get install -y -qq --no-install-recommends ca-certificates curl git >/dev/null
               useradd -m tester
-              su tester -c 'sh /install/install.sh 2>&1' > /tmp/out.txt 2>&1 || true
+              su tester -c "sh /install/install.sh" > /tmp/out.txt 2>&1 || true
               grep -q "unzip is required to install bun (Debian/Ubuntu: apt-get install -y unzip)" /tmp/out.txt
             '
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,6 +71,8 @@ ensure_bun() {
   if [ -n "$missing" ]; then
     if [ "$(id -u 2>/dev/null || echo nonroot)" = "0" ] && command -v apt-get >/dev/null 2>&1; then
       log "installing missing prerequisites:$missing"
+      # Slim images ship empty apt lists — update before the first install.
+      apt-get update -qq >/dev/null 2>&1 || true
       # shellcheck disable=SC2086
       apt-get install -y $missing >/dev/null || die "apt-get install failed for:$missing"
       for tool in curl unzip; do


### PR DESCRIPTION
Third smoke-gate iteration on scripts/install.sh: the root+apt convenience path ran `apt-get install` without `apt-get update`, which fails on slim images (node:20-slim ships empty package lists) — the smoke variant died with `apt-get install failed for: curl unzip`. Run a quiet `apt-get update` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dqfx2fv2EHToaBV2xoa3G