### PR TITLE
feat(k8s): cluster-wide cpu budget env, and events RBAC for the pod-warning watcher

### DIFF
--- a/deploy/k8s/base/rbac.yaml
+++ b/deploy/k8s/base/rbac.yaml
@@ -43,6 +43,12 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "create", "delete"]
+  # The pod-warning-events watcher (src/runtime/k8s/pod-event-watcher.ts)
+  # list-watches core v1 Events to surface FailedScheduling / FailedAttachVolume
+  # / image-pull stalls on the run's event stream.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
 ---
 # Binds the control-plane SA (in the `warren` namespace) to the Role in
 # `warren-runs`. A RoleBinding's subject may live in a different namespace than

--- a/docs/RUNBOOK-K8S.md
+++ b/docs/RUNBOOK-K8S.md
@@ -489,6 +489,8 @@ Manifest values live in `deploy/k8s/base/deployment.yaml` plus the overlays.
 | `WARREN_K8S_ANTHROPIC_SECRET_NAME` / `_KEY` | `warren-anthropic-key` / `api-key` | optional agent-key `secretKeyRef` |
 | `WARREN_K8S_GIT_SECRET_NAME` / `_KEY` | `warren-git-token` / `token` | init-container git token source |
 | `WARREN_K8S_EPHEMERAL_STORAGE_REQUEST_MIB` / `_LIMIT_MIB` | `10240` / `10240` (10Gi) | cluster-wide default ephemeral-storage budget (request + limit + emptyDir `sizeLimit`). A per-project `resources` block beats it (§7.3.1) |
+| `WARREN_K8S_MEMORY_REQUEST_MIB` / `_LIMIT_MIB` | `2048` / `4096` | cluster-wide default memory budget; a per-project `resources` block beats it |
+| `WARREN_K8S_CPU_REQUEST_MILLICORES` / `_LIMIT_MILLICORES` | `1000` / `4000` | cluster-wide default cpu budget; a per-project `resources` block beats it. Lower the request on a small node (a two-core laptop VM never schedules the 1-CPU default) |
 | `WARREN_AUTH` | unset ⇒ `token` | auth posture (§2.5); `public` admits credential-less spectators to the public projection |
 | `WARREN_PUBLIC_ALLOWLIST` | unset | owners and/or `owner/repo` entries a public instance may hold; required under `WARREN_AUTH=public` |
 | `WARREN_GITHUB_APP_REGISTRATION` | unset (fail-safe default, §2.6) | existence gate for the `/github-app/*` registration surface (warren-e320). `on`/`off` overrides the default. Gated-off routes answer 404 |

--- a/docs/RUNBOOK-K8S.md
+++ b/docs/RUNBOOK-K8S.md
@@ -511,6 +511,7 @@ The verbs are exactly what `src/runtime/k8s/` exercises:
 | `pods` | `get, list, watch, create, delete` | dispatch (create), the pod-watcher informer (list/watch), status reads (get), reap + GC (delete) |
 | `pods/log` | `get, watch` | the pod-log NDJSON event stream (§6.1 / §5.1) |
 | `configmaps` | `get, list, create, delete` | per-run seed-file ConfigMaps — create at dispatch, list/delete at GC |
+| `events` | `get, list, watch` | the pod-warning-events watcher (`src/runtime/k8s/pod-event-watcher.ts`, warren-32f8) list-watches core Events to surface `FailedScheduling`, `FailedAttachVolume`, and image-pull stalls on the run's event stream. Without it the watcher reconnects on 403 forever |
 
 Two verb families are absent on purpose:
 
@@ -530,7 +531,7 @@ kubectl auth can-i --as=system:serviceaccount:warren:warren \
 
 If dispatch fails with a `403 Forbidden` from the K8s API, check this Role first.
 A missing verb shows up as pods that never get created, or as an informer that never attaches.
-`configmaps` and `watch` are the common gaps — the plan text under-specified them.
+`configmaps`, `watch`, and `events` are the common gaps — the plan text under-specified them.
 
 ### 4.1 NetworkPolicy — run-pod egress contract (warren-8dbb)
 

--- a/src/runtime/k8s/pod-resources.test.ts
+++ b/src/runtime/k8s/pod-resources.test.ts
@@ -152,6 +152,37 @@ describe("resolveK8sPodConfig — ephemeral-storage", () => {
 		expect(c.limits.memoryMiB).toBe(8192);
 		expect(c.requests.memoryMiB).toBe(2048);
 	});
