### PR TITLE
deploy-gke: quote rendered env values so numeric repo variables apply (warren-ff6f follow-up)

### DIFF
--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -427,7 +427,7 @@ jobs:
                         - name: warren
                           env:
                             - name: ${name}
-                              value: ${value}
+                              value: "${value}"
           EOF
           done
           echo "----- rendered gke-live kustomization -----"


### PR DESCRIPTION
Deploy run 33721708276 failed: the warren-ff6f render block emits `value: 4096` / `value: 1` unquoted, YAML parses them as integers, and the apiserver rejects the Deployment env patch. Quote the value. The repo-cache block was never affected because a PVC name is a string.

Plan pl-6076 (Spot + memory repo variables).