### PR TITLE
fix(workspace): keep harness state and seed drops out of run branches

### DIFF
--- a/src/runtime/k8s/workspace-init.test.ts
+++ b/src/runtime/k8s/workspace-init.test.ts
@@ -11,6 +11,17 @@ import {
 const ok = { exitCode: 0, stdout: "", stderr: "" };
 
 /**
+ * Real git answers `rev-parse --git-path <p>` with a path, and the exclude
+ * seeding (warren-194a) reads it. A fake that returned the blanket `ok` would
+ * hand back an empty path, which is a failure real git never produces.
+ */
+function gitPathReply(args: string[]): { exitCode: number; stdout: string; stderr: string } | null {
+	const i = args.indexOf("--git-path");
+	if (args[0] !== "rev-parse" || i === -1) return null;
+	return { exitCode: 0, stdout: `.git/${args[i + 1] ?? ""}\n`, stderr: "" };
+}
+
+/**
  * Recording git that lets a test steer the mirror probe + fail specific argv.
  * `bareRepoProbe` decides what `git rev-parse --is-bare-repository` reports
  * (default `false` ⇒ mirror treated as absent ⇒ create path).
@@ -25,16 +36,24 @@ function cacheGit(overrides: {
 		if (overrides.fail?.(args, opts?.cwd)) {
 			return Promise.resolve({ exitCode: 1, stdout: "", stderr: "boom" });
 		}
-		if (args.includes("--is-bare-repository")) {
-			return Promise.resolve({
-				exitCode: overrides.bareRepoProbe ? 0 : 128,
-				stdout: overrides.bareRepoProbe ? "true\n" : "",
-				stderr: overrides.bareRepoProbe ? "" : "fatal: not a git repository",
-			});
-		}
-		return Promise.resolve(ok);
+		return Promise.resolve(
+			gitPathReply(args) ?? bareRepoReply(args, overrides.bareRepoProbe === true) ?? ok,
+		);
 	};
 	return { git, calls };
+}
+
+/** What `git rev-parse --is-bare-repository` reports for the steered mirror. */
+function bareRepoReply(
+	args: string[],
+	isBare: boolean,
+): { exitCode: number; stdout: string; stderr: string } | null {
+	if (!args.includes("--is-bare-repository")) return null;
+	return {
+		exitCode: isBare ? 0 : 128,
+		stdout: isBare ? "true\n" : "",
+		stderr: isBare ? "" : "fatal: not a git repository",
+	};
 }
 
 const CACHE_ENV = {
@@ -116,6 +135,8 @@ function recordingGit(overrides: { fail?: (args: string[]) => boolean } = {}): {
 	const git: InitGitRunner = (args, opts) => {
 		calls.push({ args, ...(opts?.cwd !== undefined ? { cwd: opts.cwd } : {}) });
 		if (overrides.fail?.(args)) return Promise.resolve({ exitCode: 1, stdout: "", stderr: "boom" });
+		const gitPath = gitPathReply(args);
+		if (gitPath !== null) return Promise.resolve(gitPath);
 		return Promise.resolve(ok);
 	};
 	return { git, calls };
@@ -132,7 +153,7 @@ describe("runWorkspaceInit", () => {
 				WARREN_WORKSPACE_PATH: "/ws",
 				WARREN_GIT_TOKEN: "tok",
 			},
-			{ git, log: () => {} },
+			{ git, fs: noopFs, log: () => {} },
 		);
 		expect(calls[0]?.args).toEqual([
 			"clone",
@@ -158,9 +179,10 @@ describe("runWorkspaceInit", () => {
 				WARREN_BRANCH: "b",
 				WARREN_BASE_BRANCH: "main",
 			},
-			{ git, log: () => {} },
+			{ git, fs: noopFs, log: () => {} },
 		);
-		expect(calls.map((c) => c.args[0])).toEqual(["clone", "switch"]);
+		// The trailing rev-parse is the exclude seeding resolving info/exclude.
+		expect(calls.map((c) => c.args[0])).toEqual(["clone", "switch", "rev-parse"]);
 	});
 
 	test("branch === baseBranch (ref-dispatch, warren-dac8) skips the colliding switch -c", async () => {
@@ -172,7 +194,7 @@ describe("runWorkspaceInit", () => {
 				WARREN_BASE_BRANCH: "fix/pr-head",
 				WARREN_WORKSPACE_PATH: "/ws",
 			},
-			{ git, log: () => {} },
+			{ git, fs: noopFs, log: () => {} },
 		);
 		expect(calls[0]?.args).toEqual([
 			"clone",
@@ -196,7 +218,7 @@ describe("runWorkspaceInit", () => {
 				WARREN_BASE_BRANCH: sha,
 				WARREN_WORKSPACE_PATH: "/ws",
 			},
-			{ git, log: () => {} },
+			{ git, fs: noopFs, log: () => {} },
 		);
 		const argv = calls.map((c) => c.args);
 		expect(argv[1]).toEqual(["clone", "--filter=blob:none", "https://github.com/o/r.git", "/ws"]);
@@ -213,7 +235,7 @@ describe("runWorkspaceInit", () => {
 					WARREN_BRANCH: "b",
 					WARREN_BASE_BRANCH: "main",
 				},
-				{ git, log: () => {} },
+				{ git, fs: noopFs, log: () => {} },
 			),
 		).rejects.toThrow(/git clone .* failed/);
 	});
@@ -235,7 +257,10 @@ describe("runWorkspaceInit", () => {
 				writes.push({ path: p, data: new TextDecoder().decode(d) });
 				return Promise.resolve();
 			},
-			readFile: () => Promise.resolve(manifest),
+			// Path-aware: only the manifest path holds the manifest. The exclude
+			// seeding reads .git/info/exclude, which does not exist yet.
+			readFile: (p) =>
+				p === "/seeds/seeds.json" ? Promise.resolve(manifest) : Promise.reject(new Error("ENOENT")),
 		};
 		await runWorkspaceInit(
 			{
@@ -247,11 +272,43 @@ describe("runWorkspaceInit", () => {
 			},
 			{ git, fs, log: () => {} },
 		);
-		expect(writes).toEqual([
+		expect(writes.slice(0, 2)).toEqual([
 			{ path: "/ws/.warren/agent.json", data: "{}" },
 			{ path: "/ws/.mulch/x", data: "hello" },
 		]);
-		expect(mkdirs).toEqual(["/ws/.warren", "/ws/.mulch"]);
+		expect(mkdirs.slice(0, 2)).toEqual(["/ws/.warren", "/ws/.mulch"]);
+	});
+
+	test("excludes the harness state and every seeded path from the pod's clone", async () => {
+		const writes: Array<{ path: string; data: string }> = [];
+		const { git } = recordingGit();
+		const manifest = JSON.stringify([{ path: ".warren/agent.json", contents: "{}" }]);
+		const fs: InitFs = {
+			mkdir: () => Promise.resolve(),
+			writeFile: (p, d) => {
+				writes.push({ path: p, data: new TextDecoder().decode(d) });
+				return Promise.resolve();
+			},
+			readFile: (p) =>
+				p === "/seeds/seeds.json" ? Promise.resolve(manifest) : Promise.reject(new Error("ENOENT")),
+		};
+		await runWorkspaceInit(
+			{
+				WARREN_REPO_URL: "https://github.com/o/r.git",
+				WARREN_BRANCH: "b",
+				WARREN_BASE_BRANCH: "main",
+				WARREN_WORKSPACE_PATH: "/ws",
+				WARREN_SEED_MANIFEST: "/seeds/seeds.json",
+			},
+			{ git, fs, log: () => {} },
+		);
+		const exclude = writes.find((w) => w.path === "/ws/.git/info/exclude");
+		expect(exclude).toBeDefined();
+		// Both halves land: the harness's own scratch and the seed drop that
+		// warren wrote into the workspace (warren-194a).
+		expect(exclude?.data).toContain(".pi/sessions/");
+		expect(exclude?.data).toContain(".claude/");
+		expect(exclude?.data).toContain(".warren/agent.json");
 	});
 
 	test("refuses a seed path that escapes the workspace", async () => {
@@ -369,7 +426,7 @@ describe("runWorkspaceInit repo-cache path (warren-e908, §4.3/R2)", () => {
 				WARREN_WORKSPACE_PATH: "/ws",
 				WARREN_GIT_TOKEN: "tok",
 			},
-			{ git, log: () => {} },
+			{ git, fs: noopFs, log: () => {} },
 		);
 		const argv = calls.map((c) => c.args);
 		expect(argv).toContainEqual([

--- a/src/runtime/k8s/workspace-init.ts
+++ b/src/runtime/k8s/workspace-init.ts
@@ -69,6 +69,8 @@ import { dirname, isAbsolute, join, normalize } from "node:path";
 import { WorkspaceMaterializationError } from "../../workspace/errors.ts";
 import { authenticatedCloneUrl, bareTokenCredential } from "../../workspace/git/clone-url.ts";
 import { runGit } from "../../workspace/git/exec.ts";
+import { writeWorkspaceExcludes } from "../../workspace/git-exclude.ts";
+import { harnessStatePrefixes } from "../adapters/index.ts";
 import { parseSeedManifest } from "./seed-configmap.ts";
 
 /** Parsed, validated view of the init container's env. */
@@ -342,8 +344,13 @@ function resolveSeedTarget(workspacePath: string, seedPath: string): string {
 	return join(workspacePath, normalize(seedPath));
 }
 
-async function writeSeedFiles(cfg: InitEnv, fs: InitFs, log: (m: string) => void): Promise<void> {
-	if (cfg.seedManifestPath === undefined) return;
+/** Drop the seed files and report their workspace-relative paths to the caller. */
+async function writeSeedFiles(
+	cfg: InitEnv,
+	fs: InitFs,
+	log: (m: string) => void,
+): Promise<readonly string[]> {
+	if (cfg.seedManifestPath === undefined) return [];
 	const raw = await fs.readFile(cfg.seedManifestPath);
 	const entries = parseSeedManifest(raw);
 	for (const entry of entries) {
@@ -356,6 +363,7 @@ async function writeSeedFiles(cfg: InitEnv, fs: InitFs, log: (m: string) => void
 		await fs.writeFile(target, data);
 	}
 	log(`workspace-init: wrote ${entries.length} seed file(s) into ${cfg.workspacePath}`);
+	return entries.map((entry) => entry.path);
 }
 
 /**
@@ -384,7 +392,14 @@ export async function runWorkspaceInit(
 
 	const usedCache = await materializeViaCache(git, fs, cfg, log);
 	if (!usedCache) await directClone(git, cfg, log);
-	await writeSeedFiles(cfg, fs, log);
+	const seedPaths = await writeSeedFiles(cfg, fs, log);
+	// warren-194a: keep warren's harness scratch and seed drops out of the
+	// agent's commits when the target repo's .gitignore does not cover them.
+	// The pod's clone is its own, so the exclude never outlives the run.
+	await writeWorkspaceExcludes(cfg.workspacePath, [...harnessStatePrefixes(), ...seedPaths], {
+		git,
+		fs,
+	});
 	log(`workspace-init: checked out ${cfg.branch} off ${cfg.baseBranch}`);
 	return cfg;
 }

--- a/src/runtime/local/engine.test.ts
+++ b/src/runtime/local/engine.test.ts
@@ -192,6 +192,10 @@ describe("LocalEngine.create", () => {
 			// the profile binds the real HOME + the worktree's git common dir
 			expect(h.profiles[0]?.home).toBe(homePath);
 			expect(h.profiles[0]?.workspaceGitdir).toBeDefined();
+			// warren-194a: harness scratch and the seed drop are excluded, so a
+			// target repo that does not gitignore them keeps them out of the PR
+			const dirty = await fixtureGitOrThrow(workspacePath, ["status", "--porcelain"]);
+			expect(dirty.stdout).not.toContain(".warren/agent.json");
 		} finally {
 			await h.cleanup();
 		}

--- a/src/runtime/local/engine.ts
+++ b/src/runtime/local/engine.ts
@@ -33,12 +33,14 @@ import { defaultFs } from "../../runs/reap/util.ts";
 import type { EnvLike } from "../../runs/spawn/callback-env.ts";
 import { loopbackApiUrl } from "../../runs/spawn/callback-env.ts";
 import { branchExists, discoverHostClone } from "../../workspace/git/worktree.ts";
+import { writeWorkspaceExcludes } from "../../workspace/git-exclude.ts";
 import {
 	type MaterializedWorkspace,
 	materializeProjectWorkspace,
 	removeMaterializedWorkspace,
 } from "../../workspace/materialize.ts";
 import { writeWorkspaceSeedFiles } from "../../workspace/seed-files.ts";
+import { harnessStatePrefixes } from "../adapters/index.ts";
 import type {
 	FinalizeIntent,
 	FinalizeResult,
@@ -156,6 +158,14 @@ export class LocalEngine {
 				originUrl: spec.originUrl,
 			});
 			await writeWorkspaceSeedFiles(workspacePath, spec.seedFiles);
+			// warren-194a: a target repo whose .gitignore does not cover warren's
+			// harness scratch and seed drops lets the agent commit them into the
+			// run branch, and they ride into the PR. Excludes are checkout-local
+			// and never reach the remote.
+			await writeWorkspaceExcludes(workspacePath, [
+				...harnessStatePrefixes(),
+				...spec.seedFiles.map((file) => file.path),
+			]);
 		} catch (err) {
 			// Partial-failure cleanup (the rollback posture burrow's provider owned):
 			// reclaim the dirs we made and rethrow the ORIGINAL error.

--- a/src/workspace/git-exclude.test.ts
+++ b/src/workspace/git-exclude.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkspaceMaterializationError } from "./errors.ts";
+import { runGit } from "./git/exec.ts";
+import {
+	EXCLUDE_BLOCK_END,
+	EXCLUDE_BLOCK_START,
+	renderManagedExclude,
+	writeWorkspaceExcludes,
+} from "./git-exclude.ts";
+
+function tempRoot(): string {
+	return mkdtempSync(join(tmpdir(), "warren-git-exclude-"));
+}
+
+/** A clone with one commit, so `git status` and worktrees both work. */
+async function initClone(root: string): Promise<string> {
+	const clone = join(root, "clone");
+	mkdirSync(clone, { recursive: true });
+	await runGit(["init", "-q", "-b", "main"], { cwd: clone });
+	await runGit(["config", "user.email", "test@warren.invalid"], { cwd: clone });
+	await runGit(["config", "user.name", "warren test"], { cwd: clone });
+	writeFileSync(join(clone, "README.md"), "hi\n");
+	await runGit(["add", "."], { cwd: clone });
+	await runGit(["commit", "-qm", "init"], { cwd: clone });
+	return clone;
+}
+
+async function untracked(cwd: string): Promise<string[]> {
+	const res = await runGit(["status", "--porcelain"], { cwd });
+	return res.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.startsWith("??"));
+}
+
+describe("renderManagedExclude", () => {
+	test("appends a fenced block to an empty file", () => {
+		expect(renderManagedExclude("", [".pi/sessions/"])).toBe(
+			`${EXCLUDE_BLOCK_START}\n.pi/sessions/\n${EXCLUDE_BLOCK_END}\n`,
+		);
+	});
+
+	test("preserves lines the operator wrote before the block", () => {
+		const out = renderManagedExclude("# operator note\nbuild/\n", [".claude/"]);
+		expect(out).toBe(
+			`# operator note\nbuild/\n${EXCLUDE_BLOCK_START}\n.claude/\n${EXCLUDE_BLOCK_END}\n`,
+		);
+	});
+
+	test("replaces an existing block instead of stacking a second one", () => {
+		const first = renderManagedExclude("keep/\n", [".pi/sessions/"]);
+		const second = renderManagedExclude(first, [".claude/", ".warren/agent.json"]);
+		expect(second).toBe(
+			`keep/\n${EXCLUDE_BLOCK_START}\n.claude/\n.warren/agent.json\n${EXCLUDE_BLOCK_END}\n`,
+		);
+		expect(second.split(EXCLUDE_BLOCK_START)).toHaveLength(2);
+	});
+
+	test("is idempotent, so a second run against one clone rewrites the same bytes", () => {
+		const once = renderManagedExclude("", [".pi/sessions/", ".warren/agent.json"]);
+		expect(renderManagedExclude(once, [".pi/sessions/", ".warren/agent.json"])).toBe(once);
+	});
+
+	test("keeps operator lines that follow the block", () => {
+		const seeded = `${EXCLUDE_BLOCK_START}\nold/\n${EXCLUDE_BLOCK_END}\ntrailing/\n`;
+		expect(renderManagedExclude(seeded, ["new/"])).toBe(
+			`trailing/\n${EXCLUDE_BLOCK_START}\nnew/\n${EXCLUDE_BLOCK_END}\n`,
+		);
+	});
+
+	test("drops duplicates and blank entries, keeping caller order", () => {
+		const out = renderManagedExclude("", [".pi/", "", "  ", ".pi/", ".warren/agent.json"]);
+		expect(out).toBe(`${EXCLUDE_BLOCK_START}\n.pi/\n.warren/agent.json\n${EXCLUDE_BLOCK_END}\n`);
+	});
+
+	test("removes the block entirely when no patterns remain", () => {
+		const seeded = renderManagedExclude("keep/\n", [".pi/sessions/"]);
+		expect(renderManagedExclude(seeded, [])).toBe("keep/\n");
+		expect(renderManagedExclude(renderManagedExclude("", [".pi/"]), [])).toBe("");
+	});
+});
+
+describe("writeWorkspaceExcludes", () => {
+	test("hides harness state from git status in a plain clone", async () => {
+		const root = tempRoot();
+		try {
+			const clone = await initClone(root);
+			mkdirSync(join(clone, ".pi/sessions"), { recursive: true });
+			mkdirSync(join(clone, ".warren"), { recursive: true });
+			writeFileSync(join(clone, ".pi/sessions/s.jsonl"), "{}\n");
+			writeFileSync(join(clone, ".warren/agent.json"), "{}\n");
+			writeFileSync(join(clone, "agent-work.txt"), "real change\n");
+
+			expect(await untracked(clone)).not.toHaveLength(0);
+			await writeWorkspaceExcludes(clone, [".pi/sessions/", ".warren/agent.json"]);
+
+			// The agent's actual work still shows; only warren's own files are hidden.
+			expect(await untracked(clone)).toEqual(["?? agent-work.txt"]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("hides harness state in a worktree, where the exclude file is the clone's shared one", async () => {
+		const root = tempRoot();
+		try {
+			const clone = await initClone(root);
+			const workspace = join(root, "ws");
+			await runGit(["worktree", "add", "-q", workspace, "-b", "run/abc", "main"], {
+				cwd: clone,
+			});
+			mkdirSync(join(workspace, ".pi/sessions"), { recursive: true });
+			writeFileSync(join(workspace, ".pi/sessions/s.jsonl"), "{}\n");
+
+			await writeWorkspaceExcludes(workspace, [".pi/sessions/"]);
+
+			expect(await untracked(workspace)).toHaveLength(0);
+			// git reads info/exclude as a common path, so the write lands on the
+			// parent clone rather than under .git/worktrees/<name>/.
+			expect(readFileSync(join(clone, ".git/info/exclude"), "utf8")).toContain(".pi/sessions/");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("leaves an operator's own exclude entries in place", async () => {
+		const root = tempRoot();
+		try {
+			const clone = await initClone(root);
+			writeFileSync(join(clone, ".git/info/exclude"), "# mine\nscratch/\n");
+			await writeWorkspaceExcludes(clone, [".pi/sessions/"]);
+			const written = readFileSync(join(clone, ".git/info/exclude"), "utf8");
+			expect(written).toContain("# mine\nscratch/\n");
+			expect(written).toContain(".pi/sessions/");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("rewrites rather than appends when the same workspace is seeded twice", async () => {
+		const root = tempRoot();
+		try {
+			const clone = await initClone(root);
+			await writeWorkspaceExcludes(clone, [".pi/sessions/"]);
+			await writeWorkspaceExcludes(clone, [".pi/sessions/"]);
+			const written = readFileSync(join(clone, ".git/info/exclude"), "utf8");
+			expect(written.split(EXCLUDE_BLOCK_START)).toHaveLength(2);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("leaves no temp file behind", async () => {
+		const root = tempRoot();
+		try {
+			const clone = await initClone(root);
+			await writeWorkspaceExcludes(clone, [".pi/sessions/"]);
+			const res = await runGit(["status", "--porcelain", "--ignored"], { cwd: clone });
+			expect(res.stdout).not.toContain(".tmp");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	test("fails loudly when the workspace is not a git repository", async () => {
+		const root = tempRoot();
+		try {
+			await expect(writeWorkspaceExcludes(root, [".pi/sessions/"])).rejects.toThrow(
+				WorkspaceMaterializationError,
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/workspace/git-exclude.ts
+++ b/src/workspace/git-exclude.ts
@@ -1,0 +1,165 @@
+/**
+ * Managed `.git/info/exclude` block for warren-owned workspace state (warren-194a).
+ *
+ * The harness writes its scratch inside the worktree (pi pins
+ * `.pi/sessions/`, claude-code `.claude/`), and warren's own seed drops land
+ * beside it (`.warren/agent.json` and friends, `buildSeedFiles`). A target
+ * repository whose `.gitignore` does not cover those paths lets the agent's
+ * own `git add` sweep them into the run branch, and they ride into the pull
+ * request. Warren's repo happens to ignore them; a mirror of someone else's
+ * does not.
+ *
+ * git resolves `info/exclude` as a COMMON path: every worktree of a clone
+ * reads the same file, and `git rev-parse --git-path info/exclude` returns
+ * that shared file rather than a per-worktree copy. A file written to
+ * `.git/worktrees/<name>/info/exclude` is not read at all (verified on git
+ * 2.43.0), so the shared file is the only exclude a worktree honors.
+ *
+ * The write therefore reaches the host clone, which is why it is confined to a
+ * marked block and rewritten in full each time: every run renders the same
+ * bytes, so two runs materializing against one project converge instead of
+ * racing, and an operator can see and delete exactly what warren added.
+ * Excludes are local to a checkout and never reach the remote, which is the
+ * property this fix needs.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
+import { WorkspaceMaterializationError } from "./errors.ts";
+import { runGit } from "./git/exec.ts";
+
+export const EXCLUDE_BLOCK_START = "# >>> warren managed >>>";
+export const EXCLUDE_BLOCK_END = "# <<< warren managed <<<";
+
+export type ExcludeGitRunner = (
+	args: string[],
+	opts?: { cwd?: string },
+) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+
+/**
+ * Filesystem seam, shaped to match the K8s init container's `InitFs` so the
+ * pod path can hand its injectable fs straight in. `rename` is optional
+ * because that seam does not carry one: with it we swap the file in atomically,
+ * without it we write in place. The pod materializes a fresh per-run clone
+ * nobody else reads, so the in-place write is safe there.
+ */
+export interface ExcludeFs {
+	mkdir: (path: string, opts: { recursive: true }) => Promise<unknown>;
+	readFile: (path: string) => Promise<string>;
+	writeFile: (path: string, data: Uint8Array) => Promise<void>;
+	rename?: (from: string, to: string) => Promise<void>;
+}
+
+export interface WriteExcludeDeps {
+	git?: ExcludeGitRunner;
+	fs?: ExcludeFs;
+}
+
+const defaultGit: ExcludeGitRunner = (args, opts) => runGit(args, opts ?? {});
+
+const defaultFs: ExcludeFs = {
+	mkdir: (path, opts) => mkdir(path, opts),
+	readFile: (path) => readFile(path, "utf8"),
+	writeFile: (path, data) => writeFile(path, data),
+	rename: (from, to) => rename(from, to),
+};
+
+/**
+ * Normalize the caller's patterns: drop blanks, collapse duplicates, keep the
+ * caller's order. Adapters and seed builders both hand us plain workspace
+ * paths, and the two lists overlap (`.pi/` shows up in each), so dedupe is not
+ * cosmetic.
+ */
+function normalizePatterns(patterns: readonly string[]): string[] {
+	const seen = new Set<string>();
+	for (const raw of patterns) {
+		const pattern = raw.trim();
+		if (pattern === "" || pattern.startsWith("#")) continue;
+		seen.add(pattern);
+	}
+	return [...seen];
+}
+
+/**
+ * Render `existing` with warren's block replaced by `patterns`, leaving every
+ * other line untouched. An empty pattern list removes the block, so a caller
+ * that stops excluding leaves nothing behind.
+ *
+ * Pure so the block algebra is testable without a git repository.
+ */
+export function renderManagedExclude(existing: string, patterns: readonly string[]): string {
+	const lines = existing.split("\n");
+	const start = lines.indexOf(EXCLUDE_BLOCK_START);
+	const end = lines.indexOf(EXCLUDE_BLOCK_END);
+	const managed = start !== -1 && end > start;
+	const before = managed ? lines.slice(0, start) : lines;
+	const after = managed ? lines.slice(end + 1) : [];
+
+	const kept = [...before, ...after].join("\n").replace(/\n+$/, "");
+	const normalized = normalizePatterns(patterns);
+	if (normalized.length === 0) return kept === "" ? "" : `${kept}\n`;
+
+	const block = [EXCLUDE_BLOCK_START, ...normalized, EXCLUDE_BLOCK_END].join("\n");
+	return kept === "" ? `${block}\n` : `${kept}\n${block}\n`;
+}
+
+/**
+ * Resolve the exclude file git actually reads for `workspaceRoot`.
+ *
+ * `--git-path` answers relative to the invocation cwd when the workspace is a
+ * plain clone (`.git/info/exclude`) and absolute for a worktree, so join the
+ * relative form onto the workspace rather than assuming either shape.
+ */
+async function resolveExcludePath(workspaceRoot: string, git: ExcludeGitRunner): Promise<string> {
+	const res = await git(["rev-parse", "--git-path", "info/exclude"], { cwd: workspaceRoot });
+	if (res.exitCode !== 0) {
+		throw new WorkspaceMaterializationError(
+			`git rev-parse --git-path info/exclude failed (exit ${res.exitCode}): ${
+				res.stderr.trim() || res.stdout.trim()
+			}`,
+			{
+				recoveryHint:
+					"The workspace is not a git repository yet. Seed excludes after the worktree or clone exists.",
+			},
+		);
+	}
+	const raw = res.stdout.trim();
+	if (raw === "") {
+		throw new WorkspaceMaterializationError(
+			"git rev-parse --git-path info/exclude returned an empty path",
+		);
+	}
+	return isAbsolute(raw) ? raw : join(workspaceRoot, raw);
+}
+
+/**
+ * Write warren's managed exclude block into the workspace's exclude file.
+ *
+ * Writes through a temp file in the same directory and renames, so a reader
+ * never sees a half-written exclude and a concurrent writer cannot interleave
+ * lines. Both runs render identical bytes, so last-write-wins is the correct
+ * outcome rather than a lost update.
+ */
+export async function writeWorkspaceExcludes(
+	workspaceRoot: string,
+	patterns: readonly string[],
+	deps: WriteExcludeDeps = {},
+): Promise<void> {
+	const git = deps.git ?? defaultGit;
+	const fs = deps.fs ?? defaultFs;
+
+	const excludePath = await resolveExcludePath(workspaceRoot, git);
+	const existing = await fs.readFile(excludePath).catch(() => "");
+	const next = renderManagedExclude(existing, patterns);
+	if (next === existing) return;
+
+	await fs.mkdir(dirname(excludePath), { recursive: true });
+	const data = new TextEncoder().encode(next);
+	if (fs.rename === undefined) {
+		await fs.writeFile(excludePath, data);
+		return;
+	}
+	const tmpPath = `${excludePath}.warren-${process.pid}.tmp`;
+	await fs.writeFile(tmpPath, data);
+	await fs.rename(tmpPath, excludePath);
+}


### PR DESCRIPTION
Closes #1239

## What

Seed `info/exclude` when a run's workspace is materialized, so the harness's own scratch and warren's seed drops stay out of the agent's commits. A target repository whose `.gitignore` does not cover those paths no longer carries `.pi/sessions/*.jsonl` or `.warren/agent.json` into the pull request.

Covered on both paths the issue names: the LocalProvider engine and the K8s init container.

## One correction to the fix direction

The issue says the exclude file for a worktree lives at `.git/worktrees/<name>/info/exclude`. git does not read that file. `info/exclude` is a common path, so it stays shared across every worktree of a clone. The recommended command is still the right one: `git rev-parse --git-path info/exclude` returns that shared file.

Verified on git 2.43.0, with `.pi/sessions/s.jsonl` and `.warren/agent.json` present in a worktree, writing the patterns to one file at a time:

| file written | `git status --porcelain` in the worktree |
| --- | --- |
| `.git/worktrees/wt/info/exclude` | `?? .pi/` and `?? .warren/` |
| `.git/info/exclude` | empty |

`src/workspace/git-exclude.test.ts` pins both halves of that: one test asserts the worktree goes clean, and asserts the bytes landed in the parent clone's `.git/info/exclude` rather than under `.git/worktrees/`.

Full detail and the reproduction are in the issue thread.

## Shape

Because the write reaches the host clone, it is confined to a marked block and rendered in full on every materialization:

```
# >>> warren managed >>>
.claude/
.claude.json
.pi/sessions/
.warren/agent.json
# <<< warren managed <<<
```

Every run renders the same bytes, so two runs against one project converge instead of racing, and an operator can see and delete exactly what warren added. Operator lines outside the block survive untouched, and an empty pattern list removes the block rather than leaving a stale one. Excludes are local to a checkout and never reach the remote, which is the property this needs.

The clone-backed paths (`materializeViaClone`, and the pod's per-run clone) each own their `.git`, so neither shares nor outlives anything.

## Where the patterns come from

The callers supply them, rather than `src/workspace/` reaching into the runtime:

```ts
await writeWorkspaceExcludes(workspacePath, [
	...harnessStatePrefixes(),
	...spec.seedFiles.map((file) => file.path),
]);
```

`src/workspace/materialize.ts` documents itself as neutral and deliberately free of coupling, so importing `src/runtime/adapters/` and `src/runs/seed.ts` into it would cut against that. `writeWorkspaceExcludes` takes optional `git` and `fs` seams shaped to match the init container's existing `InitFs` and `InitGitRunner`, so the pod path hands its injectable fakes straight in and stays testable without disk or a real git.

`writeSeedFiles` now returns the paths it wrote, which is what the K8s side passes as the seed half of the list.

## Tests

- `src/workspace/git-exclude.test.ts`, new: 13 cases. Seven cover the block algebra as a pure function (append, replace rather than stack, idempotence, operator lines before and after, dedupe, removal). Six run against real temporary git repositories: a plain clone, a worktree, an operator's pre-existing entries, a repeat seeding, no temp file left behind, and a loud failure when the workspace is not a repository.
- `src/runtime/k8s/workspace-init.test.ts`: a new case asserting both halves of the list reach the pod's exclude file.
- `src/runtime/local/engine.test.ts`: the existing create-path test now asserts the seeded `.warren/agent.json` does not show up in `git status`.

Two test-harness changes came with it. The fake git runners now answer `rev-parse --git-path`, which real git always answers and the blanket success stub did not. And five `runWorkspaceInit` cases now pass the no-op `fs` explicitly; they were only staying off disk because the seed loop returns early without a manifest, so the real `fs` default was never exercised.

`bun run check:all` passes 12 of 12 gates, measured on Ubuntu 24.04 with bubblewrap 0.9.0.

One note on reproducing that: on a machine with bwrap, `check:coverage` also fails on `src/sandbox/git-preflight.test.ts`, which this branch does not touch and which fails identically on an unmodified `main`. That defect is #1255, sent separately. This branch does not depend on it; the two were measured together only because the local pre-commit gate runs the whole manifest.


## Out of scope

Moving pi's session directory out of the worktree, as the issue notes.

Two things noticed and deliberately left alone, each worth its own change: the header comment on `src/workspace/materialize.ts` still says the module is "intentionally unimported by the domain", which `src/runtime/local/engine.ts` has since made untrue; and `scripts/bundle-size-budgets.json` repeatedly recommends `bun run check:bundle-size:build --update`, a script that is not in `package.json`. Happy to file either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