+
+	// cpu follows the same chain: a two-core laptop VM never schedules the
+	// 1-CPU default request, and the repo cannot always carry a .warren/ block.
+	test("reads bounded millicore integers from the WARREN_K8S_CPU_*_MILLICORES env", () => {
+		const c = resolveK8sPodConfig({
+			WARREN_K8S_CPU_REQUEST_MILLICORES: "250",
+			WARREN_K8S_CPU_LIMIT_MILLICORES: "2000",
+		});
+		expect(c.requests.cpuMillicores).toBe(250);
+		expect(c.limits.cpuMillicores).toBe(2000);
+	});
+
+	test("invalid cpu env falls back to the 1/4 CPU defaults", () => {
+		for (const raw of ["9", "64001", "-5", "1.5", "  ", "abc"]) {
+			const c = resolveK8sPodConfig({
+				WARREN_K8S_CPU_REQUEST_MILLICORES: raw,
+				WARREN_K8S_CPU_LIMIT_MILLICORES: raw,
+			});
+			expect(c.requests.cpuMillicores).toBe(1000);
+			expect(c.limits.cpuMillicores).toBe(4000);
+		}
+	});
+
+	test("a per-project cpu block beats the cpu env default", () => {
+		const c = resolveK8sPodConfig(
+			{ WARREN_K8S_CPU_REQUEST_MILLICORES: "250" },
+			{ requests: { cpuMillicores: 500 } },
+		);
+		expect(c.requests.cpuMillicores).toBe(500);
+		expect(c.limits.cpuMillicores).toBe(4000);
+	});
 });
 
 describe("buildRunPod — resource rendering", () => {

--- a/src/runtime/k8s/pod-resources.ts
+++ b/src/runtime/k8s/pod-resources.ts
@@ -9,6 +9,8 @@
 
 import type { V1ResourceRequirements } from "@kubernetes/client-node";
 import {
+	DEFAULT_K8S_CPU_LIMIT_MILLICORES,
+	DEFAULT_K8S_CPU_REQUEST_MILLICORES,
 	DEFAULT_K8S_EPHEMERAL_STORAGE_LIMIT_MIB,
 	DEFAULT_K8S_EPHEMERAL_STORAGE_REQUEST_MIB,
 	DEFAULT_K8S_MEMORY_LIMIT_MIB,
@@ -31,6 +33,40 @@ function pickMiB(env: ResourceEnv, key: string, fallback: number): number {
 	if (raw === undefined || raw === "") return fallback;
 	const n = Number(raw);
 	return Number.isInteger(n) && n >= 64 && n <= 1_048_576 ? n : fallback;
+}
+
+/**
+ * Read a millicore env override, validated against the same 10m..64 CPU bounds
+ * the `.warren/config.yaml` `resources` schema enforces. Invalid values fall
+ * back to `fallback`, same as `pickMiB`.
+ */
+function pickMillicores(env: ResourceEnv, key: string, fallback: number): number {
+	const raw = env[key]?.trim();
+	if (raw === undefined || raw === "") return fallback;
+	const n = Number(raw);
+	return Number.isInteger(n) && n >= 10 && n <= 64_000 ? n : fallback;
+}
+
+/**
+ * Resolve the cpu request/limit (millicores) for a run pod. Same precedence
+ * as `resolveMemoryMiB`: the per-project `resources` block wins, then the
+ * `WARREN_K8S_CPU_REQUEST_MILLICORES` / `_LIMIT_MILLICORES` env defaults,
+ * then the compiled-in 1/4 CPU defaults. The env slot serves a repo that
+ * cannot carry a `.warren/` directory and a small cluster (a laptop VM with
+ * two allocatable cores) where the 1-CPU default request never schedules.
+ */
+export function resolveCpuMillicores(
+	env: ResourceEnv,
+	resources: ResourcesConfig | null | undefined,
+): { request: number; limit: number } {
+	return {
+		request:
+			resources?.requests?.cpuMillicores ??
+			pickMillicores(env, "WARREN_K8S_CPU_REQUEST_MILLICORES", DEFAULT_K8S_CPU_REQUEST_MILLICORES),
+		limit:
+			resources?.limits?.cpuMillicores ??
+			pickMillicores(env, "WARREN_K8S_CPU_LIMIT_MILLICORES", DEFAULT_K8S_CPU_LIMIT_MILLICORES),
+	};
 }
 
 /**

--- a/src/runtime/k8s/pod-spec.ts
+++ b/src/runtime/k8s/pod-spec.ts
@@ -28,8 +28,6 @@
 
 import type { V1Container, V1Pod, V1PodSecurityContext } from "@kubernetes/client-node";
 import {
-	DEFAULT_K8S_CPU_LIMIT_MILLICORES,
-	DEFAULT_K8S_CPU_REQUEST_MILLICORES,
 	DEFAULT_K8S_NETWORK,
 	type NetworkPolicy,
 	type ResourcesConfig,
@@ -52,6 +50,7 @@ import {
 import {
 	clampRequests,
 	type ResolvedResourceQuantities,
+	resolveCpuMillicores,
 	resolveEphemeralStorageMiB,
 	resolveMemoryMiB,
 	resourceRequirements,
@@ -281,6 +280,7 @@ export function resolveK8sPodConfig(
 	// Per-project resources block > WARREN_K8S_EPHEMERAL_STORAGE_*_MIB > 10Gi (warren-4a95).
 	const ephemeral = resolveEphemeralStorageMiB(env, resources);
 	const memory = resolveMemoryMiB(env, resources); // warren-06b8 chain: see pod-resources.ts
+	const cpu = resolveCpuMillicores(env, resources);
 	const config: K8sPodConfig = {
 		namespace: pickString(env, "WARREN_K8S_NAMESPACE", DEFAULT_K8S_NAMESPACE),
 		agentImage: pickString(env, "WARREN_K8S_AGENT_IMAGE", DEFAULT_K8S_AGENT_IMAGE),
@@ -289,12 +289,12 @@ export function resolveK8sPodConfig(
 		gid: WARREN_POD_GID,
 		requests: {
 			memoryMiB: memory.requestMiB,
-			cpuMillicores: resources?.requests?.cpuMillicores ?? DEFAULT_K8S_CPU_REQUEST_MILLICORES,
+			cpuMillicores: cpu.request,
 			ephemeralStorageMiB: ephemeral.requestMiB,
 		},
 		limits: {
 			memoryMiB: memory.limitMiB,
-			cpuMillicores: resources?.limits?.cpuMillicores ?? DEFAULT_K8S_CPU_LIMIT_MILLICORES,
+			cpuMillicores: cpu.limit,
 			ephemeralStorageMiB: ephemeral.limitMiB,
 		},
 		network: resources?.network ?? DEFAULT_K8S_NETWORK,


### PR DESCRIPTION
Two small K8s-runtime fixes, found while bringing warren up on a laptop cluster (Rancher Desktop, k3s, 2 allocatable cores) to drive Azure DevOps repos.

**Why we needed it**

- A run pod requests 1 CPU by default. On a 2-core node where the system pods already hold ~1.2 cores, the pod sat in `Pending` with `FailedScheduling: Insufficient cpu` and the run was eventually cancelled. Memory and ephemeral storage already have cluster-wide `WARREN_K8S_*` env defaults; CPU did not. The only override was a `resources` block in the target repo's `.warren/config.yaml`, which is not always possible when the repo is not yours to change (or is a mirror).
- The `FailedScheduling` was also invisible from warren: the pod-warning-events watcher (warren-32f8) logged `pod-event-watch disconnected; backing off before resume` in a loop. The base `Role` grants pods/pods.log/configmaps but never `events`, so every list-watch got 403. Anyone deploying from `deploy/k8s/base` has a dead watcher today.

**Changes**

- `WARREN_K8S_CPU_REQUEST_MILLICORES` / `WARREN_K8S_CPU_LIMIT_MILLICORES` (`src/runtime/k8s/pod-resources.ts` → `resolveCpuMillicores`), same precedence as the memory knob: per-project `resources` block > env > compiled defaults (1000/4000). Validated to the same 10m..64 CPU bounds the config schema uses; invalid values fall back, like `pickMiB`. `pod-spec.ts` consumes it.
- `deploy/k8s/base/rbac.yaml`: `get/list/watch` on core `events` for the runs-namespace Role.
- `docs/RUNBOOK-K8S.md`: rows for the new CPU knob and for the existing `WARREN_K8S_MEMORY_*` knob, which was missing from the env table.
- Tests: `pod-resources.test.ts` covers env override, per-project precedence, and invalid-value fallback.

Verified on the cluster above: with `WARREN_K8S_CPU_REQUEST_MILLICORES=250` the pod schedules, and with the RBAC change the watcher connects and `FailedScheduling`/image-pull warnings land on the run's event stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rf5tbgdUDmHzKnNXpiJLvg
