### PR TITLE
test(deploy-trigger): decrement the kubectl stub's budget with bun, not node

### DIFF
--- a/scripts/deploy-trigger.test.ts
+++ b/scripts/deploy-trigger.test.ts
@@ -135,6 +135,9 @@ function runApplyOverlay(opts: {
 		// Stub kubectl: `kustomize -o DIR` writes three rendered files (a
 		// namespace and two namespaced objects); `apply -f FILE` consults the
 		// per-resource failure budget and appends to an apply log on success.
+		// The budget is decremented with `bun -e`, not `node -e`: the oven/bun
+		// image has no Node, and its `node` wrapper drops the first argument,
+		// which silently made every apply look like a failure.
 		const stub = join(bin, "kubectl");
 		writeFileSync(
 			stub,
@@ -148,7 +151,7 @@ function runApplyOverlay(opts: {
 				"    done ;;",
 				"  apply)",
 				'    name=$(basename "$3" .yaml)',
-				`    left=$(node -e 'const f=require(process.argv[1]);const n=f[process.argv[2]]??0;if(n!==0&&n!==-1)f[process.argv[2]]=n-1;require("fs").writeFileSync(process.argv[1],JSON.stringify(f));console.log(n)' "${state}/failures.json" "$name")`,
+				`    left=$(bun -e 'const f=require(process.argv[1]);const n=f[process.argv[2]]??0;if(n!==0&&n!==-1)f[process.argv[2]]=n-1;require("fs").writeFileSync(process.argv[1],JSON.stringify(f));console.log(n)' "${state}/failures.json" "$name")`,
 				'    if [ "$left" != "0" ]; then echo "Error from server (InternalError): $name" >&2; exit 1; fi',
 				`    echo "$name" >> "${state}/applied"`,
 				'    echo "$name configured" ;;',


### PR DESCRIPTION
Closes #1247.

One word, plus three lines of comment so it does not get reverted by the next person who reaches for `node`.

The issue carries the diagnosis and the argv transcript. Short version: the bun image has no Node, its `node` wrapper drops the first argument, so `require(process.argv[1])` in the stub received the resource name instead of the path to `failures.json`, threw, and every apply came back looking like a failure.

Measured on `dd98a4ab` in `oven/bun:1.3.14`, clean clone, root `bun install` plus `bun run ui:install`:

```
before   bun test scripts/deploy-trigger.test.ts    18 pass, 2 fail
after    bun test scripts/deploy-trigger.test.ts    20 pass, 0 fail
after    bun run check:all                          12/12 gates passed (72.4s), exit 0
```

The last line is the point of the PR. `check:all` has been red on a clean clone every time I have measured it, and `scripts/hooks/pre-commit` runs the whole suite with no escape variable, so the hook has not passed for anyone without a real Node on PATH.

No assertion moves and no behaviour changes. The stub is test-local, and the one-liner inside it is byte-identical apart from the interpreter.
