### PR TITLE
fix(retry): classify an explicit finish_reason error as transient

### DIFF
--- a/src/runs/retry/provider-retry.classify.test.ts
+++ b/src/runs/retry/provider-retry.classify.test.ts
@@ -21,6 +21,8 @@ describe("classifyProviderError", () => {
 		expect(classifyProviderError("request timed out after 30s")).toBe("transient");
 		expect(classifyProviderError("connect ETIMEDOUT 10.0.0.1:443")).toBe("transient");
 		expect(classifyProviderError("Stream ended without finish_reason")).toBe("transient");
+		expect(classifyProviderError("Provider finish_reason: error")).toBe("transient");
+		expect(classifyProviderError("finish_reason error")).toBe("transient");
 		expect(classifyProviderError("The operation was aborted")).toBe("transient");
 		expect(classifyProviderError("Premature close")).toBe("transient");
 	});

--- a/src/runs/retry/provider-retry.ts
+++ b/src/runs/retry/provider-retry.ts
@@ -144,6 +144,10 @@ const TRANSIENT_PATTERNS: readonly RegExp[] = [
 	// Stream breaks can arrive after headers with no status/body left to parse.
 	/stream ended/,
 	/without finish_reason/,
+	// The provider can also end the stream with an explicit error finish
+	// (`Provider finish_reason: error`, run_03wb2b8crbz6 on 2026-09-03, #1238):
+	// same upstream break, just spelled from the other side.
+	/finish_reason:?\s*error/,
 	/premature close/,
 	/\baborted\b/,
 	/fetch failed/,


### PR DESCRIPTION
## Summary

- Item 3 of #1238. The provider text observed on `run_03wb2b8crbz6` (2026-09-03) was `Provider finish_reason: error`. The transient list carries `/without finish_reason/` from #1211 but not the explicit error finish, so `classifyProviderError` returned `unknown` and reap emitted `reap.provider_retry_skipped` for a stream break that should retry once.
- One pattern beside its sibling, `/finish_reason:?\s*error/`, with both spellings covered in the classify test.
- Items 1 and 2 (open the PR when the branch is pushed with commits ahead, and stop calling pushed work "unrecoverable") are a reap policy change and wait for the answer on the issue.

Part of #1238

## Changes

- `src/runs/retry/provider-retry.ts`: the new transient pattern, with the run and issue it comes from in the comment.
- `src/runs/retry/provider-retry.classify.test.ts`: two assertions in the network-class case.

## Test plan

- [x] `biome check .` passes
- [x] `tsc --noEmit` passes
- [x] `bun test` passes
- [x] Manual verification (if applicable)

`bun run check:all` in a clean `oven/bun:1.3.14` container off `0165b4f5`: 12/12 gates pass. With `provider-retry.ts` reverted to `main` and the test kept, the classify case fails with `Expected: "transient", Received: "unknown"`; `bun test src/runs/retry/ src/runs/reap/` with the change: 344 pass, 0 fail.
