### PR TITLE
test: report missing kubectl checks as skipped

### DIFF
--- a/scripts/postgres-component-manifest.test.ts
+++ b/scripts/postgres-component-manifest.test.ts
@@ -34,6 +34,8 @@ function hasKubectl(): boolean {
 	}
 }
 
+const HAS_KUBECTL = hasKubectl();
+
 interface K8sDoc {
 	kind?: string;
 	metadata?: { name?: string; namespace?: string };
@@ -64,13 +66,9 @@ function renderComponent(): K8sDoc[] {
 }
 
 describe("deploy/k8s/components/postgres", () => {
-	test(
+	test.skipIf(!HAS_KUBECTL)(
 		"kubectl kustomize of an including overlay renders all seven objects",
 		() => {
-			if (!hasKubectl()) {
-				console.warn("kubectl not found — skipping kustomize render check");
-				return;
-			}
 			const docs = renderComponent();
 			const byName = (kind: string, name: string) =>
 				docs.some((d) => d.kind === kind && d.metadata?.name === name);
@@ -95,13 +93,9 @@ describe("deploy/k8s/components/postgres", () => {
 		{ timeout: 2 * KUBECTL_TIMEOUT_MS + 5_000 },
 	);
 
-	test(
+	test.skipIf(!HAS_KUBECTL)(
 		"backup CronJob runs pg_dump nightly with Forbid concurrency and the restore template ships placeholders",
 		() => {
-			if (!hasKubectl()) {
-				console.warn("kubectl not found — skipping kustomize render check");
-				return;
-			}
 			const docs = renderComponent() as Array<Record<string, unknown>>;
 			const cron = docs.find(
 				(d) => d.kind === "CronJob" && (d.metadata as { name?: string }).name === "postgres-backup",


### PR DESCRIPTION
## Summary

- detect `kubectl` availability once when the manifest test module loads
- register the two kubectl-dependent checks with `test.skipIf(...)`
- preserve the existing manifest assertions when `kubectl` is available

Previously, when `kubectl` was unavailable, the two tests printed a warning
and returned normally. Bun and JUnit therefore reported those checks as
passing instead of skipped.

## Validation

Without `kubectl`:

- 1 passed
- 2 skipped
- 0 failed
- JUnit reports `skipped="2"`

With checksum-verified `kubectl` v1.37.0 available:

- 3 passed
- 0 failed
- all manifest assertions executed

Repository validation:

- Warren pre-commit gates: 12/12 passed
- `git diff --check`: passed

The two optional Linux+bwrap sandbox tests were skipped in the controlled
validation environment because `bwrap` was intentionally unavailable; no
bwrap-related source changes are included in this PR.

Fixes #1233
