### PR TITLE
ci(acceptance): let bwrap configure loopback on ubuntu-latest

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -9,11 +9,14 @@ name: Acceptance (nightly)
 #
 # ## Runner shape
 #
-# - `ubuntu-latest`. The runner already ships kernel user-namespaces
-#   enabled with a positive `user.max_user_namespaces`, so bwrap can nest
-#   without a sysctl step (contrast the docker-compose deploy path,
-#   which needs the four bwrap-friendly flags baked into
-#   `docker-compose.yml`; in the raw runner env bwrap just works).
+# - `ubuntu-latest`. User namespaces are enabled (`user.max_user_namespaces`
+#   is positive), but Ubuntu 24.04 also ships
+#   `kernel.apparmor_restrict_unprivileged_userns=1`, which confines the
+#   non-setuid bwrap and refuses the loopback setup inside the network
+#   namespace that `--unshare-all` creates. The sysctl step below turns
+#   that restriction off for the job (contrast the docker-compose deploy
+#   path, which needs the four bwrap-friendly flags baked into
+#   `docker-compose.yml`).
 # - `bubblewrap` + `uidmap` installed via apt so `burrow serve` can run
 #   its bwrap-based sandbox (same substrate `Dockerfile:68-79` bakes into
 #   the release image).
@@ -109,6 +112,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends bubblewrap uidmap
+
+      - name: Allow bwrap to configure loopback in its network namespace
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

- `Acceptance (nightly)` has never passed. Every cron run since 2026-07-31 fails with `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`, and only scenarios 01 and 11 survive because they never call `POST /projects`.
- Ubuntu 24.04 ships `kernel.apparmor_restrict_unprivileged_userns=1`. The apt `bwrap` is not setuid, so the AppArmor profile confines it and refuses the loopback setup inside the network namespace that `--unshare-all` creates.
- One step after the bubblewrap install turns that sysctl off for the job. The header comment named `user.max_user_namespaces` as the reason the runner works, which is the wrong knob, so it is corrected in the same change.

Closes #1250

## Changes

- `.github/workflows/acceptance.yml`: new step `Allow bwrap to configure loopback in its network namespace`, and the "Runner shape" comment now describes the restriction the step lifts.

## Test plan

- [ ] `biome check .` passes
- [ ] `tsc --noEmit` passes
- [ ] `bun test` passes
- [x] Manual verification (if applicable)

The diff is a workflow file only, so the three gates above do not see it. The verification is run [34132356400](https://github.com/jayminwest/warren/actions/runs/34132356400) on the probe branch, which has this exact step and nothing else: 22 passed, 1 failed, 1 skipped, against 2 passed and 21 failed on the last cron run. The one remaining failure is scenario 42 (`EACCES` on `operator-token`), which fails the same way with and without the sysctl and is a separate defect.
