### PR TITLE
Expose the composed workspace branch on the run wire (warren-5255)

### DIFF
--- a/extensions/campaign-controller/src/dispatch/dispatcher.test.ts
+++ b/extensions/campaign-controller/src/dispatch/dispatcher.test.ts
@@ -290,6 +290,30 @@ describe("WarrenDispatcher", () => {
 		expect(h.store.budget.listReservations(h.campaign.id)[0]?.state).toBe("active");
 	});
 
+	test("settles resultBranch from the composed run branch when no targetBranch override exists (warren-5255)", async () => {
+		const h = harness();
+		const outcome = await h.dispatcher.dispatch({
+			campaignId: h.campaign.id,
+			workItemId: h.workItem.id,
+			request: REQUEST,
+			reservationId: h.reservationId,
+		});
+		const runId = outcome.runId as string;
+		// The live-bug shape: a default dispatch has no targetBranch override;
+		// warren serves only the composed `branch` (warren-5255).
+		h.warren.setRunState(runId, {
+			state: "succeeded",
+			costUsd: 0.55,
+			branch: "burrow/run_seq-1",
+		});
+		const reconciled = await h.dispatcher.reconcileRun(runId);
+		expect(reconciled.terminal).toBe(true);
+		expect(reconciled.branch).toBe("burrow/run_seq-1");
+		const action = h.store.actions.listActionsForWorkItem(h.workItem.id)[0] as ActionAssert;
+		expect(action.state).toBe("succeeded");
+		expect(action.resultBranch).toBe("burrow/run_seq-1");
+	});
+
 	test("restart with a known run resumes reads and settles terminal cost", async () => {
 		const h = harness();
 		const outcome = await h.dispatcher.dispatch({

--- a/extensions/campaign-controller/src/dispatch/dispatcher.ts
+++ b/extensions/campaign-controller/src/dispatch/dispatcher.ts
@@ -41,6 +41,7 @@ import { TERMINAL_ACTION_STATES } from "../store/types.ts";
 import {
 	DispatchUncertainError,
 	isTerminalRunState,
+	runPushedBranch,
 	WarrenAuthError,
 	type WarrenClient,
 	WarrenRateLimitError,
@@ -447,7 +448,7 @@ export class WarrenDispatcher {
 				terminal: false,
 				settledNow: false,
 				workItemStatus: workItemId === null ? null : "running",
-				branch: run.targetBranch,
+				branch: runPushedBranch(run),
 				costUsdCents: null,
 			};
 		}
@@ -459,7 +460,7 @@ export class WarrenDispatcher {
 				terminal: true,
 				settledNow: false,
 				workItemStatus: null,
-				branch: run.targetBranch,
+				branch: runPushedBranch(run),
 				costUsdCents: run.costUsd === null ? null : usdToCents(run.costUsd),
 			};
 		}
@@ -472,7 +473,7 @@ export class WarrenDispatcher {
 					? null
 					: canonicalJson({ runState: run.state, failureReason: run.failureReason }),
 				resultRunId: run.id,
-				resultBranch: run.targetBranch,
+				resultBranch: runPushedBranch(run),
 			});
 			if (workItemId !== null) {
 				this.#store.campaigns.setWorkItemStatus(workItemId, succeeded ? "terminal" : "failed");
@@ -490,7 +491,7 @@ export class WarrenDispatcher {
 			terminal: true,
 			settledNow: true,
 			workItemStatus: succeeded ? "terminal" : "failed",
-			branch: run.targetBranch,
+			branch: runPushedBranch(run),
 			costUsdCents: run.costUsd === null ? null : usdToCents(run.costUsd),
 		};
 	}

--- a/extensions/campaign-controller/src/store/actions.ts
+++ b/extensions/campaign-controller/src/store/actions.ts
@@ -194,6 +194,32 @@ export class ActionStore {
 		return this.getAction(id) as ActionRow;
 	}
 
+	/**
+	 * Backfill a settled succeeded action's null `result_branch` from a safe
+	 * re-read of the run (warren-5255): a dispatch that settled against a
+	 * warren predating the run-wire `branch` field journaled null. Fills
+	 * null → value only; a recorded branch is frozen — a mismatch is a
+	 * StateError, never an overwrite.
+	 */
+	backfillResultBranch(id: string, branch: string): ActionRow {
+		const action = this.requireAction(id);
+		if (action.state !== "succeeded") {
+			throw new StateError(
+				`action ${id} is ${action.state}; only a succeeded row backfills a branch`,
+			);
+		}
+		if (action.resultBranch !== null) {
+			if (action.resultBranch !== branch) {
+				throw new StateError(
+					`action ${id} already recorded branch '${action.resultBranch}'; refusing to overwrite with '${branch}'`,
+				);
+			}
+			return action;
+		}
+		this.#update(id, { result_branch: branch });
+		return this.getAction(id) as ActionRow;
+	}
+
 	listActionsForWorkItem(workItemId: string): ActionRow[] {
 		const rows = this.#ctx.db
 			.query(`SELECT ${COLUMNS} FROM actions WHERE work_item_id = ? ORDER BY created_at_ms, id`)

--- a/extensions/campaign-controller/src/tick/tick.test.ts
+++ b/extensions/campaign-controller/src/tick/tick.test.ts
@@ -332,8 +332,8 @@ describe("runTick", () => {
 		h.warren.onGetRunRead((_id, count) => {
 			reads = count;
 			// Read #1 was tick 1's post-dispatch confirmation; read #2 is the
-		// item loop's reconcile (still running), read #3 is the restart
-		// sweep — the run settles only there.
+			// item loop's reconcile (still running), read #3 is the restart
+			// sweep — the run settles only there.
 			if (count >= 3) {
 				h.warren.setRunState(runId, {
 					state: "succeeded",
@@ -384,6 +384,39 @@ describe("runTick", () => {
 		expect(intents).toHaveLength(1);
 		const tick4 = await runTick(h.deps, h.campaignId);
 		expect(stagesOf(tick4.stages)).toContain("pr_intent:already_journaled");
+		expect(
+			h.store.actions
+				.listActionsForCampaign(h.campaignId)
+				.filter((action) => action.actionType === PR_INTENT_ACTION_TYPE),
+		).toHaveLength(1);
+	});
+
+	test("backfills a null journaled result_branch from the run wire (warren-5255)", async () => {
+		const h = harness({});
+		const tick1 = await runTick(h.deps, h.campaignId);
+		const runId = runIdOf(tick1);
+		// A warren predating the run-wire `branch` field: the run succeeds
+		// with no targetBranch override and no composed branch served, so the
+		// dispatch settles with result_branch null and the intent refuses.
+		h.warren.setRunState(runId, { state: "succeeded", costUsd: 1 });
+		const tick2 = await runTick(h.deps, h.campaignId);
+		expect(stagesOf(tick2.stages)).toContain("pr_intent:refused");
+		const settled = h.store.actions
+			.listActionsForCampaign(h.campaignId)
+			.find((action) => action.state === "succeeded");
+		expect(settled?.resultBranch).toBeNull();
+
+		// The warren upgrade lands and the run wire now serves the composed
+		// branch; the next tick backfills the journal row and renders.
+		h.warren.setRunState(runId, { branch: BRANCH });
+		const tick3 = await runTick(h.deps, h.campaignId);
+		expect(stagesOf(tick3.stages)).toContain("pr_intent:rendered");
+		const backfilled = h.store.actions
+			.listActionsForCampaign(h.campaignId)
+			.find((action) => action.resultRunId === runId && action.state === "succeeded");
+		expect(backfilled?.resultBranch).toBe(BRANCH);
+		// No second dispatch, no second intent.
+		expect(h.warren.createdRunCount()).toBe(1);
 		expect(
 			h.store.actions
 				.listActionsForCampaign(h.campaignId)

--- a/extensions/campaign-controller/src/tick/tick.ts
+++ b/extensions/campaign-controller/src/tick/tick.ts
@@ -45,7 +45,7 @@ import {
 import { UpstreamPrReconciler } from "../reconcile/reconciler.ts";
 import type { CampaignStateStore } from "../store/state-store.ts";
 import type { CampaignRow, CampaignStatus, WorkItemRow } from "../store/types.ts";
-import type { WarrenClient } from "../warren-client.ts";
+import { runPushedBranch, type WarrenClient } from "../warren-client.ts";
 
 /** A concurrent tick holds the campaign lease. */
 export class TickConcurrentError extends CampaignControllerError {
@@ -221,14 +221,14 @@ async function runLeasedTick(
 		if (item.status === "terminal" && !intentRenderedFor.has(item.id)) {
 			stages.push(
 				await intentOutcome({
-				deps,
-				dispatcher,
-				campaign,
-				manifest,
-				item,
-				nowMs: deps.clock.nowMs(),
-				alreadyDispatched: true,
-			}),
+					deps,
+					dispatcher,
+					campaign,
+					manifest,
+					item,
+					nowMs: deps.clock.nowMs(),
+					alreadyDispatched: true,
+				}),
 			);
 		}
 	}
@@ -434,6 +434,11 @@ async function intentOutcome(ctx: WorkItemContext): Promise<TickOutcome> {
 			detail: { issue: issueNumber },
 		};
 	}
+	// warren-5255: a dispatch that settled against a warren predating the
+	// run-wire `branch` field journaled result_branch null. Re-read the run
+	// (a safe, retryable GET — the same class reconciliation uses) and
+	// backfill so the intent can derive its cross-fork head ref.
+	await backfillDispatchBranch(ctx);
 	const issue = await readIssueSnapshot(ctx.deps.github, ctx.manifest, issueNumber);
 	const upstream = await readUpstreamFacts(ctx.deps, ctx.manifest);
 	try {
@@ -462,6 +467,30 @@ async function intentOutcome(ctx: WorkItemContext): Promise<TickOutcome> {
 			};
 		}
 		throw error;
+	}
+}
+
+/**
+ * Backfill a succeeded dispatch's missing result_branch from the run wire
+ * (warren-5255). Fill-only: a journaled branch is frozen, and a warren that
+ * still serves no branch leaves the row untouched (the intent then refuses
+ * `run_branch_missing` fail-closed, exactly as before).
+ */
+async function backfillDispatchBranch(ctx: WorkItemContext): Promise<void> {
+	const settled = ctx.deps.store.actions
+		.listActionsForWorkItem(ctx.item.id)
+		.find(
+			(action) =>
+				action.actionType === WARREN_DISPATCH_ACTION_TYPE &&
+				action.state === "succeeded" &&
+				action.resultRunId !== null &&
+				action.resultBranch === null,
+		);
+	if (settled === undefined || settled.resultRunId === null) return;
+	const run = await ctx.deps.warrenClient.getRun(settled.resultRunId);
+	const branch = runPushedBranch(run);
+	if (branch !== null) {
+		ctx.deps.store.actions.backfillResultBranch(settled.id, branch);
 	}
 }
 

--- a/extensions/campaign-controller/src/warren-client.test.ts
+++ b/extensions/campaign-controller/src/warren-client.test.ts
@@ -316,6 +316,7 @@ describe("terminal-state facts", () => {
 			state: "succeeded",
 			ref: "refs/heads/main",
 			targetBranch: "warren/run/seq-1",
+			branch: "warren/run/seq-1",
 			costUsd: 1.25,
 		});
 		const facts = readTerminalFacts(await client.getRun(id));
@@ -325,6 +326,7 @@ describe("terminal-state facts", () => {
 			failureReason: null,
 			ref: "refs/heads/main",
 			targetBranch: "warren/run/seq-1",
+			branch: "warren/run/seq-1",
 			costUsd: 1.25,
 		});
 	});

--- a/extensions/campaign-controller/src/warren-client.ts
+++ b/extensions/campaign-controller/src/warren-client.ts
@@ -41,9 +41,28 @@ export interface WarrenRunView {
 	ref: string | null;
 	/** Branch the reap path pushes the workspace back to. */
 	targetBranch: string | null;
+	/**
+	 * Composed workspace branch frozen at dispatch (warren-5255):
+	 * `${runBranchPrefix}/${runId}`, or the targetBranch override. Null on
+	 * warren instances or run rows predating the column.
+	 */
+	branch: string | null;
 	provider: string | null;
 	model: string | null;
 	costUsd: number | null;
+}
+
+/**
+ * The branch the run's push actually landed on: the dispatch-frozen
+ * `branch` when warren serves it (warren-5255), else the operator
+ * `targetBranch` override, else unknown. Never derives the prefix
+ * composition locally — that is warren's own single source of truth.
+ */
+export function runPushedBranch(run: {
+	branch: string | null;
+	targetBranch: string | null;
+}): string | null {
+	return run.branch ?? run.targetBranch;
 }
 
 /** Terminal-state facts reconciliation (pl-91b6 step 7) reads. */
@@ -53,6 +72,7 @@ export interface WarrenTerminalFacts {
 	failureReason: string | null;
 	ref: string | null;
 	targetBranch: string | null;
+	branch: string | null;
 	costUsd: number | null;
 }
 
@@ -210,6 +230,7 @@ export function parseRunEnvelope(raw: unknown): WarrenRunView {
 		failureReason: asString(row.failureReason),
 		ref: asString(row.ref),
 		targetBranch: asString(row.targetBranch),
+		branch: asString(row.branch),
 		provider: asString(row.provider),
 		model: asString(row.model),
 		costUsd: typeof row.costUsd === "number" ? row.costUsd : null,
@@ -231,6 +252,7 @@ export function readTerminalFacts(run: WarrenRunView): WarrenTerminalFacts {
 		failureReason: run.failureReason,
 		ref: run.ref,
 		targetBranch: run.targetBranch,
+		branch: run.branch,
 		costUsd: run.costUsd,
 	};
 }

--- a/extensions/campaign-controller/src/warren-fake.ts
+++ b/extensions/campaign-controller/src/warren-fake.ts
@@ -37,6 +37,8 @@ export interface FakeRunRow {
 	failureReason: string | null;
 	ref: string | null;
 	targetBranch: string | null;
+	/** Composed workspace branch frozen at dispatch (warren-5255). */
+	branch: string | null;
 	costUsd: number | null;
 }
 
@@ -218,7 +220,7 @@ export class FakeWarrenServer {
 	setRunState(
 		id: string,
 		patch: Partial<
-			Pick<FakeRunRow, "state" | "failureReason" | "costUsd" | "ref" | "targetBranch">
+			Pick<FakeRunRow, "state" | "failureReason" | "costUsd" | "ref" | "targetBranch" | "branch">
 		>,
 	): void {
 		const run = this.runs.get(id);
@@ -272,6 +274,7 @@ export class FakeWarrenServer {
 			failureReason: null,
 			ref: null,
 			targetBranch: null,
+			branch: null,
 			costUsd: null,
 			...fields,
 		};

--- a/src/cli/commands/plan-status.test.ts
+++ b/src/cli/commands/plan-status.test.ts
@@ -105,6 +105,7 @@ function runRow(over: Partial<RunRow> = {}): RunRow {
 		prState: null,
 		prMergedAt: null,
 		targetBranch: null,
+		branch: null,
 		ref: null,
 		provider: null,
 		baseCommit: null,

--- a/src/cli/commands/run.test.ts
+++ b/src/cli/commands/run.test.ts
@@ -64,6 +64,7 @@ function runRow(over: Partial<RunRow> = {}): RunRow {
 		prState: null,
 		prMergedAt: null,
 		targetBranch: null,
+		branch: null,
 		ref: null,
 		baseCommit: null,
 		provider: null,

--- a/src/cli/commands/show.test.ts
+++ b/src/cli/commands/show.test.ts
@@ -51,6 +51,7 @@ function runRow(over: Partial<RunRow> = {}): RunRow {
 		prState: null,
 		prMergedAt: null,
 		targetBranch: null,
+		branch: null,
 		ref: null,
 		baseCommit: null,
 		provider: null,

--- a/src/cli/commands/wait.test.ts
+++ b/src/cli/commands/wait.test.ts
@@ -56,6 +56,7 @@ function runRow(over: Partial<RunRow> = {}): RunRow {
 		prState: null,
 		prMergedAt: null,
 		targetBranch: null,
+		branch: null,
 		ref: null,
 		baseCommit: null,
 		provider: null,

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -131,6 +131,12 @@ export interface RunRow {
 	prState: PullRequestLifecycle | null;
 	prMergedAt: string | null;
 	targetBranch: string | null;
+	/**
+	 * The composed workspace branch the run's push lands on (warren-5255):
+	 * `${runBranchPrefix}/${runId}`, or `targetBranch` when that override
+	 * pinned it. Frozen at dispatch. Null on rows predating the column.
+	 */
+	branch: string | null;
 	/** Dispatch-supplied git ref the workspace was cloned from (warren-afeb). Null when unset. */
 	ref: string | null;
 	/** Base-commit pin (warren-aaf7): 40-hex SHA the workspace was cut at. Null when unset. */

--- a/src/db/migrations/0054_young_gunslinger.sql
+++ b/src/db/migrations/0054_young_gunslinger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `runs` ADD `branch` text;

--- a/src/db/migrations/meta/0054_snapshot.json
+++ b/src/db/migrations/meta/0054_snapshot.json
@@ -1,0 +1,1443 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "4c8747fb-9b01-4373-821b-0622c1fd5b29",
+	"prevId": "2f42fd01-8372-4d44-8b75-86c85c68144f",
+	"tables": {
+		"agents": {
+			"name": "agents",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"rendered_json": {
+					"name": "rendered_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"registered_at": {
+					"name": "registered_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_refreshed": {
+					"name": "last_refreshed",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"agents_name_idx": {
+					"name": "agents_name_idx",
+					"columns": ["name"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"dispatch_context": {
+			"name": "dispatch_context",
+			"columns": {
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_source": {
+					"name": "provider_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"model_source": {
+					"name": "model_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cap_source": {
+					"name": "cap_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"max_cost_usd": {
+					"name": "max_cost_usd",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"runtime_id": {
+					"name": "runtime_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"runtime_backend": {
+					"name": "runtime_backend",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"prompt_bytes": {
+					"name": "prompt_bytes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"network": {
+					"name": "network",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"queue_queued_runs": {
+					"name": "queue_queued_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"queue_running_runs": {
+					"name": "queue_running_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"queue_project_non_terminal": {
+					"name": "queue_project_non_terminal",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"queue_snapshot_source": {
+					"name": "queue_snapshot_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dispatch_origin": {
+					"name": "dispatch_origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dispatcher_handle": {
+					"name": "dispatcher_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"trigger_id": {
+					"name": "trigger_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"plan_run_id": {
+					"name": "plan_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"retry_kind": {
+					"name": "retry_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"retry_of_run_id": {
+					"name": "retry_of_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"attempt_no": {
+					"name": "attempt_no",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"root_run_id": {
+					"name": "root_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"seed_status": {
+					"name": "seed_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"seed_priority": {
+					"name": "seed_priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"seed_size": {
+					"name": "seed_size",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"dispatch_context_created_at_idx": {
+					"name": "dispatch_context_created_at_idx",
+					"columns": ["created_at"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"dispatch_context_run_id_runs_id_fk": {
+					"name": "dispatch_context_run_id_runs_id_fk",
+					"tableFrom": "dispatch_context",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"events": {
+			"name": "events",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"sandbox_event_seq": {
+					"name": "sandbox_event_seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ts": {
+					"name": "ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"stream": {
+					"name": "stream",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"payload_json": {
+					"name": "payload_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"events_run_seq_idx": {
+					"name": "events_run_seq_idx",
+					"columns": ["run_id", "sandbox_event_seq"],
+					"isUnique": false
+				},
+				"events_run_ts_idx": {
+					"name": "events_run_ts_idx",
+					"columns": ["run_id", "ts"],
+					"isUnique": false
+				},
+				"events_kind_ts_idx": {
+					"name": "events_kind_ts_idx",
+					"columns": ["kind", "ts"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"events_run_id_runs_id_fk": {
+					"name": "events_run_id_runs_id_fk",
+					"tableFrom": "events",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"plan_run_children": {
+			"name": "plan_run_children",
+			"columns": {
+				"plan_run_id": {
+					"name": "plan_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_merged_at": {
+					"name": "pr_merged_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"retry_count": {
+					"name": "retry_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"plan_run_children_run_idx": {
+					"name": "plan_run_children_run_idx",
+					"columns": ["run_id"],
+					"isUnique": false
+				},
+				"plan_run_children_state_idx": {
+					"name": "plan_run_children_state_idx",
+					"columns": ["plan_run_id", "state"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"plan_run_children_plan_run_id_plan_runs_id_fk": {
+					"name": "plan_run_children_plan_run_id_plan_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "plan_runs",
+					"columnsFrom": ["plan_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"plan_run_children_run_id_runs_id_fk": {
+					"name": "plan_run_children_run_id_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"plan_run_children_plan_run_id_seq_pk": {
+					"columns": ["plan_run_id", "seq"],
+					"name": "plan_run_children_plan_run_id_seq_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"plan_runs": {
+			"name": "plan_runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"plan_id": {
+					"name": "plan_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'plan'"
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"prompt_template": {
+					"name": "prompt_template",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'work on sd {seed_id}'"
+				},
+				"ref": {
+					"name": "ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider_override": {
+					"name": "provider_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"model_override": {
+					"name": "model_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"max_cost_usd": {
+					"name": "max_cost_usd",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"dispatcher_handle": {
+					"name": "dispatcher_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'operator'"
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'manual'"
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"resumed_at": {
+					"name": "resumed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"plan_runs_project_state_idx": {
+					"name": "plan_runs_project_state_idx",
+					"columns": ["project_id", "state"],
+					"isUnique": false
+				},
+				"plan_runs_state_idx": {
+					"name": "plan_runs_state_idx",
+					"columns": ["state"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"plan_runs_project_id_projects_id_fk": {
+					"name": "plan_runs_project_id_projects_id_fk",
+					"tableFrom": "plan_runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"projects": {
+			"name": "projects",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"git_url": {
+					"name": "git_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"local_path": {
+					"name": "local_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"default_branch": {
+					"name": "default_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_fetched_at": {
+					"name": "last_fetched_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_head_sha": {
+					"name": "last_head_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"has_seeds": {
+					"name": "has_seeds",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				}
+			},
+			"indexes": {
+				"projects_git_url_idx": {
+					"name": "projects_git_url_idx",
+					"columns": ["git_url"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"run_inbox": {
+			"name": "run_inbox",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"priority": {
+					"name": "priority",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'normal'"
+				},
+				"from_actor": {
+					"name": "from_actor",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'operator'"
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'unread'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"delivered_at": {
+					"name": "delivered_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"run_inbox_run_state_idx": {
+					"name": "run_inbox_run_state_idx",
+					"columns": ["run_id", "state"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"run_inbox_run_id_runs_id_fk": {
+					"name": "run_inbox_run_id_runs_id_fk",
+					"tableFrom": "run_inbox",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"runs": {
+			"name": "runs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandbox_id": {
+					"name": "sandbox_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"sandbox_run_id": {
+					"name": "sandbox_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"rendered_agent_json": {
+					"name": "rendered_agent_json",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"prompt": {
+					"name": "prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"pr_url": {
+					"name": "pr_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"target_branch": {
+					"name": "target_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"branch": {
+					"name": "branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"ref": {
+					"name": "ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"base_commit": {
+					"name": "base_commit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"salvage_ref": {
+					"name": "salvage_ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"salvage_path": {
+					"name": "salvage_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cost_usd": {
+					"name": "cost_usd",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"cost_basis": {
+					"name": "cost_basis",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'api'"
+				},
+				"tokens_input": {
+					"name": "tokens_input",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_output": {
+					"name": "tokens_output",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_cache_read": {
+					"name": "tokens_cache_read",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tokens_cache_write": {
+					"name": "tokens_cache_write",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_state": {
+					"name": "preview_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_port": {
+					"name": "preview_port",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_started_at": {
+					"name": "preview_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_last_hit_at": {
+					"name": "preview_last_hit_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"preview_failure_message": {
+					"name": "preview_failure_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'batch'"
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"clone_kind": {
+					"name": "clone_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"retry_of": {
+					"name": "retry_of",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_state": {
+					"name": "pr_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pr_merged_at": {
+					"name": "pr_merged_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"commits_ahead": {
+					"name": "commits_ahead",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"files_changed": {
+					"name": "files_changed",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"insertions": {
+					"name": "insertions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deletions": {
+					"name": "deletions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"runs_state_idx": {
+					"name": "runs_state_idx",
+					"columns": ["state"],
+					"isUnique": false
+				},
+				"runs_project_started_idx": {
+					"name": "runs_project_started_idx",
+					"columns": ["project_id", "\"started_at\" DESC"],
+					"isUnique": false
+				},
+				"runs_agent_started_idx": {
+					"name": "runs_agent_started_idx",
+					"columns": ["agent_name", "\"started_at\" DESC"],
+					"isUnique": false
+				},
+				"runs_worker_state_idx": {
+					"name": "runs_worker_state_idx",
+					"columns": ["worker_id", "state"],
+					"isUnique": false
+				},
+				"runs_mode_idx": {
+					"name": "runs_mode_idx",
+					"columns": ["mode"],
+					"isUnique": false
+				},
+				"runs_pr_url_idx": {
+					"name": "runs_pr_url_idx",
+					"columns": ["pr_url"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"runs_project_id_projects_id_fk": {
+					"name": "runs_project_id_projects_id_fk",
+					"tableFrom": "runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"tool_calls": {
+			"name": "tool_calls",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ts": {
+					"name": "ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"tool_name": {
+					"name": "tool_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"command": {
+					"name": "command",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"file_paths": {
+					"name": "file_paths",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"tool_use_id": {
+					"name": "tool_use_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"is_error": {
+					"name": "is_error",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"result_bytes": {
+					"name": "result_bytes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"tool_calls_run_seq_idx": {
+					"name": "tool_calls_run_seq_idx",
+					"columns": ["run_id", "seq"],
+					"isUnique": true
+				},
+				"tool_calls_run_use_id_idx": {
+					"name": "tool_calls_run_use_id_idx",
+					"columns": ["run_id", "tool_use_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"tool_calls_run_id_runs_id_fk": {
+					"name": "tool_calls_run_id_runs_id_fk",
+					"tableFrom": "tool_calls",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"triggers": {
+			"name": "triggers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"trigger_id": {
+					"name": "trigger_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"last_fired_at": {
+					"name": "last_fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"next_fire_at": {
+					"name": "next_fire_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_run_id": {
+					"name": "last_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"triggers_project_idx": {
+					"name": "triggers_project_idx",
+					"columns": ["project_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"triggers_project_id_projects_id_fk": {
+					"name": "triggers_project_id_projects_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"triggers_last_run_id_runs_id_fk": {
+					"name": "triggers_last_run_id_runs_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "runs",
+					"columnsFrom": ["last_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {
+			"runs_project_started_idx": {
+				"columns": {
+					"\"started_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			},
+			"runs_agent_started_idx": {
+				"columns": {
+					"\"started_at\" DESC": {
+						"isExpression": true
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -379,6 +379,13 @@
 			"when": 1787850244312,
 			"tag": "0053_futuristic_blur",
 			"breakpoints": true
+		},
+		{
+			"idx": 54,
+			"version": "6",
+			"when": 1787855601342,
+			"tag": "0054_young_gunslinger",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/migrations/postgres/0049_lively_terrax.sql
+++ b/src/db/migrations/postgres/0049_lively_terrax.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "runs" ADD COLUMN "branch" text;

--- a/src/db/migrations/postgres/meta/0049_snapshot.json
+++ b/src/db/migrations/postgres/meta/0049_snapshot.json
@@ -1,0 +1,1570 @@
+{
+	"id": "0afa4c61-54b9-4f13-92d2-5f14a529f9f6",
+	"prevId": "d2533b46-21eb-4095-bec6-7ed8582d6779",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.agents": {
+			"name": "agents",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"rendered_json": {
+					"name": "rendered_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"registered_at": {
+					"name": "registered_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_refreshed": {
+					"name": "last_refreshed",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"agents_name_idx": {
+					"name": "agents_name_idx",
+					"columns": [
+						{
+							"expression": "name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.dispatch_context": {
+			"name": "dispatch_context",
+			"schema": "",
+			"columns": {
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_source": {
+					"name": "provider_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"model_source": {
+					"name": "model_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cap_source": {
+					"name": "cap_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_cost_usd": {
+					"name": "max_cost_usd",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"runtime_id": {
+					"name": "runtime_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"runtime_backend": {
+					"name": "runtime_backend",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prompt_bytes": {
+					"name": "prompt_bytes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"network": {
+					"name": "network",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"queue_queued_runs": {
+					"name": "queue_queued_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"queue_running_runs": {
+					"name": "queue_running_runs",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"queue_project_non_terminal": {
+					"name": "queue_project_non_terminal",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"queue_snapshot_source": {
+					"name": "queue_snapshot_source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatch_origin": {
+					"name": "dispatch_origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatcher_handle": {
+					"name": "dispatcher_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"trigger_id": {
+					"name": "trigger_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"plan_run_id": {
+					"name": "plan_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retry_kind": {
+					"name": "retry_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retry_of_run_id": {
+					"name": "retry_of_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"attempt_no": {
+					"name": "attempt_no",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"root_run_id": {
+					"name": "root_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seed_status": {
+					"name": "seed_status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seed_priority": {
+					"name": "seed_priority",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seed_size": {
+					"name": "seed_size",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"dispatch_context_created_at_idx": {
+					"name": "dispatch_context_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"dispatch_context_run_id_runs_id_fk": {
+					"name": "dispatch_context_run_id_runs_id_fk",
+					"tableFrom": "dispatch_context",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.events": {
+			"name": "events",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"sandbox_event_seq": {
+					"name": "sandbox_event_seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ts": {
+					"name": "ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stream": {
+					"name": "stream",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"payload_json": {
+					"name": "payload_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"events_run_seq_idx": {
+					"name": "events_run_seq_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "sandbox_event_seq",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"events_run_ts_idx": {
+					"name": "events_run_ts_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "ts",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"events_kind_ts_idx": {
+					"name": "events_kind_ts_idx",
+					"columns": [
+						{
+							"expression": "kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "ts",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"events_run_id_runs_id_fk": {
+					"name": "events_run_id_runs_id_fk",
+					"tableFrom": "events",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.plan_run_children": {
+			"name": "plan_run_children",
+			"schema": "",
+			"columns": {
+				"plan_run_id": {
+					"name": "plan_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pr_merged_at": {
+					"name": "pr_merged_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retry_count": {
+					"name": "retry_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				}
+			},
+			"indexes": {
+				"plan_run_children_run_idx": {
+					"name": "plan_run_children_run_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"plan_run_children_state_idx": {
+					"name": "plan_run_children_state_idx",
+					"columns": [
+						{
+							"expression": "plan_run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"plan_run_children_plan_run_id_plan_runs_id_fk": {
+					"name": "plan_run_children_plan_run_id_plan_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "plan_runs",
+					"columnsFrom": ["plan_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"plan_run_children_run_id_runs_id_fk": {
+					"name": "plan_run_children_run_id_runs_id_fk",
+					"tableFrom": "plan_run_children",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"plan_run_children_plan_run_id_seq_pk": {
+					"name": "plan_run_children_plan_run_id_seq_pk",
+					"columns": ["plan_run_id", "seq"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.plan_runs": {
+			"name": "plan_runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"plan_id": {
+					"name": "plan_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source": {
+					"name": "source",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'plan'"
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"prompt_template": {
+					"name": "prompt_template",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'work on sd {seed_id}'"
+				},
+				"ref": {
+					"name": "ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider_override": {
+					"name": "provider_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"model_override": {
+					"name": "model_override",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"max_cost_usd": {
+					"name": "max_cost_usd",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"dispatcher_handle": {
+					"name": "dispatcher_handle",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'operator'"
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'manual'"
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resumed_at": {
+					"name": "resumed_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"plan_runs_project_state_idx": {
+					"name": "plan_runs_project_state_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"plan_runs_state_idx": {
+					"name": "plan_runs_state_idx",
+					"columns": [
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"plan_runs_project_id_projects_id_fk": {
+					"name": "plan_runs_project_id_projects_id_fk",
+					"tableFrom": "plan_runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.projects": {
+			"name": "projects",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"git_url": {
+					"name": "git_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"local_path": {
+					"name": "local_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"default_branch": {
+					"name": "default_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"added_at": {
+					"name": "added_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_fetched_at": {
+					"name": "last_fetched_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_head_sha": {
+					"name": "last_head_sha",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_seeds": {
+					"name": "has_seeds",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {
+				"projects_git_url_idx": {
+					"name": "projects_git_url_idx",
+					"columns": [
+						{
+							"expression": "git_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.run_inbox": {
+			"name": "run_inbox",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"body": {
+					"name": "body",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"priority": {
+					"name": "priority",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'normal'"
+				},
+				"from_actor": {
+					"name": "from_actor",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'operator'"
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'unread'"
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"delivered_at": {
+					"name": "delivered_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"run_inbox_run_state_idx": {
+					"name": "run_inbox_run_state_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"run_inbox_run_id_runs_id_fk": {
+					"name": "run_inbox_run_id_runs_id_fk",
+					"tableFrom": "run_inbox",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.runs": {
+			"name": "runs",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"agent_name": {
+					"name": "agent_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sandbox_id": {
+					"name": "sandbox_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"sandbox_run_id": {
+					"name": "sandbox_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"worker_id": {
+					"name": "worker_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"seed_id": {
+					"name": "seed_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"rendered_agent_json": {
+					"name": "rendered_agent_json",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"state": {
+					"name": "state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"failure_reason": {
+					"name": "failure_reason",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ended_at": {
+					"name": "ended_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"prompt": {
+					"name": "prompt",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"trigger": {
+					"name": "trigger",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"pr_url": {
+					"name": "pr_url",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"target_branch": {
+					"name": "target_branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"branch": {
+					"name": "branch",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ref": {
+					"name": "ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"base_commit": {
+					"name": "base_commit",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"salvage_ref": {
+					"name": "salvage_ref",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"salvage_path": {
+					"name": "salvage_path",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cost_usd": {
+					"name": "cost_usd",
+					"type": "double precision",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cost_basis": {
+					"name": "cost_basis",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'api'"
+				},
+				"tokens_input": {
+					"name": "tokens_input",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_output": {
+					"name": "tokens_output",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_cache_read": {
+					"name": "tokens_cache_read",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tokens_cache_write": {
+					"name": "tokens_cache_write",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_state": {
+					"name": "preview_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_port": {
+					"name": "preview_port",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_started_at": {
+					"name": "preview_started_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_last_hit_at": {
+					"name": "preview_last_hit_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"preview_failure_message": {
+					"name": "preview_failure_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'batch'"
+				},
+				"parent_run_id": {
+					"name": "parent_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"clone_kind": {
+					"name": "clone_kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"retry_of": {
+					"name": "retry_of",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"model": {
+					"name": "model",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pr_state": {
+					"name": "pr_state",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"pr_merged_at": {
+					"name": "pr_merged_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"commits_ahead": {
+					"name": "commits_ahead",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"files_changed": {
+					"name": "files_changed",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"insertions": {
+					"name": "insertions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"deletions": {
+					"name": "deletions",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"runs_state_idx": {
+					"name": "runs_state_idx",
+					"columns": [
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_project_started_idx": {
+					"name": "runs_project_started_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"started_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_agent_started_idx": {
+					"name": "runs_agent_started_idx",
+					"columns": [
+						{
+							"expression": "agent_name",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"started_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_worker_state_idx": {
+					"name": "runs_worker_state_idx",
+					"columns": [
+						{
+							"expression": "worker_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "state",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_mode_idx": {
+					"name": "runs_mode_idx",
+					"columns": [
+						{
+							"expression": "mode",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"runs_pr_url_idx": {
+					"name": "runs_pr_url_idx",
+					"columns": [
+						{
+							"expression": "pr_url",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"runs_project_id_projects_id_fk": {
+					"name": "runs_project_id_projects_id_fk",
+					"tableFrom": "runs",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.tool_calls": {
+			"name": "tool_calls",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"run_id": {
+					"name": "run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"seq": {
+					"name": "seq",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"ts": {
+					"name": "ts",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tool_name": {
+					"name": "tool_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"command": {
+					"name": "command",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"file_paths": {
+					"name": "file_paths",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"tool_use_id": {
+					"name": "tool_use_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_error": {
+					"name": "is_error",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"result_bytes": {
+					"name": "result_bytes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"origin": {
+					"name": "origin",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"tool_calls_run_seq_idx": {
+					"name": "tool_calls_run_seq_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "seq",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"tool_calls_run_use_id_idx": {
+					"name": "tool_calls_run_use_id_idx",
+					"columns": [
+						{
+							"expression": "run_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "tool_use_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"tool_calls_run_id_runs_id_fk": {
+					"name": "tool_calls_run_id_runs_id_fk",
+					"tableFrom": "tool_calls",
+					"tableTo": "runs",
+					"columnsFrom": ["run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.triggers": {
+			"name": "triggers",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"project_id": {
+					"name": "project_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"trigger_id": {
+					"name": "trigger_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_fired_at": {
+					"name": "last_fired_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"next_fire_at": {
+					"name": "next_fire_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_run_id": {
+					"name": "last_run_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"triggers_project_idx": {
+					"name": "triggers_project_idx",
+					"columns": [
+						{
+							"expression": "project_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"triggers_project_id_projects_id_fk": {
+					"name": "triggers_project_id_projects_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "projects",
+					"columnsFrom": ["project_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"triggers_last_run_id_runs_id_fk": {
+					"name": "triggers_last_run_id_runs_id_fk",
+					"tableFrom": "triggers",
+					"tableTo": "runs",
+					"columnsFrom": ["last_run_id"],
+					"columnsTo": ["id"],
+					"onDelete": "set null",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/src/db/migrations/postgres/meta/_journal.json
+++ b/src/db/migrations/postgres/meta/_journal.json
@@ -344,6 +344,13 @@
 			"when": 1787850245665,
 			"tag": "0048_legal_wild_child",
 			"breakpoints": true
+		},
+		{
+			"idx": 49,
+			"version": "7",
+			"when": 1787855601644,
+			"tag": "0049_lively_terrax",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/repos/runs-pr.ts
+++ b/src/db/repos/runs-pr.ts
@@ -1,6 +1,7 @@
 /**
- * PR-fact write methods for the `runs` table (warren-f6af's `setPrUrl`,
- * warren-3bc6's `setPrState`), extracted from `RunsRepo` to keep `runs.ts`
+ * PR- and branch-fact write methods for the `runs` table (warren-f6af's
+ * `setPrUrl`, warren-3bc6's `setPrState`, warren-5255's `setBranch`),
+ * extracted from `RunsRepo` to keep `runs.ts`
  * under the file-size budget. Mirrors the `runs-queries.ts` /
  * `runs-ci-fixer.ts` precedent: each method is a free function taking the
  * `DrizzleAdapter` as its first argument, and `RunsRepo` delegates to it
@@ -28,6 +29,23 @@ async function requireRun(adapter: DrizzleAdapter, id: string): Promise<RunRow> 
  * `finalize` because reap fires this *before* the terminal transition
  * (so the URL lands on the `reap.completed` event payload too).
  */
+/**
+ * Persist the composed workspace branch spawnRun dispatched to
+ * (warren-5255). Written once, right after branch composition — the run id
+ * is generated inside `create`, so the branch cannot ride the insert.
+ */
+export async function setBranch(
+	adapter: DrizzleAdapter,
+	id: string,
+	branch: string,
+): Promise<RunRow> {
+	const db = adapter.drizzle as SqliteDrizzleDb;
+	const runs = adapter.schema.runs;
+	const current = await requireRun(adapter, id);
+	await adapter.runWrite(db.update(runs).set({ branch }).where(eq(runs.id, id)));
+	return { ...current, branch };
+}
+
 export async function setPrUrl(
 	adapter: DrizzleAdapter,
 	id: string,

--- a/src/db/repos/runs-preview.ts
+++ b/src/db/repos/runs-preview.ts
@@ -1,0 +1,93 @@
+/**
+ * Preview-environment write method for the `runs` table (R-19 /
+ * docs/design/preview-environments.md), extracted from `RunsRepo` to keep
+ * `runs.ts` under the file-size budget. Mirrors the `runs-pr.ts` /
+ * `runs-queries.ts` precedent: a free function taking the
+ * `DrizzleAdapter` first, with `RunsRepo` delegating so the call surface
+ * is unchanged.
+ */
+
+import { eq } from "drizzle-orm";
+import { NotFoundError, StateTransitionError, ValidationError } from "../../core/errors.ts";
+import type { SqliteDrizzleDb } from "../client.ts";
+import type { PreviewState, RunRow } from "../schema.ts";
+import type { DrizzleAdapter } from "./drizzle-adapter.ts";
+
+/**
+ * Legal per-run preview-environment advances (warren-66d2). Enumerated from
+ * the live writers: the port allocator stamps `starting` (its own CAS),
+ * launch/reap write `live`/`failed` through `attachPreview`, and teardown /
+ * eviction flip `starting`/`live` → `torn-down` with a state-filtered CAS.
+ *
+ * `null` is the unset arm (project never opted in, or allocation failed
+ * before `starting`) — hence `null → failed`. `torn-down` and `failed`
+ * release the port; a retry re-enters at `starting`, which is why
+ * `failed → starting` is legal while `torn-down → live` (warren-66d2) is not.
+ */
+const PREVIEW_ALLOWED_TRANSITIONS: Record<PreviewState | "unset", readonly PreviewState[]> = {
+	unset: ["starting", "live", "failed"],
+	starting: ["live", "failed", "torn-down"],
+	live: ["failed", "torn-down"],
+	failed: ["starting", "torn-down"],
+	"torn-down": ["starting"],
+};
+
+/**
+ * Guard one preview-state advance. A same-state write is an idempotent re-assert;
+ * anything not in the table throws StateTransitionError (HTTP 409 via server/errors).
+ */
+export function assertPreviewTransition(from: PreviewState | null, to: PreviewState): void {
+	if (from === to) return;
+	if (!PREVIEW_ALLOWED_TRANSITIONS[from ?? "unset"].includes(to)) {
+		throw new StateTransitionError(`invalid preview transition: ${from ?? "unset"} → ${to}`);
+	}
+}
+
+export interface AttachPreviewInput {
+	previewState?: PreviewState | null;
+	previewPort?: number | null;
+	previewStartedAt?: string | null;
+	previewLastHitAt?: string | null;
+	previewFailureMessage?: string | null;
+}
+
+/**
+ * Persist per-run preview environment fields. Mirrors `attachStats`'s
+ * partial-input semantics (mx-49272e): omitted fields preserve existing
+ * values, explicit `null` clears. Throws ValidationError when called with
+ * no fields, matching `attachBurrow` / `attachStats`. Used by reap's
+ * `preview_launch` sub-step, the readiness probe, the host reverse proxy
+ * (debounced `previewLastHitAt`), the eviction worker, and the manual
+ * teardown route.
+ */
+export async function attachPreview(
+	adapter: DrizzleAdapter,
+	id: string,
+	input: AttachPreviewInput,
+): Promise<RunRow> {
+	const db = adapter.drizzle as SqliteDrizzleDb;
+	const runs = adapter.schema.runs;
+	const keys: (keyof AttachPreviewInput)[] = [
+		"previewState",
+		"previewPort",
+		"previewStartedAt",
+		"previewLastHitAt",
+		"previewFailureMessage",
+	];
+	if (keys.every((k) => input[k] === undefined)) {
+		throw new ValidationError("attachPreview requires at least one preview field");
+	}
+	const row = await adapter.pickOne<RunRow>(db.select().from(runs).where(eq(runs.id, id)));
+	if (!row) throw new NotFoundError(`run not found: ${id}`);
+	if (input.previewState !== undefined && input.previewState !== null) {
+		assertPreviewTransition(row.previewState, input.previewState);
+	}
+	const patch: Partial<RunRow> = {};
+	for (const k of keys) {
+		if (input[k] !== undefined) {
+			(patch as Record<string, unknown>)[k] = input[k];
+		}
+	}
+	await adapter.runWrite(db.update(runs).set(patch).where(eq(runs.id, id)));
+	return { ...row, ...patch };
+}

--- a/src/db/repos/runs.ts
+++ b/src/db/repos/runs.ts
@@ -6,7 +6,6 @@ import { generateId } from "../../core/ids.ts";
 import type { SqliteDrizzleDb } from "../client.ts";
 import type {
 	CloneKind,
-	PreviewState,
 	PullRequestLifecycle,
 	RunCostBasis,
 	RunFailureReason,
@@ -22,7 +21,8 @@ import {
 	type RunOutcomeFacts,
 	setOutcomeFacts as setOutcomeFactsBody,
 } from "./runs-outcome-facts.ts";
-import { setPrState, setPrUrl } from "./runs-pr.ts";
+import { setBranch, setPrState, setPrUrl } from "./runs-pr.ts";
+import { type AttachPreviewInput, attachPreview } from "./runs-preview.ts";
 import {
 	aggregate,
 	findByRetryOf,
@@ -51,35 +51,9 @@ export function assertRunTransition(from: RunState, to: RunState): void {
 	}
 }
 
-/**
- * Legal per-run preview-environment advances (warren-66d2). Enumerated from
- * the live writers: the port allocator stamps `starting` (its own CAS),
- * launch/reap write `live`/`failed` through `attachPreview`, and teardown /
- * eviction flip `starting`/`live` → `torn-down` with a state-filtered CAS.
- *
- * `null` is the unset arm (project never opted in, or allocation failed
- * before `starting`) — hence `null → failed`. `torn-down` and `failed`
- * release the port; a retry re-enters at `starting`, which is why
- * `failed → starting` is legal while `torn-down → live` (warren-66d2) is not.
- */
-const PREVIEW_ALLOWED_TRANSITIONS: Record<PreviewState | "unset", readonly PreviewState[]> = {
-	unset: ["starting", "live", "failed"],
-	starting: ["live", "failed", "torn-down"],
-	live: ["failed", "torn-down"],
-	failed: ["starting", "torn-down"],
-	"torn-down": ["starting"],
-};
-
-/**
- * Guard one preview-state advance. A same-state write is an idempotent re-assert;
- * anything not in the table throws StateTransitionError (HTTP 409 via server/errors).
- */
-export function assertPreviewTransition(from: PreviewState | null, to: PreviewState): void {
-	if (from === to) return;
-	if (!PREVIEW_ALLOWED_TRANSITIONS[from ?? "unset"].includes(to)) {
-		throw new StateTransitionError(`invalid preview transition: ${from ?? "unset"} → ${to}`);
-	}
-}
+// Preview-transition guard + input shape live in runs-preview.ts (file-size
+// split); re-exported here so existing import sites keep working.
+export { type AttachPreviewInput, assertPreviewTransition } from "./runs-preview.ts";
 
 export interface CreateRunInput {
 	id?: string;
@@ -136,14 +110,6 @@ export interface AttachStatsInput {
 	tokensCacheWrite?: number | null;
 }
 
-export interface AttachPreviewInput {
-	previewState?: PreviewState | null;
-	previewPort?: number | null;
-	previewStartedAt?: string | null;
-	previewLastHitAt?: string | null;
-	previewFailureMessage?: string | null;
-}
-
 export class RunsRepo {
 	constructor(private readonly adapter: DrizzleAdapter) {}
 
@@ -180,6 +146,7 @@ export class RunsRepo {
 			trigger: input.trigger,
 			prUrl: null,
 			targetBranch: input.targetBranch ?? null,
+			branch: null,
 			ref: input.ref ?? null,
 			baseCommit: input.baseCommit ?? null,
 			provider: input.provider ?? null,
@@ -381,43 +348,19 @@ export class RunsRepo {
 		return { ...current, ...patch };
 	}
 
-	/**
-	 * Persist per-run preview environment fields (R-19 / docs/design/preview-environments.md). Mirrors
-	 * `attachStats`'s partial-input semantics (mx-49272e): omitted fields
-	 * preserve existing values, explicit `null` clears. Throws ValidationError
-	 * when called with no fields, matching `attachBurrow` / `attachStats`.
-	 * Used by reap's `preview_launch` sub-step, the readiness probe, the host
-	 * reverse proxy (debounced `previewLastHitAt`), the eviction worker, and
-	 * the manual teardown route.
-	 */
-	async attachPreview(id: string, input: AttachPreviewInput): Promise<RunRow> {
-		const keys: (keyof AttachPreviewInput)[] = [
-			"previewState",
-			"previewPort",
-			"previewStartedAt",
-			"previewLastHitAt",
-			"previewFailureMessage",
-		];
-		if (keys.every((k) => input[k] === undefined)) {
-			throw new ValidationError("attachPreview requires at least one preview field");
-		}
-		const current = await this.require(id);
-		if (input.previewState !== undefined && input.previewState !== null) {
-			assertPreviewTransition(current.previewState, input.previewState);
-		}
-		const patch: Partial<RunRow> = {};
-		for (const k of keys) {
-			if (input[k] !== undefined) {
-				(patch as Record<string, unknown>)[k] = input[k];
-			}
-		}
-		await this.adapter.runWrite(this.db.update(this.runs).set(patch).where(eq(this.runs.id, id)));
-		return { ...current, ...patch };
+	/** Preview-environment write (R-19); body lives in runs-preview.ts. */
+	attachPreview(id: string, input: AttachPreviewInput): Promise<RunRow> {
+		return attachPreview(this.adapter, id, input);
 	}
 
 	/** PR-fact writes (warren-f6af / warren-3bc6); bodies live in runs-pr.ts. */
 	setPrUrl(id: string, prUrl: string | null): Promise<RunRow> {
 		return setPrUrl(this.adapter, id, prUrl);
+	}
+
+	/** Branch-fact write (warren-5255); body lives in runs-pr.ts. */
+	setBranch(id: string, branch: string): Promise<RunRow> {
+		return setBranch(this.adapter, id, branch);
 	}
 
 	setPrState(

--- a/src/db/schema/postgres.ts
+++ b/src/db/schema/postgres.ts
@@ -112,6 +112,9 @@ export const runs = pgTable(
 		trigger: text("trigger").notNull(),
 		prUrl: text("pr_url"),
 		targetBranch: text("target_branch"),
+		// Composed workspace branch frozen at dispatch (warren-5255); the full
+		// story lives on the `Run.branch` doc comment in src/client/types.ts.
+		branch: text("branch"),
 		// Dispatch-supplied clone ref (warren-afeb); see the sqlite schema comment.
 		ref: text("ref"),
 		// Base-commit pinning (warren-aaf7); see the sqlite schema comment.

--- a/src/db/schema/sqlite.ts
+++ b/src/db/schema/sqlite.ts
@@ -162,10 +162,10 @@ export const runs = sqliteTable(
 		prUrl: text("pr_url"),
 		// Operator-requested target branch (warren-1f81, #419); null = none.
 		targetBranch: text("target_branch"),
+		branch: text("branch"), // composed workspace branch frozen at dispatch (warren-5255)
 		// Operator-requested git ref the workspace was cloned from (warren-afeb),
-		// frozen from the dispatch body's explicit `ref` so POST /runs and the
-		// run projections can echo what a ref-pinned dispatch took. Null = the
-		// run dispatched against the resolved default/continuation base.
+		// frozen from the dispatch body's explicit `ref` so the run projections
+		// echo it. Null = the resolved default/continuation base was used.
 		ref: text("ref"),
 		// Base-commit pinning (warren-aaf7): a 40-hex commit SHA the workspace is
 		// cut at, SPLIT from `ref` (which stays branch-shaped and feeds the PR

--- a/src/runs/spawn/dispatch.ts
+++ b/src/runs/spawn/dispatch.ts
@@ -303,6 +303,11 @@ async function dispatchRun(input: SpawnRunInput): Promise<SpawnRunResult> {
 		env: runEnv,
 	};
 	try {
+		// warren-5255: freeze the composed workspace branch onto the row so
+		// HTTP consumers (the campaign-controller's cross-fork head ref) read
+		// it instead of re-deriving the prefix composition. Inside the try so
+		// a failure unwinds through the same rollback as the dispatch itself.
+		await input.repos.runs.setBranch(run.id, branch);
 		// warren-1f03: dispatch-time drizzle migration preflight. A ref-dispatch
 		// onto an existing branch whose generated migrations collide with a
 		// journal slot main landed after the branch was cut is healed prompt-free

--- a/src/runs/spawn/target-branch.test.ts
+++ b/src/runs/spawn/target-branch.test.ts
@@ -36,6 +36,8 @@ describe("spawnRun: targetBranch (warren-709e)", () => {
 		expect(run.targetBranch).toBe("fix/pr-head");
 		const reread = await repos.runs.require(run.id);
 		expect(reread.targetBranch).toBe("fix/pr-head");
+		// warren-5255: the frozen workspace branch equals the override.
+		expect(reread.branch).toBe("fix/pr-head");
 
 		// The burrow workspace branch equals the push target, not
 		// `${prefix}/${runId}`.
@@ -108,6 +110,10 @@ describe("spawnRun: targetBranch (warren-709e)", () => {
 		expect(run.targetBranch).toBeNull();
 		const upBody = calls[0]?.body as { branch?: string };
 		expect(upBody.branch).toBe(`warren/${run.id}`);
+		// warren-5255: a default dispatch freezes the composed branch onto the
+		// row, so HTTP consumers read it instead of re-deriving the prefix.
+		const reread = await repos.runs.require(run.id);
+		expect(reread.branch).toBe(`warren/${run.id}`);
 	});
 });
 

--- a/src/server/handlers/__golden__/envelopes/run-detail.json
+++ b/src/server/handlers/__golden__/envelopes/run-detail.json
@@ -24,6 +24,7 @@
 			"trigger": "manual",
 			"prUrl": null,
 			"targetBranch": null,
+			"branch": null,
 			"ref": null,
 			"baseCommit": null,
 			"salvageRef": null,

--- a/src/server/handlers/runs/lifecycle.ts
+++ b/src/server/handlers/runs/lifecycle.ts
@@ -45,6 +45,9 @@ export const PUBLIC_RUN_FIELDS = [
 	"trigger",
 	"prUrl",
 	"targetBranch",
+	// warren-5255: the composed workspace branch frozen at dispatch — a
+	// branch name carrying the run id, same spectator class as salvageRef.
+	"branch",
 	// warren-afeb: the dispatch-supplied clone ref — a branch/tag/SHA name of
 	// the same class as targetBranch and salvageRef, safe for spectators.
 	"ref",

--- a/src/ui/src/api/types.ts
+++ b/src/ui/src/api/types.ts
@@ -163,14 +163,14 @@ export interface RunRow {
 	 */
 	prUrl: string | null;
 	/**
-	 * Merge-watcher PR facts (warren-3bc6 / pl-103e step 6). `prState` is
-	 * the forge-reported PR lifecycle; `prMergedAt` its merge instant. Null reads
-	 * as "unknown" (historical rows, no PR), never "not merged".
+	 * Merge-watcher PR facts (warren-3bc6): forge-reported lifecycle + merge
+	 * instant. Null reads as "unknown" (historical rows, no PR), never "not merged".
 	 */
 	prState: PullRequestLifecycle | null;
 	prMergedAt: string | null;
 	/** Existing branch reap pushes the workspace back to (#419). Null when unset. */
 	targetBranch: string | null;
+	branch: string | null; // composed workspace branch frozen at dispatch (warren-5255)
 	/** Dispatch-supplied clone ref (warren-afeb) / base-commit pin (warren-aaf7). Null when unset. */
 	ref: string | null;
 	baseCommit: string | null;


### PR DESCRIPTION
## Why

The live OpenClaw campaign dry run (camp-openclaw-129750) surfaced a gap: run `run_bgm99r4szw2n` succeeded and pushed `burrow/run_bgm99r4szw2n` to the bot fork, but the campaign-controller's `pr_intent` stage refused fail-closed with `run_branch_missing`. The dispatcher settles `resultBranch` from `run.targetBranch` — the operator override, which is null on every default dispatch — and warren never persisted or served the composed `${prefix}/${runId}` branch anywhere on the run wire. An HTTP-only consumer cannot re-derive the composition (the prefix is server-side project config), and doing so would duplicate warren's single source of truth.

## What

**Core**
- New nullable `runs.branch` column (sqlite + postgres migrations): the composed workspace branch, frozen at dispatch by `spawnRun` via `RunsRepo.setBranch` inside the dispatch rollback boundary. Handles all three shapes: default composition, `targetBranch` pin, continuation.
- Served on the run wire; classified public (`PUBLIC_RUN_FIELDS`) — a branch name carrying the run id, same spectator class as `salvageRef`. Run-detail golden regenerated.
- SDK + UI `Run` types gain `branch: string | null`.

**Extension (campaign-controller)**
- `WarrenRunView` parses `branch`; `runPushedBranch()` prefers it with a `targetBranch` fallback for warrens predating the column.
- The dispatcher settles `resultBranch` through that helper (the live-bug fix).
- The `pr_intent` stage backfills a null journaled `result_branch` through a safe, retryable `GET /runs/:id` re-read (`CampaignActions.backfillResultBranch`, fill-only, frozen once recorded) — so the already-settled OpenClaw dispatch heals on the next tick after this deploys, with no store surgery.

## Evidence

- warren: `check:all` 12/12 gates, `build:ui` clean.
- extension: 290/290 tests, acceptance scenario 2/2, typecheck + lint clean.
- New tests: composed-branch persistence on the run row (both shapes), dispatcher settling from `branch` with no override, tick-level backfill → render after a "warren upgrade" mid-campaign.

Blocks warren-84da (Phase 2 first live OpenClaw PR): the RUNBOOK §5 evidence checklist needs the rendered cross-fork intent, which needs this branch fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fp3AVBDMXE1bHipbyuxtdo