### PR TITLE
fix(judge): stop a $0 failure from writing a permanent unjudged marker

### DIFF
--- a/extensions/judge/README.md
+++ b/extensions/judge/README.md
@@ -114,8 +114,10 @@ Step 6 (warren-33da) adds the collector daemon:
   candidate pool next pass instead of a `budget_exceeded` marker
   permanently excluding it. The deferral stays visible in the cycle
   stats and a once-per-pass log line. Per-judgment failures from billed
-  attempts still write markers. Disabled unless
-  `JUDGE_CALIBRATION_MODEL` is set.
+  attempts still write markers; a failure that cost $0 (an expired key, a
+  model the account cannot reach) is skipped the same way a deferral is,
+  because nothing was billed and a marker would exclude the run for good.
+  Disabled unless `JUDGE_CALIBRATION_MODEL` is set.
 
 Step 8 (warren-265d) adds the export surface and the end-to-end smoke:
 

--- a/extensions/judge/src/calibration.test.ts
+++ b/extensions/judge/src/calibration.test.ts
@@ -280,6 +280,32 @@ describe("calibrateOnce", () => {
 		verdicts.close();
 	});
 
+	test("a $0 failure is skipped, not marked, and the run is re-drawn next pass", async () => {
+		const judge: JudgeFn = () =>
+			Promise.resolve({
+				kind: "unjudged",
+				reason: "judge_error",
+				detail: "401 invalid x-api-key",
+				stats: stats(0),
+			});
+		const { deps, verdicts, spend } = makeDeps({ judge });
+		seedCheapVerdicts(verdicts, ["run-1"]);
+		const skips: string[] = [];
+
+		const result = await calibrateOnce({ ...deps, onZeroCostSkipped: (runId) => skips.push(runId) });
+		expect(result.zeroCostSkipped).toBe(1);
+		expect(result.rejudged).toBe(0);
+		expect(skips).toEqual(["run-1"]);
+		// Only the cheap verdict seeded above: no strong-judge row took the
+		// dedupe key, so the run is still a candidate.
+		expect(verdicts.rowsForRun("run-1")).toHaveLength(1);
+		expect(spend.spendForDay("2026-08-15")).toBeCloseTo(0);
+
+		const rerun = await calibrateOnce(deps);
+		expect(rerun.candidates).toBe(1);
+		verdicts.close();
+	});
+
 	test("persists the agreement report as a queryable per-rubric-version metric", async () => {
 		const { deps, verdicts, metrics } = makeDeps();
 		seedCheapVerdicts(verdicts, ["run-1", "run-2"]);

--- a/extensions/judge/src/calibration.ts
+++ b/extensions/judge/src/calibration.ts
@@ -21,7 +21,10 @@
  * The deferral stays visible in the cycle stats and the once-per-pass
  * deferral log line. Per-judgment failures (judge_error,
  * malformed_verdict, a mid-attempt cap breach) still record markers,
- * because the attempts were billed.
+ * because the attempts were billed. A failure that cost $0 was not
+ * billed, so it is skipped the same way a deferral is (warren-d8df): an
+ * expired key or a missing model would otherwise take the dedupe key and
+ * drop the run from every future sample without a model ever reading it.
  *
  * The agreement rate is computed from the store's calibration join and
  * persisted per rubric version in the `calibration_metrics` table, so the
@@ -264,6 +267,8 @@ export interface CalibrationDeps {
 	readonly onJudgment?: (runId: string, outcome: string) => void;
 	/** Once per pass, on the first budget deferral — loud by design (§12.5). */
 	readonly onBudgetDeferred?: (runId: string, detail: string) => void;
+	/** Once per pass, when a $0 failure is skipped instead of marked. */
+	readonly onZeroCostSkipped?: (runId: string, detail: string) => void;
 }
 
 export interface CalibrationCycleStats {
@@ -272,6 +277,8 @@ export interface CalibrationCycleStats {
 	readonly rejudged: number;
 	/** Sampled runs deferred by the exhausted daily budget — no row written. */
 	readonly budgetDeferred: number;
+	/** Runs skipped (not marked) because the attempt cost nothing. */
+	readonly zeroCostSkipped: number;
 	readonly report: AgreementReport;
 }
 
@@ -332,6 +339,8 @@ export async function calibrateOnce(deps: CalibrationDeps): Promise<CalibrationC
 
 	let rejudged = 0;
 	let budgetDeferred = 0;
+	let zeroCostSkipped = 0;
+	let zeroCostAnnounced = false;
 	let deferralAnnounced = false;
 	for (const runId of sample) {
 		try {
@@ -369,6 +378,21 @@ export async function calibrateOnce(deps: CalibrationDeps): Promise<CalibrationC
 						model: strongId,
 					},
 				});
+			} else if (outcome.stats.costUsd === 0) {
+				// SKIP, never mark: the marker rationale above is that the
+				// attempts were billed, and a $0 attempt was not. Writing one
+				// would occupy the dedupe key over a failure no model was paid
+				// for, so the run leaves the pool for good. No write means the
+				// next pass re-draws it.
+				zeroCostSkipped += 1;
+				if (!zeroCostAnnounced) {
+					zeroCostAnnounced = true;
+					deps.onZeroCostSkipped?.(
+						runId,
+						`${outcome.reason} at $0.0000, not marked: ${outcome.detail}`,
+					);
+				}
+				continue;
 			} else {
 				deps.verdicts.recordUnjudged({
 					runId,
@@ -403,6 +427,7 @@ export async function calibrateOnce(deps: CalibrationDeps): Promise<CalibrationC
 		sampled: sample.length,
 		rejudged,
 		budgetDeferred,
+		zeroCostSkipped,
 		report,
 	};
 }

--- a/extensions/judge/src/collector.test.ts
+++ b/extensions/judge/src/collector.test.ts
@@ -197,6 +197,34 @@ describe("collectOnce", () => {
 		}
 	});
 
+	test("a $0 failure is skipped, not marked, and the run comes back next cycle", async () => {
+		const h = makeHarness({
+			script: {
+				"run-1": {
+					kind: "unjudged",
+					reason: "judge_error",
+					detail: "401 invalid x-api-key",
+					stats: stats(0),
+				},
+			},
+		});
+		h.fake.addRun({ id: "run-1", state: "failed", startedAt: "2026-08-15T10:00:00.000Z" });
+		const skips: string[] = [];
+		try {
+			const out = await collectOnce({ ...h.deps, onZeroCostSkipped: (id) => skips.push(id) });
+			expect(out.zeroCostSkipped).toBe(1);
+			expect(out.judged).toBe(0);
+			expect(skips).toEqual(["run-1"]);
+			// No marker: a row under the dedupe key would drop the run for good
+			// over a failure nothing was paid for.
+			expect(h.verdicts.rowsForRun("run-1")).toHaveLength(0);
+			// No checkpoint either, so the next cycle re-lists it.
+			expect(h.cursors.needsJudgment("run-1", RUBRIC_V1, MODEL)).toBe(true);
+		} finally {
+			teardown(h);
+		}
+	});
+
 	test("defers without a marker or checkpoint once the daily budget is exhausted", async () => {
 		// Each stubbed judgment spends 0.01, so the first run lands exactly
 		// on the budget and the rest see it exhausted.

--- a/extensions/judge/src/collector.ts
+++ b/extensions/judge/src/collector.ts
@@ -73,6 +73,8 @@ export interface JudgeCollectorDeps {
 	 * (§12.5), but once, not once per deferred run (a big backlog would
 	 * repeat the line hundreds of times every cycle).
 	 */
+	/** Once per cycle, when a $0 failure is skipped instead of marked. */
+	readonly onZeroCostSkipped?: (runId: string, detail: string) => void;
 	readonly onBudgetDeferred?: (runId: string, detail: string) => void;
 }
 
@@ -83,6 +85,8 @@ export interface JudgeCycleStats {
 	readonly alreadyJudged: number;
 	/** Runs deferred (not judged, not marked) because the daily budget is spent. */
 	readonly budgetDeferred: number;
+	/** Runs skipped (not marked, not checkpointed) because the attempt cost $0. */
+	readonly zeroCostSkipped: number;
 }
 
 const DEFAULT_RUNS_PAGE_SIZE = 500;
@@ -115,9 +119,17 @@ async function judgeOneRun(
 	remainingBudgetUsd: number,
 	deps: JudgeCollectorDeps,
 	now: () => Date,
-): Promise<"judged"> {
+): Promise<"judged" | "zero_cost_skipped"> {
 	const maxCostUsd = Math.min(deps.maxCostUsdPerJudgment, remainingBudgetUsd);
 	const outcome = await deps.judge(runId, { maxCostUsd });
+
+	if (outcome.kind !== "verdict" && outcome.stats.costUsd === 0) {
+		// SKIP, never mark, and never checkpoint: a marker earns its place
+		// because the attempts were billed, and a $0 attempt was not. The
+		// cursor is per run, so leaving it alone re-lists this run next
+		// cycle instead of losing it behind a marker no model produced.
+		return "zero_cost_skipped";
+	}
 
 	if (outcome.kind === "verdict") {
 		deps.verdicts.recordVerdict(outcome.verdict);
@@ -130,8 +142,8 @@ async function judgeOneRun(
 			detail: outcome.detail,
 		});
 	}
-	// Spend is ledgered for every outcome — an unjudged marker is not a
-	// refund, the provider billed the attempts either way.
+	// Spend is ledgered for every outcome that produced one: an unjudged
+	// marker is not a refund, the provider billed the attempts either way.
 	deps.spend.record(outcome.stats.costUsd, now());
 	// Checkpoint ONLY after the store accepted (audit-log discipline).
 	deps.cursors.checkpoint(runId, {
@@ -158,6 +170,8 @@ export async function collectOnce(deps: JudgeCollectorDeps): Promise<JudgeCycleS
 	let alreadyJudged = 0;
 	let budgetDeferred = 0;
 	let deferralAnnounced = false;
+	let zeroCostSkipped = 0;
+	let zeroCostAnnounced = false;
 	for (const run of terminal) {
 		if (!deps.cursors.needsJudgment(run.id, deps.rubricVersion, deps.judgeModelId)) {
 			alreadyJudged += 1;
@@ -182,8 +196,19 @@ export async function collectOnce(deps: JudgeCollectorDeps): Promise<JudgeCycleS
 			continue;
 		}
 		try {
-			await judgeOneRun(run.id, remaining, deps, now);
-			judged += 1;
+			const result = await judgeOneRun(run.id, remaining, deps, now);
+			if (result === "zero_cost_skipped") {
+				zeroCostSkipped += 1;
+				if (!zeroCostAnnounced) {
+					zeroCostAnnounced = true;
+					deps.onZeroCostSkipped?.(
+						run.id,
+						"judgment failed at $0.0000, not marked; the run stays a candidate",
+					);
+				}
+			} else {
+				judged += 1;
+			}
 		} catch (err) {
 			// Per-run isolation: one failing judgment (warren unreachable,
 			// wire drift, store error) must not starve the others. The
@@ -197,6 +222,7 @@ export async function collectOnce(deps: JudgeCollectorDeps): Promise<JudgeCycleS
 		judged,
 		alreadyJudged,
 		budgetDeferred,
+		zeroCostSkipped,
 	};
 }
 


### PR DESCRIPTION
Closes #1231.

## The rule was already written down, just never checked

Two comments in `calibration.ts` state the behaviour this PR implements.

The header at `:22-24`:

```
 * Per-judgment failures (judge_error, malformed_verdict, a mid-attempt
 * cap breach) still record markers, because the attempts were billed.
```

And `calibrationCandidates` at `:290-295`:

```
 * Runs eligible for the calibration sample: judged by the cheap model under
 * this rubric version, with no row yet from the strong model (a verdict OR
 * an unjudged marker from a billed attempt).
```

Both turn on the word billed, and nothing enforces it. `:372-380` calls `recordUnjudged` for every non-verdict outcome without looking at `outcome.stats.costUsd`, which is read two lines further down for the spend ledger and nowhere else. So a 401, an expired key or a model the account cannot reach writes a marker, `strongResolved` in the candidate query picks that row up, and the run leaves the calibration pool permanently over an attempt nobody paid for.

## The change

Mirror the budget deferral, which already solves the same problem for a different reason. A non-verdict outcome at $0 bumps a `zeroCostSkipped` counter, announces once per pass through a new `onZeroCostSkipped`, and continues without writing a row. `collector.ts` gets the same guard.

## What I checked before touching the collector

The collector also checkpoints a cursor, so skipping only the marker would still have lost the run. Reading the store settled it: `judgment_cursors` is keyed `run_id TEXT PRIMARY KEY`, `needsJudgment` compares the rubric version and judge model pair rather than mere presence, and `collectOnce` re-lists every run each cycle with no changed-since filter. Leaving the cursor alone is therefore safe, and it is what puts the run back in front of the next cycle. `judgeOneRun` now returns `"zero_cost_skipped"` and the loop counts it apart from `judged`.

## One interaction worth naming

#1245 merged minutes before this opened, so the branch already sees that traffic. It ends a judgment on the first provider error instead of retrying, so a refused request now arrives here as one failed attempt rather than three. Whether such a request bills anything is the provider's call and I have not watched one, but the accounting only matters when it comes back $0, which is the case this guard covers.

## Gates

Measured with this patch alone, on clean `main` at `1893d015` inside `oven/bun:1.3.14`, with #1245 not applied.

`bun run check:all` gives 11 of 12, the same as clean `main` in the same container. The red one is `check:coverage`, on the two `gke-live overlay apply` cases that want a `kubectl` the container does not have. I compared the failure sets rather than the counts and they are identical.

The ratchet does not move: `functions 91.43% (floor 90.91%), lines 93.62% (floor 93.37%)` on both sides, at 6958 tests against 6956.

`cd extensions/judge && bun test` goes from 161 to 163, and `bun run typecheck` is clean.
