### PR TITLE
reap: count commits ahead with --first-parent

### DIFF
--- a/src/runs/reap/no-changes.test.ts
+++ b/src/runs/reap/no-changes.test.ts
@@ -198,7 +198,7 @@ describe("reapRun ref-dispatch zero-commit (warren-ba08)", () => {
 		expect(measured).toEqual([
 			["rev-parse", "--verify", "origin/fix/pr-head"],
 			["push", "origin", "HEAD:fix/pr-head"],
-			["rev-list", "--count", `${FAKE_REV_PARSE_SHA}..HEAD`],
+			["rev-list", "--count", "--first-parent", `${FAKE_REV_PARSE_SHA}..HEAD`],
 			["diff", "--numstat", `${FAKE_REV_PARSE_SHA}..HEAD`],
 		]);
 		const row = await repos.runs.require(runId);

--- a/src/runs/reap/run.test.ts
+++ b/src/runs/reap/run.test.ts
@@ -63,7 +63,7 @@ describe("reapRun", () => {
 		expect(e.calls[0]?.args).toEqual(["push", "origin", "HEAD:agent/refactor-bot/run-1"]);
 		expect(e.calls[0]?.cwd).toBe("/data/sandbox/ws");
 		expect(e.calls[1]?.cmd).toBe("git");
-		expect(e.calls[1]?.args).toEqual(["rev-list", "--count", "main..HEAD"]);
+		expect(e.calls[1]?.args).toEqual(["rev-list", "--count", "--first-parent", "main..HEAD"]);
 		expect(e.calls[2]?.cmd).toBe("git");
 		expect(e.calls[2]?.args).toEqual(["diff", "--numstat", "main..HEAD"]);
 		expect(e.calls[2]?.cwd).toBe("/data/sandbox/ws");
@@ -223,7 +223,7 @@ describe("reapRun", () => {
 
 		expect(result.commitsAhead).toBe(2);
 		const revList = e.calls.find((c) => c.args[0] === "rev-list");
-		expect(revList?.args).toEqual(["rev-list", "--count", "develop..HEAD"]);
+		expect(revList?.args).toEqual(["rev-list", "--count", "--first-parent", "develop..HEAD"]);
 		await customDb.close();
 	});
 

--- a/src/runtime/contract.ts
+++ b/src/runtime/contract.ts
@@ -293,7 +293,7 @@ export interface FinalizeIntent {
 	commit?: string[];
 	/**
 	 * Base ref for the commits-ahead / empty-push count
-	 * (`git rev-list --count <baseBranch>..HEAD`). A provider-NEUTRAL git ref
+	 * (`git rev-list --count --first-parent <baseBranch>..HEAD`). A provider-NEUTRAL git ref
 	 * (RunSpec.baseBranch was promoted first-class, §6.2), NOT a host path.
 	 * Omitted ⇒ `commitsAhead` is `null` (warren-f3bb).
 	 */

--- a/src/runtime/k8s/finalize-collect.ts
+++ b/src/runtime/k8s/finalize-collect.ts
@@ -336,7 +336,7 @@ async function countCommitsAhead(
 		trail.failed("commits_ahead", countBase.error);
 		return null;
 	}
-	const res = await git(["rev-list", "--count", `${countBase.ref}..HEAD`], {
+	const res = await git(["rev-list", "--count", "--first-parent", `${countBase.ref}..HEAD`], {
 		cwd: workspacePath,
 		timeoutMs: 10_000,
 	});

--- a/src/runtime/k8s/finalize-entrypoint.repair-base.test.ts
+++ b/src/runtime/k8s/finalize-entrypoint.repair-base.test.ts
@@ -66,7 +66,7 @@ describe("collectFinalizeResult — ref-dispatch repair topology (warren-ba08)",
 		expect(calls).toEqual([
 			["rev-parse", "--verify", "origin/fix/pr-head"],
 			["push", "origin", "HEAD:fix/pr-head"],
-			["rev-list", "--count", `${SHA}..HEAD`],
+			["rev-list", "--count", "--first-parent", `${SHA}..HEAD`],
 		]);
 		expect(r.stages).toEqual([
 			{ stage: "branch_push", status: "ok" },

--- a/src/runtime/local/finalize.repair-base.test.ts
+++ b/src/runtime/local/finalize.repair-base.test.ts
@@ -54,7 +54,7 @@ describe("finalize — ref-dispatch repair topology (warren-ba08)", () => {
 		expect(exec.calls.map((c) => c.args)).toEqual([
 			["rev-parse", "--verify", "origin/fix/pr-head"],
 			["push", "origin", "HEAD:fix/pr-head"],
-			["rev-list", "--count", `${FAKE_REV_PARSE_SHA}..HEAD`],
+			["rev-list", "--count", "--first-parent", `${FAKE_REV_PARSE_SHA}..HEAD`],
 		]);
 		// Every rev-parse / rev-list runs in the workspace.
 		expect(new Set(exec.calls.map((c) => c.cwd))).toEqual(new Set([WS]));
@@ -120,7 +120,7 @@ describe("finalize — ref-dispatch repair topology (warren-ba08)", () => {
 		expect(result.commitsAheadBase).toBe("main");
 		expect(exec.calls.map((c) => c.args)).toEqual([
 			["push", "origin", "HEAD:warren/run-1"],
-			["rev-list", "--count", "main..HEAD"],
+			["rev-list", "--count", "--first-parent", "main..HEAD"],
 		]);
 	});
 });

--- a/src/runtime/local/finalize.test.ts
+++ b/src/runtime/local/finalize.test.ts
@@ -280,7 +280,7 @@ describe("finalize — stage trail + push reporting", () => {
 		expect(result.commitsAheadBase).toBe("main");
 		expect(exec.calls.map((c) => c.args)).toEqual([
 			["push", "origin", "HEAD:warren/run-1"],
-			["rev-list", "--count", "main..HEAD"],
+			["rev-list", "--count", "--first-parent", "main..HEAD"],
 		]);
 	});
 });

--- a/src/runtime/local/finalize.ts
+++ b/src/runtime/local/finalize.ts
@@ -467,10 +467,14 @@ async function countCommitsAhead(
 	}
 	try {
 		if ("error" in countBase) throw countBase.error;
-		const out = await exec.run("git", ["rev-list", "--count", `${countBase.ref}..HEAD`], {
-			cwd: workspacePath,
-			timeoutMs: 10_000,
-		});
+		const out = await exec.run(
+			"git",
+			["rev-list", "--count", "--first-parent", `${countBase.ref}..HEAD`],
+			{
+				cwd: workspacePath,
+				timeoutMs: 10_000,
+			},
+		);
 		const parsed = Number.parseInt(out.stdout.trim(), 10);
 		trail.ok("commits_ahead");
 		return Number.isFinite(parsed) ? parsed : null;


### PR DESCRIPTION
## Summary
- \`commitsAhead\` is \`git rev-list --count <base>..HEAD\`. When an agent merges upstream into its branch (a follow-up run onto an existing PR branch, like run_gevytzavaht0), every merged-in upstream commit lands in that range. That run reported 3278 commits for a merge plus three fix commits.
- Add \`--first-parent\` to the count in both the local finalizer and the K8s finalizer, so a merge counts as one commit. Linear runs are unchanged.
- Update the exact-args assertions in the affected tests and the \`baseBranch\` doc comment on the runtime contract.

Tracker: warren-a8cc

## Test plan
- [x] \`bun run check:all\` green locally (12/12 after formatting)
- [x] finalize / reap test suites pass with the new arg