### PR TITLE
fix(judge): end the judgment on a provider error instead of burning the retries

### DIFF
--- a/extensions/judge/src/judge-loop.test.ts
+++ b/extensions/judge/src/judge-loop.test.ts
@@ -14,8 +14,12 @@ const RUBRIC_VERSION = "sha256:" + "ab".repeat(32);
 const JUDGED_AT = new Date("2026-08-15T17:00:00.000Z");
 
 interface StubBehavior {
-	/** Per-attempt behavior: report a verdict, end in plain text, or throw. */
-	kind: "verdict" | "plain_text" | "throw";
+	/**
+	 * Per-attempt behavior: report a verdict, end in plain text, throw, or
+	 * end the turn the way a provider failure does, with the text on the
+	 * session state and nothing thrown.
+	 */
+	kind: "verdict" | "plain_text" | "throw" | "provider_error";
 	args?: unknown;
 	message?: string;
 }
@@ -49,6 +53,10 @@ function makeStubFactory(
 				tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
 				costUsd: costPerAttempt,
 			}),
+			getLastError: () =>
+				behavior.kind === "provider_error"
+					? (behavior.message ?? "provider returned an error")
+					: null,
 			dispose: () => {},
 		};
 		return session;
@@ -228,6 +236,23 @@ describe("judgeRun", () => {
 	);
 
 	test(
+		"ends on the provider's error instead of spending the retry budget",
+		withFakeWarren(async (fake) => {
+			const { factory, calls } = makeStubFactory(
+				[{ kind: "provider_error", message: "401 invalid x-api-key" }],
+				0.001,
+			);
+			const outcome = await judgeRun({ ...judgeOpts(fake, factory), maxRetries: 2 });
+			expect(outcome.kind).toBe("unjudged");
+			if (outcome.kind !== "unjudged") throw new Error("expected unjudged");
+			expect(outcome.reason).toBe("judge_error");
+			expect(outcome.detail).toContain("401 invalid x-api-key");
+			expect(outcome.stats.attempts).toBe(1);
+			expect(calls).toHaveLength(1);
+		}),
+	);
+
+	test(
 		"stops early with budget_exceeded when accrued cost reaches the per-judgment cap",
 		withFakeWarren(async (fake) => {
 			const { factory } = makeStubFactory(
@@ -287,6 +312,7 @@ describe("judgeRun", () => {
 						tokens: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 },
 						costUsd: 0.001,
 					}),
+					getLastError: () => null,
 					dispose: () => {},
 				};
 			};
@@ -340,6 +366,7 @@ describe("judgeRun", () => {
 						tokens: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 },
 						costUsd: sessionCost,
 					}),
+					getLastError: () => null,
 					dispose: () => {},
 				};
 			};
@@ -389,6 +416,7 @@ describe("judgeRun", () => {
 						tokens: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 },
 						costUsd: 0.15,
 					}),
+					getLastError: () => null,
 					dispose: () => {},
 				};
 			};

--- a/extensions/judge/src/judge-loop.ts
+++ b/extensions/judge/src/judge-loop.ts
@@ -54,6 +54,15 @@ export interface JudgeSession {
 	/** Resolve when the agent loop has settled (verdict called or plain-text end). */
 	waitForIdle(): Promise<void>;
 	getSessionStats(): SessionStatsSnapshot;
+	/**
+	 * The provider error that ended the most recent turn, or null when the
+	 * turn ended normally. A provider failure (an expired key, a 401, a
+	 * model the account cannot reach) does not throw: the agent loop encodes
+	 * it on the final assistant message and goes idle, so without this the
+	 * loop cannot tell a dead credential from a model that talked instead of
+	 * calling report_verdict.
+	 */
+	getLastError(): string | null;
 	dispose(): void;
 }
 
@@ -191,6 +200,7 @@ export async function judgeRun(opts: JudgeRunOptions): Promise<JudgeOutcome> {
 		});
 		let session: JudgeSession | null = null;
 		let attemptError: unknown = null;
+		let providerError: string | null = null;
 		try {
 			session = await opts.sessionFactory({ systemPrompt, tools });
 			liveSession = session;
@@ -213,6 +223,13 @@ export async function judgeRun(opts: JudgeRunOptions): Promise<JudgeOutcome> {
 				} catch {
 					// Stats are accounting, not the judgment: a stats-capture
 					// failure never turns a good verdict into an unjudged marker.
+				}
+				try {
+					// Read before dispose, and in its own try for the same reason
+					// the stats capture has one.
+					providerError = session.getLastError();
+				} catch {
+					providerError = null;
 				}
 				session.dispose();
 			}
