### PR TITLE
fix: accept bare GitHub URLs and link console brand home

### DIFF
--- a/src/projects/add-project.test.ts
+++ b/src/projects/add-project.test.ts
@@ -41,6 +41,36 @@ describe("addProject", () => {
 		expect(await repo.listAll()).toHaveLength(1);
 	});
 
+	test("normalizes bare GitHub URLs before cloning, persistence, and duplicate lookup", async () => {
+		let clonedUrl: string | undefined;
+		const row = await addProject({
+			repo,
+			config: CFG,
+			gitUrl: "  github.com/jayminwest/warren\n",
+			spawn: NOOP_SPAWN,
+			clone: async (input) => {
+				clonedUrl = input.gitUrl;
+				return fakeClone()(input);
+			},
+		});
+		expect(clonedUrl).toBe("https://github.com/jayminwest/warren");
+		expect(row.gitUrl).toBe("https://github.com/jayminwest/warren");
+		expect((await repo.require(row.id)).gitUrl).toBe("https://github.com/jayminwest/warren");
+		for (const gitUrl of ["github.com/jayminwest/warren", "https://github.com/jayminwest/warren"]) {
+			await expect(
+				addProject({
+					repo,
+					config: CFG,
+					gitUrl,
+					spawn: NOOP_SPAWN,
+					clone: async () => {
+						throw new Error("duplicate must not clone");
+					},
+				}),
+			).rejects.toThrow("project already exists");
+		}
+	});
+
 	test("propagates an explicit defaultBranch into the cloner and the row", async () => {
 		let received: string | undefined;
 		const row = await addProject({

--- a/src/projects/manage.ts
+++ b/src/projects/manage.ts
@@ -54,7 +54,7 @@ import {
 	type RefreshProjectCloneResult,
 	refreshProjectClone,
 } from "./refresh.ts";
-import { assertNoUserinfo, parseProjectUrl } from "./url.ts";
+import { assertNoUserinfo, normalizeGitHubUrl, parseProjectUrl } from "./url.ts";
 
 export interface AddProjectInput {
 	readonly repo: ProjectsRepo;
@@ -106,7 +106,8 @@ export interface AddProjectInput {
 }
 
 export async function addProject(input: AddProjectInput): Promise<ProjectRow> {
-	const { repo, config, gitUrl } = input;
+	const { repo, config } = input;
+	const gitUrl = normalizeGitHubUrl(input.gitUrl);
 	// warren-ce9b/0883: on a public instance only allowlisted repos may
 	// ever be registered — refused here, BEFORE anything is cloned, from
 	// the single enforcement site every surface shares.

--- a/src/projects/public-allowlist.test.ts
+++ b/src/projects/public-allowlist.test.ts
@@ -196,6 +196,7 @@ describe("assertGitUrlAllowlisted", () => {
 	test("accepts every URL shape parseGitHubUrl accepts", () => {
 		for (const url of [
 			"https://github.com/os-eco/warren",
+			"github.com/os-eco/warren",
 			"https://github.com/os-eco/warren.git",
 			"git@github.com:os-eco/warren.git",
 			"ssh://git@github.com/OS-ECO/warren",

--- a/src/projects/url.test.ts
+++ b/src/projects/url.test.ts
@@ -4,9 +4,58 @@ import { AdoForge } from "../forge/ado/provider.ts";
 import type { Forge } from "../forge/contract.ts";
 import { FakeForge } from "../forge/fake/fake-forge.ts";
 import { GitHubForge } from "../forge/github/provider.ts";
-import { assertNoUserinfo, parseForgeOwnedUrl, parseGitHubUrl, parseProjectUrl } from "./url.ts";
+import {
+	assertNoUserinfo,
+	normalizeGitHubUrl,
+	parseForgeOwnedUrl,
+	parseGitHubUrl,
+	parseProjectUrl,
+} from "./url.ts";
+
+describe("normalizeGitHubUrl", () => {
+	test("adds HTTPS to bare GitHub URLs and trims pasted whitespace", () => {
+		expect(normalizeGitHubUrl("  github.com/owner/repo.git/\n")).toBe(
+			"https://github.com/owner/repo.git/",
+		);
+		expect(normalizeGitHubUrl("GITHUB.COM/owner/repo")).toBe("https://GITHUB.COM/owner/repo");
+	});
+
+	test("leaves explicit transports and other hosts unchanged", () => {
+		for (const url of [
+			"https://github.com/o/r",
+			"http://github.com/o/r",
+			"git@github.com:o/r",
+			"ssh://git@github.com/o/r",
+			"fake://o/r",
+			"gitlab.com/o/r",
+			"github.com.evil/o/r",
+			"github.com@evil/o/r",
+		]) {
+			expect(normalizeGitHubUrl(url)).toBe(url);
+		}
+	});
+});
 
 describe("parseGitHubUrl", () => {
+	test("parses bare GitHub URLs using the same repository validation", () => {
+		for (const url of [
+			"github.com/owner/repo",
+			"github.com/owner/repo.git/",
+			"  GITHUB.COM/owner/repo\n",
+		]) {
+			expect(parseGitHubUrl(url)).toEqual({ owner: "owner", name: "repo" });
+		}
+		for (const url of [
+			"github.com/owner",
+			"github.com/owner/-repo",
+			"github.com/o/r/extra",
+			"github.com.evil/o/r",
+			"github.com@evil/o/r",
+		]) {
+			expect(() => parseGitHubUrl(url)).toThrow(ValidationError);
+		}
+	});
+
 	test("accepts https URLs with and without the .git suffix", () => {
 		expect(parseGitHubUrl("https://github.com/jayminwest/warren")).toEqual({
 			owner: "jayminwest",

--- a/src/projects/url.ts
+++ b/src/projects/url.ts
@@ -2,9 +2,10 @@
  * Parse a GitHub URL into the `{owner, name}` pair warren uses to lay
  * out `/data/projects/<owner>/<name>` (docs/design/runtime-and-supervisor.md).
  *
- * Three accepted shapes — the operator pastes whichever GitHub UI gave
+ * Four accepted shapes — the operator pastes whichever GitHub UI gave
  * them:
  *   - `https://github.com/<owner>/<name>[.git]`
+ *   - `github.com/<owner>/<name>[.git]` (defaults to HTTPS)
  *   - `git@github.com:<owner>/<name>[.git]`
  *   - `ssh://git@github.com/<owner>/<name>[.git]`
  *
@@ -29,8 +30,14 @@ export interface ParsedGitHubUrl {
 
 const SEGMENT = /^[A-Za-z0-9._-]+$/;
 
-export function parseGitHubUrl(input: string): ParsedGitHubUrl {
+/** Supply HTTPS only for a bare github.com host, leaving other transports intact. */
+export function normalizeGitHubUrl(input: string): string {
 	const trimmed = input.trim();
+	return /^github\.com\//i.test(trimmed) ? `https://${trimmed}` : trimmed;
+}
+
+export function parseGitHubUrl(input: string): ParsedGitHubUrl {
+	const trimmed = normalizeGitHubUrl(input);
 	if (trimmed === "") {
 		throw new ValidationError("gitUrl is empty", {
 			recoveryHint: "pass a GitHub URL, e.g. https://github.com/owner/name",

--- a/src/ui-tests/brand-home-link.test.ts
+++ b/src/ui-tests/brand-home-link.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+// The UI has no DOM test harness; pin the shared shell's link contract.
+describe("console brand navigation", () => {
+	for (const file of ["console-shell.tsx", "console-sidebar.tsx"]) {
+		test(`links the logo and wordmark home in ${file}`, () => {
+			const source = readFileSync(
+				new URL(`../ui/src/components/console/${file}`, import.meta.url),
+				"utf8",
+			);
+			expect(source).toMatch(
+				/<Link\s+to="\/"\s+aria-label="Warren home"[\s\S]*?<WarrenLogo[\s\S]*?warren[\s\S]*?<\/Link>/,
+			);
+		});
+	}
+
+	test("closes the mobile drawer when its brand is activated", () => {
+		const source = readFileSync(
+			new URL("../ui/src/components/console/console-sidebar.tsx", import.meta.url),
+			"utf8",
+		);
+		expect(source).toContain("<BrandRow onNavigate={onNavigate} />");
+		expect(source).toMatch(/aria-label="Warren home"\s+onClick={onNavigate}/);
+	});
+});

--- a/src/ui/src/components/console/console-shell.tsx
+++ b/src/ui/src/components/console/console-shell.tsx
@@ -1,7 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Outlet, useLocation } from "react-router-dom";
+import { Link, Outlet, useLocation } from "react-router-dom";
 import { ConsoleBottomNav } from "@/components/console/console-bottom-nav.tsx";
 import { ConsoleSidebar, ConsoleSidebarBody } from "@/components/console/console-sidebar.tsx";
 import { ConsoleMobileStatusStrip, ConsoleTopbar } from "@/components/console/console-topbar.tsx";
@@ -73,10 +73,16 @@ export function ConsoleShell() {
 				{/* Mobile chrome — visible only < md (warren-3290): the mock's two
 				    stacked bands, a 48px brand bar then the 34px status strip. */}
 				<div className="flex h-12 shrink-0 items-center gap-2 border-b border-(--color-border) bg-(--color-sidebar) px-3.5 md:hidden">
-					<WarrenLogo className="h-5 w-5 shrink-0" />
-					<span className="text-[13px] leading-4 font-semibold tracking-[-0.02em] text-(--color-text)">
-						warren
-					</span>
+					<Link
+						to="/"
+						aria-label="Warren home"
+						className="flex items-center gap-2 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4"
+					>
+						<WarrenLogo className="h-5 w-5 shrink-0" />
+						<span className="text-[13px] leading-4 font-semibold tracking-[-0.02em] text-(--color-text)">
+							warren
+						</span>
+					</Link>
 					<span className="flex-1" />
 					<MobileIdentityChip stats={stats} />
 				</div>

--- a/src/ui/src/components/console/console-sidebar.tsx
+++ b/src/ui/src/components/console/console-sidebar.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { LogIn, LogOut } from "lucide-react";
-import { NavLink, useNavigate } from "react-router-dom";
+import { Link, NavLink, useNavigate } from "react-router-dom";
 import { metaApi, setApiToken } from "@/api/client.ts";
 import {
 	ALL_NAV_SECTIONS,
@@ -127,7 +127,7 @@ function InstanceCard({ stats }: { stats: ConsoleStats }) {
 }
 
 /** Brand row: mark + name + version. */
-function BrandRow() {
+function BrandRow({ onNavigate }: { onNavigate?: () => void }) {
 	const version = useQuery({
 		queryKey: ["meta", "version"],
 		queryFn: ({ signal }) => metaApi.version(signal),
@@ -136,10 +136,17 @@ function BrandRow() {
 	});
 	return (
 		<div className="flex h-[58px] shrink-0 items-center gap-2.5 border-b border-(--color-border) px-4">
-			<WarrenLogo className="h-[22px] w-[22px] shrink-0" />
-			<span className="text-[13px] leading-4 font-semibold tracking-[-0.02em] text-(--color-text)">
-				warren
-			</span>
+			<Link
+				to="/"
+				aria-label="Warren home"
+				onClick={onNavigate}
+				className="flex items-center gap-2.5 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4"
+			>
+				<WarrenLogo className="h-[22px] w-[22px] shrink-0" />
+				<span className="text-[13px] leading-4 font-semibold tracking-[-0.02em] text-(--color-text)">
+					warren
+				</span>
+			</Link>
 			<span className="flex-1" />
 			{version.data ? (
 				<span className="font-mono text-[10px] leading-3 text-(--color-text-3)">
@@ -244,7 +251,7 @@ export function ConsoleSidebarBody({
 	};
 	return (
 		<>
-			<BrandRow />
+			<BrandRow onNavigate={onNavigate} />
 			<InstanceCard stats={stats} />
 			<nav className="flex flex-col px-[9px] pt-1.5">
 				{ALL_NAV_SECTIONS.map((section) => (


### PR DESCRIPTION
## Summary
- Accept `github.com/owner/repo` by supplying `https://` in shared project registration, before allowlist/userinfo validation, duplicate lookup, cloning, and persistence. Existing HTTPS/SSH transports and non-GitHub forge URLs retain their behavior.
- Make the logo and wordmark an accessible home link in the mobile header, desktop sidebar, and mobile navigation drawer. The drawer also closes when home is selected while already on the home route.
- Add regression coverage for URL normalization, malformed/lookalike hosts, persisted clone URLs, duplicate prevention, public allowlist compatibility, and the brand-link contract.

## Validation
- `bun run check:all`: all 12 gates passed, including UI build and test coverage.
- Focused regression suite: 73 tests passed.
- Real local browser + isolated local Warren server: entered `github.com/octocat/Hello-World`, successfully cloned it, and verified the stored/displayed URL is `https://github.com/octocat/Hello-World`.
- Verified desktop and 390px mobile logo navigation to the existing `/` home route, plus mobile drawer dismissal when already home. No production state was changed.

Both fixes are scoped to this PR; no version bump, merge, or release is requested.
