### PR TITLE
fix(ci): install UI workspace before ci-postgres tests

### DIFF
--- a/.github/workflows/ci-postgres.yml
+++ b/.github/workflows/ci-postgres.yml
@@ -50,4 +50,5 @@ jobs:
 
       - run: bun install
       - run: bun run ext:install
+      - run: bun run ui:install
       - run: bun test


### PR DESCRIPTION
## Summary
`ci-postgres` ran `bun test` without installing the UI workspace, so UI tests failed on missing deps.

## Change
Add `bun run ui:install` before `bun test` in `.github/workflows/ci-postgres.yml`.

Closes #1227