@@ -243,6 +260,15 @@ export async function judgeRun(opts: JudgeRunOptions): Promise<JudgeOutcome> {
 				reason: "judge_error",
 				detail:
 					attemptError instanceof Error ? attemptError.message : String(attemptError),
+			};
+		} else if (providerError !== null) {
+			// A retry against the same dead credential cannot succeed, and each
+			// one is billed. End the judgment on the provider's own words.
+			return {
+				kind: "unjudged",
+				reason: "judge_error",
+				detail: `provider error on attempt ${attempt}, not retried: ${providerError}`,
+				stats: toJudgmentStats(stats),
 			};
 		} else {
 			lastFailure = {

--- a/extensions/judge/src/pi-session.ts
+++ b/extensions/judge/src/pi-session.ts
@@ -130,6 +130,7 @@ class PiJudgeSession implements JudgeSession {
 				};
 				cost: number;
 			};
+			readonly state: { readonly errorMessage?: string };
 			dispose(): void;
 		},
 	) {}
@@ -147,6 +148,13 @@ class PiJudgeSession implements JudgeSession {
 	public getSessionStats(): SessionStatsSnapshot {
 		const stats = this.session.getSessionStats();
 		return { tokens: { ...stats.tokens }, costUsd: stats.cost };
+	}
+
+	public getLastError(): string | null {
+		// AgentState.errorMessage carries the text of the most recent failed or
+		// aborted assistant turn. The stream contract says a request, model or
+		// runtime failure must never throw: it lands here instead.
+		return this.session.state.errorMessage ?? null;
 	}
 
 	public dispose(): void {


### PR DESCRIPTION
Closes #1235.

## What breaks

`judge-loop.ts` decides an attempt's fate by asking whether something threw. A thrown error becomes `judge_error` carrying its message, and everything else becomes `malformed_verdict` with a fixed string.

A provider failure takes neither path, and the SDK says so out loud:

```
node_modules/@earendil-works/pi-agent-core/dist/types.d.ts:8
 * - Must not throw or return a rejected promise for request/model/runtime failures.
 * - Failures must be encoded in the returned stream via protocol events and a
 *   final AssistantMessage with stopReason "error" or "aborted" and errorMessage.
```

So an expired key ends the turn quietly, `waitForIdle` resolves, no verdict was reported, and the loop files a dead credential as a malformed verdict with text that describes something else. Then it spends the rest of `maxAttempts` against the same dead credential, and each one is billed.

The provider's own text was reachable the whole time. `AgentState.errorMessage` sits at `types.d.ts:314` and `AgentSession` exposes `get state(): AgentState` at `pi-coding-agent/dist/core/agent-session.d.ts:294`. `PiJudgeSession` never read either.

## The change

`JudgeSession` gains `getLastError(): string | null`, and `PiJudgeSession` returns `this.session.state.errorMessage ?? null`. The loop reads it in the same `finally` that captures stats, before `dispose`, in its own `try` for the reason the stats capture already has one.

A non-null error returns immediately as `judge_error` with the provider's words, following the early-return shape of the cost-cap check sitting right below it. A plain-text end with no error keeps `malformed_verdict` and its full retry budget, which the existing "exhausts the retry budget on missing verdicts" case still pins.

`collector.ts` and `calibration.ts` both consume `JudgeOutcome` from `judgeRun`, so the corrected classification reaches their ledgers with neither file changing.

## What I could not check

I did not drive a real 401 through this. That wants a live provider key, and the judge suite runs deliberately without one. The claim rests on the two declarations above and on the stream contract quoted from the SDK, not on a failure I watched happen. If you have a key that 401s, one `warren judge` run against it settles it: the marker should read `judge_error` with the provider text and one attempt rather than three.

Pinned at `@earendil-works/pi-coding-agent@^0.84.4`, so the shape could move under us on a bump. The seam is one method, which is the cheap place for that to break loudly.

## Gates

Container clone of `1893d015` on `oven/bun:1.3.14`.

`bun run check:all` gives 11 of 12 with the patch, and clean `main` in the same container gives the same 11 of 12. The red one is `check:coverage`, on the two `gke-live overlay apply` cases that want a `kubectl` the container does not have. I compared the failure sets rather than the counts and they are identical.

The ratchet does not move. Both sides read `functions 91.43% (floor 90.91%), lines 93.62% (floor 93.37%)`, at 6957 tests against 6956.

`cd extensions/judge && bun test` goes from 161 to 162, and `bun run typecheck` is clean. Worth flagging that the typecheck is what caught it: adding a method to the seam left three session literals in the test file incomplete, and `bun test` stayed green while they were.
