### PR TITLE
fix(sandbox): probe the resolved git by absolute path

### DIFF
--- a/src/sandbox/git-preflight.test.ts
+++ b/src/sandbox/git-preflight.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
@@ -129,6 +129,23 @@ describe("probeSandboxGit", () => {
 		expect(seen[0]).toBe("/usr/bin");
 	});
 
+	test("spawns the resolved binary by absolute path, never a bare name", async () => {
+		const seen: string[][] = [];
+		const spawnSandbox: typeof runSandboxed = async (_profile, command) => {
+			seen.push([...command.argv]);
+			return fakeResult(0, "git version 2.39.5");
+		};
+		await probeSandboxGit({
+			which: whichWith(BAD_GIT),
+			env: {},
+			platform: "linux",
+			spawnSandbox,
+		});
+		// A bare `git` lets execvp skip the named binary and answer from a
+		// later PATH entry, so the result would name a binary that never ran.
+		expect(seen[0]).toEqual([BAD_GIT, "--version"]);
+	});
+
 	test("substitutes /usr/bin/git on darwin when the resolved git fails but the system git passes", async () => {
 		const result = await probeSandboxGit({
 			which: whichWith(BAD_GIT),
@@ -225,13 +242,16 @@ describe("probeSandboxGit (real sandbox, linux + bwrap)", () => {
 		async () => {
 			const dir = mkdtempSync(join(tmpdir(), "warren-git-preflight-real-"));
 			const binDir = join(dir, "bin");
+			mkdirSync(binDir, { recursive: true });
 			writeFileSync(join(binDir, "git"), "#!/nonexistent-interpreter-warren-1219\n", {
 				mode: 0o755,
 			});
 			try {
 				const badGit = join(binDir, "git");
 				const result = await probeSandboxGit({
-					which: (name) => (name === "git" ? badGit : null),
+					// whichWith answers for bwrap as well; a null there takes the
+					// "no sandbox wrapper" early return and the probe never runs.
+					which: whichWith(badGit),
 					env: {},
 					spawnSandbox: runSandboxed,
 				});

--- a/src/sandbox/git-preflight.ts
+++ b/src/sandbox/git-preflight.ts
@@ -2,9 +2,9 @@
  * Sandbox git preflight (warren-1219, plan pl-26f3 step 6).
  *
  * Verifies that the git binary a run would use actually EXECUTES inside the
- * composed sandbox profile — the same toolchain mounts and hardened PATH a
- * real LocalProvider run gets — by running `git --version` through
- * `runSandboxed` and checking the exit code.
+ * composed sandbox profile — the same toolchain mounts a real LocalProvider
+ * run gets — by running `<gitBin> --version` through `runSandboxed` and
+ * checking the exit code.
  *
  * Why: on macOS a nix-provided git resolved first on the server PATH but
  * its dylibs sat outside the sandbox profile's readable paths, so every
@@ -22,6 +22,14 @@
  *
  * Only the LocalProvider topology sandboxes on the host: docker/k8s callers
  * simply never invoke this probe.
+ *
+ * The probe invokes the resolved binary by ABSOLUTE path, because a bare
+ * name cannot answer for a specific binary. `execvp` resumes its PATH walk
+ * on ENOENT, EACCES and ENOTDIR, so a later git answers for the one the
+ * result names: measured on bwrap 0.9.0, a missing interpreter, a file
+ * without the execute bit, and a directory named `git` each let
+ * /usr/bin/git reply with exit 0. ENOEXEC is the exception, where execvp
+ * retries the entry under /bin/sh rather than moving on.
  */
 
 import { existsSync, mkdirSync as fsMkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
@@ -102,13 +110,6 @@ interface GitProbeOutcome {
 	readonly output: string;
 }
 
-/**
- * Probe that one git binary executes inside the composed sandbox profile.
- * Composes a minimal `SandboxProfile` with the same toolchain-mount shape
- * `buildLocalSandboxProfile` produces for git (bin dir + realpath dir +
- * the bun install root), then runs bare-name `git --version` so the
- * hardened PATH resolution a real run uses is exercised too.
- */
 /** Resolve the git binary to probe: env pin first, then PATH. */
 function resolveProbedGit(
 	env: Record<string, string | undefined>,
@@ -234,6 +235,12 @@ export function resetSandboxGitPreflightCache(): void {
 	cachedPreflight = undefined;
 }
 
+/**
+ * Probe that one git binary executes inside the composed sandbox profile.
+ * Composes a minimal `SandboxProfile` with the same toolchain-mount shape
+ * `buildLocalSandboxProfile` produces for git (bin dir + realpath dir + the
+ * bun install root), then runs `<gitBin> --version` by absolute path.
+ */
 async function runGitProbe(
 	gitBin: string,
 	deps: SandboxGitPreflightDeps,
@@ -258,7 +265,7 @@ async function runGitProbe(
 			setEnv: {},
 			toolchainPaths: gitToolchainPaths(gitBin, deps.exists ?? existsSync),
 		};
-		const command: SpawnCommand = { argv: ["git", "--version"], timeoutMs };
+		const command: SpawnCommand = { argv: [gitBin, "--version"], timeoutMs };
 		const child = await spawnSandbox(profile, command, deps.sandboxOptions ?? {});
 		const output = await drainWithTimeout(child, timeoutMs);
 		return { ok: output.exitCode === 0, output: output.text };


### PR DESCRIPTION
## The defect

`probeSandboxGit` reports that a named git binary executes inside the sandbox when that binary never ran.

`runGitProbe` spawned bare-name `git --version` inside a profile whose toolchain mounts point at the resolved binary. `execvp` walks PATH and steps over any entry it fails to execute, and the sandbox PATH always ends in `/usr/bin:/bin` (`composePath`, `src/sandbox/env.ts:71`). So a broken git is skipped, `/usr/bin/git` answers, and the probe returns:

```text
ok: true
gitPath: /tmp/x/bin/git
message: /tmp/x/bin/git executes inside the sandbox profile (git --version ok)
```

about a binary that cannot start.

Measured on bubblewrap 0.9.0 / git 2.43.0, each time with `<stub-dir>` first on PATH and a real git behind it:

| `<stub-dir>/git` is | probe sees |
| --- | --- |
| a 0755 file whose shebang names a missing interpreter | `git version 2.43.0`, exit 0 |
| a real git copy at mode 0644 | `git version 2.43.0`, exit 0 |
| a directory | `git version 2.43.0`, exit 0 |

Three different breakages, one wrong answer each time. Reproduce any row with:

```sh
bwrap --ro-bind / / --dev /dev --unshare-all \
      --setenv PATH "<stub-dir>:/usr/bin:/bin" git --version
```

With no fallback on PATH (`--setenv PATH "<stub-dir>"`) it reports `bwrap: execvp git: No such file or directory` and exits 1, which is the honest answer the probe never got to see.

This is the failure class the probe exists to catch (warren-1219). A preflight that passes wrongly costs what the probe was written to prevent.

## The fix

Invoke the resolved binary by absolute path: `argv: [gitBin, "--version"]`. A bare name cannot answer for a specific binary, and the result names a specific binary. With the change, the same stub yields `execvp <stub>: No such file or directory` and exit 1.

The dylib case that motivated the probe is unaffected in principle, since such a binary does start and then exits non-zero rather than being skipped by `execvp`. I could not verify that on macOS, so it is reasoning, not a measurement.

## What this does not cover

The probe composes its own minimal `SandboxProfile` rather than the one `buildLocalSandboxProfile` gives a real run, so it answers "this binary runs under a profile shaped like a run's" and not "git works in the run you are about to dispatch". That was already true before this change and is unchanged by it.

What is no longer exercised is the sandbox's own PATH resolution. That matters less than it sounds: `composePath` always appends `/usr/bin:/bin`, so a sandbox PATH with no reachable git is close to unreachable in practice. Say the word if you would rather it probed both the absolute path and the bare name, at the cost of a second spawn per probe.

## Two guards

`spawns the resolved binary by absolute path, never a bare name` is new and hermetic: it stubs `runSandboxed` and asserts the argv the probe hands it. It runs everywhere, CI included, because it needs no sandbox.

`catches a git stub that fails exec, naming the binary` already existed and should have caught the bug. It carried two defects that hid it:

1. `binDir` was never created, so the case died with `ENOENT` before its first assertion.
2. Its `which` seam returned `null` for every name except `git`, including `bwrap`. `probeSandboxGit` takes an early `ok: true` return when no sandbox wrapper resolves, so even past the crash the probe never ran.

Both are fixed, and it now uses the file's own hermetic `whichWith` helper rather than reaching for the host. It stays gated on `test.skipIf(!hasBwrap())` and `ci.yml` installs no bubblewrap, so it keeps skipping there. That is exactly why the hermetic guard exists: without it, reverting this line would go unnoticed on every machine without bwrap.

## Verification

`bun run check:all` is green, 12 of 12 gates, on Ubuntu 24.04 with bubblewrap 0.9.0 and git 2.43.0. `bun test src/sandbox/git-preflight.test.ts` is 13 of 13.

Both guards were mutation-tested rather than assumed. Reverting `argv` to the bare name in a copy of the repo:

```text
with bwrap:     (fail) spawns the resolved binary by absolute path, never a bare name
                (fail) catches a git stub that fails exec, naming the binary
without bwrap:  (fail) spawns the resolved binary by absolute path, never a bare name
                (skip) catches a git stub that fails exec, naming the binary
                10 pass  2 skip  1 fail
```

The real-sandbox case also goes red under hard-coding `argv` to `/usr/bin/git`, forcing the no-wrapper early return, stubbing `runGitProbe` to always succeed, and removing the `mkdirSync` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
