### PR TITLE
fix(ci): install extensions before bundle-size build:ui

### DIFF
--- a/.github/workflows/bundle-size-autoheal.yml
+++ b/.github/workflows/bundle-size-autoheal.yml
@@ -93,6 +93,8 @@ jobs:
       - if: steps.pr-gate.outputs.has-pr == 'true'
         run: bun run ui:install
       - if: steps.pr-gate.outputs.has-pr == 'true'
+        run: bun run ext:install
+      - if: steps.pr-gate.outputs.has-pr == 'true'
         run: bun run build:ui
 
       - name: Re-baseline bundle-size budgets if (and only if) that was the failure


### PR DESCRIPTION
## Summary
- Run `bun run ext:install` after `ui:install` (and before `build:ui`) in `bundle-size-autoheal.yml`, matching the same `pr-gate` path guard used for UI install.
- Avoids knip/`check:deps` failures when the autoheal job builds the UI without workspace extension deps.

Closes #1228