### PR TITLE
fix(ui): fill the Services card rows and let the run-detail aside scroll at xl

### DIFF
--- a/src/ui/src/pages/operations/services-panel.tsx
+++ b/src/ui/src/pages/operations/services-panel.tsx
@@ -10,7 +10,7 @@ import { cn, relativeTime } from "@/lib/utils.ts";
 
 function ServiceRow({ name, detail, ok }: { name: string; detail: string; ok: boolean | null }) {
 	return (
-		<div className="flex min-h-[43px] items-center gap-2 border-b border-(--color-border) px-3 py-1.5 last:border-b-0">
+		<div className="flex min-h-[43px] flex-1 items-center gap-2 border-b border-(--color-border) px-3 py-1.5 last:border-b-0">
 			<span
 				className={cn(
 					"h-1.5 w-1.5 shrink-0 rounded-full",

--- a/src/ui/src/pages/run-detail/index.tsx
+++ b/src/ui/src/pages/run-detail/index.tsx
@@ -424,7 +424,7 @@ export function RunDetailPage() {
 						terminal={isTerminal}
 					/>
 				</div>
-				<aside className="flex w-full shrink-0 flex-col gap-3 max-xl:contents xl:w-[326px]">
+				<aside className="flex w-full shrink-0 flex-col gap-3 max-xl:contents xl:min-h-0 xl:w-[326px] xl:overflow-y-auto">
 					<div className="order-1 md:order-none">
 						<RuntimePanel run={r} />
 					</div>


### PR DESCRIPTION
## Summary

Two regressions from the 2026-09-03 console patch series.

- **Operations › Services** (#1206): the Runtime row was dropped and `flex-1` was removed from `ServiceRow`. The card is stretched to the Lifecycle table's height by the side-by-side row, so the three rows sat at the top with dead space where the fourth had been. `flex-1` is restored so the rows fill the card, matching the artboard's `flexGrow: 1` rows.
- **Run detail** (#1213): the two-column row was height-bound at xl with `overflow-hidden` so the event stream scrolls internally, but the 326px aside had no scroll region of its own and Prompt / Steering were clipped past the fold. The aside now has `xl:min-h-0 xl:overflow-y-auto` so it scrolls independently. Below xl nothing changes.

## Test plan

- `bun run check:all` 12/12
- UI project typechecks clean
- Manual: Operations at md+ shows three evenly filled Services rows beside the Lifecycle table; run detail at ≥1280px reaches Prompt and Steering by scrolling the side column while the event stream stays bounded.